### PR TITLE
Sets path to DNS key file on Ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -66,7 +66,7 @@ class foreman_proxy::params {
   $dns_interface = 'eth0'
   $dns_reverse   = '100.168.192.in-addr.arpa'
   case $::operatingsystem {
-    Debian: {
+    Debian,Ubuntu: {
       $keyfile = '/etc/bind/rndc.key'
     }
     default: {


### PR DESCRIPTION
Was using default case on Ubuntu which resulted in the error:

```
Unable to save
Reverse DNS record for node1.cloudcomplab.ch task failed with the following error: Unable to find Key file - check your dns_key settings
```

When creating a host
