### PR TITLE
Allow better options for DHCP/DNS

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,9 +34,11 @@ class foreman_proxy::params {
   $servername     = $ipaddress_eth0
 
   # DHCP settings - requires optional DHCP puppet module
-  $dhcp = false
-  $gateway = '192.168.100.1'
-  $range   = '192.168.100.50 192.168.100.200'
+  $dhcp           = false
+  $dhcp_interface = 'eth0'
+  $dhcp_reverse   = '100.168.192.in-addr.arpa'
+  $gateway        = '192.168.100.1'
+  $range          = '192.168.100.50 192.168.100.200'
   case $::operatingsystem {
     Debian: {
       $dhcp_vendor = 'isc'
@@ -56,7 +58,9 @@ class foreman_proxy::params {
   }
  
   # DNS settings - requires optional DNS puppet module
-  $dns  = false
+  $dns           = false
+  $dns_interface = 'eth0'
+  $dns_reverse   = '100.168.192.in-addr.arpa'
   case $::operatingsystem {
     Debian: {
       $keyfile = '/etc/bind/rndc.key'

--- a/manifests/proxydhcp.pp
+++ b/manifests/proxydhcp.pp
@@ -1,24 +1,32 @@
 class foreman_proxy::proxydhcp {
   include foreman_proxy::params
 
+  $ip_temp   = "ipaddress_${foreman_proxy::params::dhcp_interface}"
+  $ip        = inline_template("<%= scope.lookupvar(ip_temp) %>")
+
+  $net_temp  = "::network_${foreman_proxy::params::dhcp_interface}"
+  $net       = inline_template("<%= scope.lookupvar(net_temp) %>")
+
+  $mask_temp = "::netmask_${foreman_proxy::params::dhcp_interface}"
+  $mask      = inline_template("<%= scope.lookupvar(mask_temp) %>")
+
   class { 'dhcp':
     dnsdomain    => [
       "${::domain}",
-      "100.168.192.in-addr.arpa",
+      "${foreman_proxy::params::dhcp_reverse}",
     ],
-    nameservers  => ["${::ipaddress}"],
+    nameservers  => ["${ip}"],
     ntpservers   => ['us.pool.ntp.org'],
-    interfaces   => ['eth0'],
+    interfaces   => ["${foreman_proxy::params::dhcp_interface}"],
     #dnsupdatekey => "/etc/bind/keys.d/foreman",
     #require      => Bind::Key[ 'foreman' ],
-    pxeserver    => "${::ipaddress}",
+    pxeserver    => "${ip}",
     pxefilename  => 'pxelinux.0',
-    dhcp_monitor => false,
   }
 
   dhcp::pool{ "${::domain}":
-    network => "${::network_eth0}",
-    mask    => "${::netmask_eth0}",
+    network => "${net}",
+    mask    => "${mask}",
     range   => "${foreman_proxy::params::range}",
     gateway => "${foreman_proxy::params::gateway}",
   }

--- a/manifests/proxydns.pp
+++ b/manifests/proxydns.pp
@@ -2,15 +2,18 @@ class foreman_proxy::proxydns {
   include foreman_proxy::params
   include dns
 
+  $ip_temp = "::ipaddress_${foreman_proxy::params::dns_interface}"
+  $ip      = inline_template("<%= scope.lookupvar(ip_temp) %>")
+
   dns::zone { "${::domain}":
     soa     => "${::fqdn}",
     reverse => "false",
-    soaip   => "${::ipaddress}",
+    soaip   => "${ip}",
   }
 
-  dns::zone { "100.168.192.in-addr.arpa":
+  dns::zone { "${foreman_proxy::params::dns_reverse}":
     soa     => "${::fqdn}",
     reverse => "true",
-    soaip   => "${::ipaddress}",
+    soaip   => "${ip}",
   }
 }


### PR DESCRIPTION
This allows the user to specify things like the reverse in-arpa names for zones, and the interface to retrieve data from (so, eth1 or virbr0 instead of eth0). 

This only impacts the experimental DHCP/DNS functionality, so I'll merge tomorrow night or Friday, unless anyone objects first.
