### PR TITLE
Ensure foreman-proxy is a member of the DNS group

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -68,9 +68,11 @@ class foreman_proxy::params {
   case $::operatingsystem {
     Debian,Ubuntu: {
       $keyfile = '/etc/bind/rndc.key'
+      $dns_group = 'bind'
     }
     default: {
       $keyfile = '/etc/rndc.key'
+      $dns_group = 'named'
     }
   }
 

--- a/manifests/proxydns.pp
+++ b/manifests/proxydns.pp
@@ -15,4 +15,8 @@ class foreman_proxy::proxydns {
     reverse => true,
     soaip   => $ip,
   }
+
+  group {$foreman_proxy::params::dns_group:
+    members => 'foreman-proxy',
+  }
 }


### PR DESCRIPTION
This doesn't work, but I'd like to get this issue resolved. Consider it a bug report for now :)
