### PR TITLE
Fix for DHCP file locations on Ubuntu. 

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,8 +51,8 @@ class foreman_proxy::params {
     }
     Ubuntu: {
       $dhcp_vendor = 'isc'
-      $dhcp_config = '/etc/dhcp3/dhcpd.conf'
-      $dhcp_leases = '/var/lib/dhcp3/dhcpd.leases'
+      $dhcp_config = '/etc/dhcp/dhcpd.conf'
+      $dhcp_leases = '/var/lib/dhcp/dhcpd.leases'
     }
     default: {
       $dhcp_vendor = 'isc'


### PR DESCRIPTION
Tested on 11.04. Should be confirmed on 12.04
