### PR TITLE
Avoid dependency on foreman::params

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,6 +1,6 @@
 class foreman_proxy::install {
-  include foreman::params
-  include foreman::install::repos
+  class { '::foreman::install::repos': use_testing => $foreman_proxy::params::use_testing }
+
   package {'foreman-proxy':
     ensure  => present,
     require => Class['foreman::install::repos'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,6 +2,8 @@ class foreman_proxy::params {
 
   include tftp::params
 
+  $use_testing = true
+
   # variables
   $dir  = '/usr/share/foreman-proxy'
   $user = 'foreman-proxy'


### PR DESCRIPTION
Instead use parameterized class to specify parameters for repositories.

It's related to https://github.com/theforeman/puppet-foreman/pull/4 and making foreman module parameterized.
