### PR TITLE
Parametrize params so that they can be overwritten

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,18 +1,18 @@
 class foreman_proxy::config {
-  user { $foreman_proxy::params::user:
+  user { $foreman_proxy::user:
     ensure  => 'present',
     shell   => '/sbin/nologin',
     comment => 'Foreman Proxy account',
-    groups  => $foreman_proxy::params::puppet_group,
-    home    => $foreman_proxy::params::dir,
+    groups  => $foreman_proxy::puppet_group,
+    home    => $foreman_proxy::dir,
     require => Class['foreman_proxy::install'],
     notify  => Class['foreman_proxy::service'],
   }
  
   file{'/etc/foreman-proxy/settings.yml':
     content => template('foreman_proxy/settings.yml.erb'),
-    owner   => $foreman_proxy::params::user,
-    group   => $foreman_proxy::params::user,
+    owner   => $foreman_proxy::user,
+    group   => $foreman_proxy::user,
     mode    => '0644',
     require => Class['foreman_proxy::install'],
     notify  => Class['foreman_proxy::service'],
@@ -21,21 +21,21 @@ class foreman_proxy::config {
   augeas { 'sudo-foreman-proxy':
     context => '/files/etc/sudoers',
     changes => [
-      "set spec[user = '${foreman_proxy::params::user}']/user ${foreman_proxy::params::user}",
-      "set spec[user = '${foreman_proxy::params::user}']/host_group/host ALL",
-      "set spec[user = '${foreman_proxy::params::user}']/host_group/command[1] '${foreman_proxy::params::puppetca_cmd}'",
-      "set spec[user = '${foreman_proxy::params::user}']/host_group/command[2] '${foreman_proxy::params::puppetrun_cmd}'",
-      "set spec[user = '${foreman_proxy::params::user}']/host_group/command[1]/tag NOPASSWD",
-      "set Defaults[type = ':${foreman_proxy::params::user}']/type :${foreman_proxy::params::user}",
-      "set Defaults[type = ':${foreman_proxy::params::user}']/requiretty/negate ''",
+      "set spec[user = '${foreman_proxy::user}']/user ${foreman_proxy::user}",
+      "set spec[user = '${foreman_proxy::user}']/host_group/host ALL",
+      "set spec[user = '${foreman_proxy::user}']/host_group/command[1] '${foreman_proxy::puppetca_cmd}'",
+      "set spec[user = '${foreman_proxy::user}']/host_group/command[2] '${foreman_proxy::puppetrun_cmd}'",
+      "set spec[user = '${foreman_proxy::user}']/host_group/command[1]/tag NOPASSWD",
+      "set Defaults[type = ':${foreman_proxy::user}']/type :${foreman_proxy::user}",
+      "set Defaults[type = ':${foreman_proxy::user}']/requiretty/negate ''",
     ],
   }
 
-  if $foreman_proxy::params::puppetca  { include foreman_proxy::puppetca }
-  if $foreman_proxy::params::tftp      { include foreman_proxy::tftp }
+  if $foreman_proxy::puppetca  { include foreman_proxy::puppetca }
+  if $foreman_proxy::tftp      { include foreman_proxy::tftp }
 
   # Somehow, calling these DHCP and DNS seems to conflict. So, they get a prefix...
-  if $foreman_proxy::params::dhcp      { include foreman_proxy::proxydhcp }
-  if $foreman_proxy::params::dns       { include foreman_proxy::proxydns }
+  if $foreman_proxy::dhcp      { include foreman_proxy::proxydhcp }
+  if $foreman_proxy::dns       { include foreman_proxy::proxydns }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,34 @@
-class foreman_proxy {
-
-  include foreman_proxy::params
-  include foreman_proxy::install
-  include foreman_proxy::config
-  include foreman_proxy::service
+class foreman_proxy (
+  $use_testing       = $foreman_proxy::params::use_testing,
+  $dir               = $foreman_proxy::params::dir,
+  $user              = $foreman_proxy::params::user,
+  $log               = $foreman_proxy::params::log,
+  $puppetca          = $foreman_proxy::params::puppetca,
+  $autosign_location = $foreman_proxy::params::autosign_location,
+  $puppetca_cmd      = $foreman_proxy::params::puppetca_cmd,
+  $puppet_group      = $foreman_proxy::params::puppet_group,
+  $puppetrun         = $foreman_proxy::params::puppetrun,
+  $puppetrun_cmd     = $foreman_proxy::params::puppetrun_cmd,
+  $tftp              = $foreman_proxy::params::tftp,
+  $syslinux_root     = $foreman_proxy::params::syslinux_root,
+  $syslinux_files    = $foreman_proxy::params::syslinux_files,
+  $tftproot          = $foreman_proxy::params::tftproot,
+  $tftp_dir          = $foreman_proxy::params::tftp_dir,
+  $servername        = $foreman_proxy::params::servername,
+  $dhcp              = $foreman_proxy::params::dhcp,
+  $dhcp_interface    = $foreman_proxy::params::dhcp_interface,
+  $dhcp_reverse      = $foreman_proxy::params::dhcp_reverse,
+  $gateway           = $foreman_proxy::params::gateway,
+  $range             = $foreman_proxy::params::range,
+  $dhcp_vendor       = $foreman_proxy::params::dhcp_vendor,
+  $dhcp_config       = $foreman_proxy::params::dhcp_config,
+  $dhcp_leases       = $foreman_proxy::params::dhcp_leases,
+  $dns               = $foreman_proxy::params::dns,
+  $dns_interface     = $foreman_proxy::params::dns_interface,
+  $dns_reverse       = $foreman_proxy::params::dns_reverse,
+  $keyfile           = $foreman_proxy::params::keyfile
+) inherits foreman_proxy::params {
+  class { 'foreman_proxy::install': } ~>
+  class { 'foreman_proxy::config': } ~>
+  class { 'foreman_proxy::service': }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,5 @@
 class foreman_proxy::install {
-  class { '::foreman::install::repos': use_testing => $foreman_proxy::params::use_testing }
+  class { '::foreman::install::repos': use_testing => $foreman_proxy::use_testing }
 
   package {'foreman-proxy':
     ensure  => present,

--- a/manifests/proxydhcp.pp
+++ b/manifests/proxydhcp.pp
@@ -1,23 +1,21 @@
 class foreman_proxy::proxydhcp {
-  include foreman_proxy::params
-
-  $ip_temp   = "ipaddress_${foreman_proxy::params::dhcp_interface}"
+  $ip_temp   = "ipaddress_${foreman_proxy::dhcp_interface}"
   $ip        = inline_template("<%= scope.lookupvar(ip_temp) %>")
 
-  $net_temp  = "::network_${foreman_proxy::params::dhcp_interface}"
+  $net_temp  = "::network_${foreman_proxy::dhcp_interface}"
   $net       = inline_template("<%= scope.lookupvar(net_temp) %>")
 
-  $mask_temp = "::netmask_${foreman_proxy::params::dhcp_interface}"
+  $mask_temp = "::netmask_${foreman_proxy::dhcp_interface}"
   $mask      = inline_template("<%= scope.lookupvar(mask_temp) %>")
 
   class { 'dhcp':
     dnsdomain    => [
       "${::domain}",
-      "${foreman_proxy::params::dhcp_reverse}",
+      "${foreman_proxy::dhcp_reverse}",
     ],
     nameservers  => ["${ip}"],
     ntpservers   => ['us.pool.ntp.org'],
-    interfaces   => ["${foreman_proxy::params::dhcp_interface}"],
+    interfaces   => ["${foreman_proxy::dhcp_interface}"],
     #dnsupdatekey => "/etc/bind/keys.d/foreman",
     #require      => Bind::Key[ 'foreman' ],
     pxeserver    => "${ip}",
@@ -27,8 +25,8 @@ class foreman_proxy::proxydhcp {
   dhcp::pool{ "${::domain}":
     network => "${net}",
     mask    => "${mask}",
-    range   => "${foreman_proxy::params::range}",
-    gateway => "${foreman_proxy::params::gateway}",
+    range   => "${foreman_proxy::range}",
+    gateway => "${foreman_proxy::gateway}",
   }
 
 

--- a/manifests/proxydns.pp
+++ b/manifests/proxydns.pp
@@ -1,8 +1,7 @@
 class foreman_proxy::proxydns {
-  include foreman_proxy::params
   include dns
 
-  $ip_temp = "::ipaddress_${foreman_proxy::params::dns_interface}"
+  $ip_temp = "::ipaddress_${foreman_proxy::dns_interface}"
   $ip      = inline_template("<%= scope.lookupvar(ip_temp) %>")
 
   dns::zone { "${::domain}":
@@ -11,7 +10,7 @@ class foreman_proxy::proxydns {
     soaip   => "${ip}",
   }
 
-  dns::zone { "${foreman_proxy::params::dns_reverse}":
+  dns::zone { "${foreman_proxy::dns_reverse}":
     soa     => "${::fqdn}",
     reverse => "true",
     soaip   => "${ip}",

--- a/manifests/puppetca.pp
+++ b/manifests/puppetca.pp
@@ -1,9 +1,9 @@
 class foreman_proxy::puppetca {
 
-  file { $foreman_proxy::params::autosign_location:
+  file { $foreman_proxy::autosign_location:
     ensure  => present,
-    owner   => $foreman_proxy::params::user,
-    group   => $foreman_proxy::params::puppet_group,
+    owner   => $foreman_proxy::user,
+    group   => $foreman_proxy::puppet_group,
     mode    => '0664',
     require => Class['foreman_proxy::install'],
   }

--- a/manifests/tftp.pp
+++ b/manifests/tftp.pp
@@ -1,18 +1,17 @@
 class foreman_proxy::tftp {
   include ::tftp
-  include foreman_proxy::params
 
-  file{ $foreman_proxy::params::tftp_dir:
+  file{ $foreman_proxy::tftp_dir:
     ensure  => directory,
-    owner   => $foreman_proxy::params::user,
+    owner   => $foreman_proxy::user,
     mode    => '0644',
     require => Class['foreman_proxy::install'],
     recurse => true;
   }
 
-  foreman_proxy::tftp::sync_file{$foreman_proxy::params::syslinux_files:
-    source_path => $foreman_proxy::params::syslinux_root,
-    target_path => $foreman_proxy::params::tftproot,
+  foreman_proxy::tftp::sync_file{$foreman_proxy::syslinux_files:
+    source_path => $foreman_proxy::syslinux_root,
+    target_path => $foreman_proxy::tftproot,
     require     => Class['tftp::install'];
   }
 }

--- a/templates/settings.yml.erb
+++ b/templates/settings.yml.erb
@@ -21,24 +21,24 @@
 :port: 8443
 
 # Enable TFTP management
-:tftp: <%= scope.lookupvar("foreman_proxy::params::tftp") %>
-:tftproot: <%= scope.lookupvar("foreman_proxy::params::tftproot") %>
-:tftp_servername: <%= scope.lookupvar("foreman_proxy::params::servername") %>
+:tftp: <%= scope.lookupvar("foreman_proxy::tftp") %>
+:tftproot: <%= scope.lookupvar("foreman_proxy::tftproot") %>
+:tftp_servername: <%= scope.lookupvar("foreman_proxy::servername") %>
 # Defines the TFTP Servername to use, overrides the name in the subnet declaration
 #:tftp_servername: tftp.domain.com
 
 # Enable DNS management
-:dns: <%= scope.lookupvar("foreman_proxy::params::dns") %>
-:dns_key: <%= scope.lookupvar("foreman_proxy::params::keyfile") %>
+:dns: <%= scope.lookupvar("foreman_proxy::dns") %>
+:dns_key: <%= scope.lookupvar("foreman_proxy::keyfile") %>
 # use this setting if you are managing a dns server which is not localhost though this proxy
 #:dns_server: dns.domain.com
 
 # Enable DHCP management
-:dhcp: <%= scope.lookupvar("foreman_proxy::params::dhcp") %>
-<% if scope.lookupvar("foreman_proxy::params::dhcp") == true -%>
-:dhcp_vendor: <%= scope.lookupvar("foreman_proxy::params::dhcp_vendor") %>
-:dhcp_config: <%= scope.lookupvar("foreman_proxy::params::dhcp_config") %>
-:dhcp_leases: <%= scope.lookupvar("foreman_proxy::params::dhcp_leases") %>
+:dhcp: <%= scope.lookupvar("foreman_proxy::dhcp") %>
+<% if scope.lookupvar("foreman_proxy::dhcp") == true -%>
+:dhcp_vendor: <%= scope.lookupvar("foreman_proxy::dhcp_vendor") %>
+:dhcp_config: <%= scope.lookupvar("foreman_proxy::dhcp_config") %>
+:dhcp_leases: <%= scope.lookupvar("foreman_proxy::dhcp_leases") %>
 <% else -%>
 # The vendor can be either isc or native_ms
 :dhcp_vendor: isc
@@ -56,15 +56,15 @@
 <% end -%>
 
 # enable PuppetCA management
-:puppetca: <%= scope.lookupvar("foreman_proxy::params::puppetca") %>
+:puppetca: <%= scope.lookupvar("foreman_proxy::puppetca") %>
 
 # enable Puppet management
-:puppet: <%= scope.lookupvar("foreman_proxy::params::puppetrun") %>
+:puppet: <%= scope.lookupvar("foreman_proxy::puppetrun") %>
 :puppet_conf: /etc/puppet/puppet.conf
 
 # Where our proxy log files are stored
 # filename or STDOUT
-:log_file: <%= scope.lookupvar("foreman_proxy::params::log") %>
+:log_file: <%= scope.lookupvar("foreman_proxy::log") %>
 # valid options are
 # WARN, DEBUG, Error, Fatal, INFO, UNKNOWN
 #:log_level: DEBUG


### PR DESCRIPTION
Following the pattern from puppet-puppet and puppet-foreman.

Basing the commit based on changes in pull request #5 to avoid conflicts if the pull request get's accepted. 

I've also removed `include foreman_proxy` from `proxydhcp.pp`, `proxydns.pp` and `tftp.pp` because it's already handled in `init.pp` and one can customize what proxies are used through the params.
