### PR TITLE
Changes for Puppet 2.7

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,8 +1,8 @@
 class foreman_proxy::install {
-  require 'foreman::params'
+  include foreman::params
   include foreman::install::repos
   package {'foreman-proxy':
-    ensure  => latest,
+    ensure  => present,
     require => Class['foreman::install::repos'],
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,7 @@
 class foreman_proxy::params {
+
+  include tftp::params
+
   # variables
   $dir  = '/usr/share/foreman-proxy'
   $user = 'foreman-proxy'
@@ -15,7 +18,6 @@ class foreman_proxy::params {
   $puppetrun_cmd = '/usr/sbin/puppetrun'
 
   # TFTP settings
-  require 'tftp'  # ensures we can access tftp module parameters
   $tftp           = true
   $syslinux_root  = '/usr/share/syslinux'
   $syslinux_files = ['pxelinux.0','menu.c32','chain.c32']

--- a/manifests/tftp.pp
+++ b/manifests/tftp.pp
@@ -1,5 +1,6 @@
 class foreman_proxy::tftp {
   include ::tftp
+  include foreman_proxy::params
 
   file{ $foreman_proxy::params::tftp_dir:
     ensure  => directory,


### PR DESCRIPTION
This makes everything work cleanly regarding params.  Require just doesn't seem to work on 2.7.  I also snuck in the latest -> present change so 0.5 doesn't catch people unaware.
