### PR TITLE
Include the foreman::params class in the foreman_proxy installation class

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,4 +1,6 @@
 class foreman_proxy::install {
+  include foreman::params
+
   foreman::install::repos { 'foreman_proxy':
     use_testing    => $foreman_proxy::use_testing,
     package_source => $foreman_proxy::package_source,


### PR DESCRIPTION
This fixes the issue that a user reported where the baseurl of the repo file in /etc/yum.repos.d is not populated.
