### PR TITLE
Add group defined in DNS class to the foreman-proxy user

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,9 +1,24 @@
 class foreman_proxy::config {
+
+  if $foreman_proxy::puppetca  { include foreman_proxy::puppetca }
+  if $foreman_proxy::tftp      { include foreman_proxy::tftp }
+
+  # Somehow, calling these DHCP and DNS seems to conflict. So, they get a prefix...
+  if $foreman_proxy::dhcp      { include foreman_proxy::proxydhcp }
+
+  if $foreman_proxy::dns {
+    include foreman_proxy::proxydns
+    include dns::params
+    $groups = [$dns::params::group,$foreman_proxy::puppet_group]
+  } else {
+    $groups = [$foreman_proxy::puppet_group]
+  }
+
   user { $foreman_proxy::user:
     ensure  => 'present',
     shell   => '/sbin/nologin',
     comment => 'Foreman Proxy account',
-    groups  => $foreman_proxy::puppet_group,
+    groups  => $groups,
     home    => $foreman_proxy::dir,
     require => Class['foreman_proxy::install'],
     notify  => Class['foreman_proxy::service'],
@@ -31,11 +46,5 @@ class foreman_proxy::config {
     ],
   }
 
-  if $foreman_proxy::puppetca  { include foreman_proxy::puppetca }
-  if $foreman_proxy::tftp      { include foreman_proxy::tftp }
-
-  # Somehow, calling these DHCP and DNS seems to conflict. So, they get a prefix...
-  if $foreman_proxy::dhcp      { include foreman_proxy::proxydhcp }
-  if $foreman_proxy::dns       { include foreman_proxy::proxydns }
 
 }


### PR DESCRIPTION
As an alternative to pull request 17, this checks if the DNS module is enabled. If so, it takes the group defined in the DNS class and adds it to foreman-proxy's users.

We will need to update the DNS module to be a bit smarter - it currently assumes the group is 'bind' which isn't true on every distro.
