### PR TITLE
Remove ntpservers call from dhcp code

### DIFF
--- a/manifests/proxydhcp.pp
+++ b/manifests/proxydhcp.pp
@@ -14,7 +14,6 @@ class foreman_proxy::proxydhcp {
       $foreman_proxy::dhcp_reverse,
     ],
     nameservers  => [$ip],
-    ntpservers   => ['us.pool.ntp.org'],
     interfaces   => [$foreman_proxy::dhcp_interface],
     #dnsupdatekey => /etc/bind/keys.d/foreman,
     #require      => Bind::Key[ 'foreman' ],


### PR DESCRIPTION
Duplicate of https://github.com/theforeman/puppet-foreman_proxy/pull/19 since I closed it by accident and you can't re-open.
