### PR TITLE
Don't use nightly by default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,5 @@
 class foreman_proxy (
   $use_testing       = $foreman_proxy::params::use_testing,
-  $package_source    = $foreman_proxy::params::package_source,
   $dir               = $foreman_proxy::params::dir,
   $user              = $foreman_proxy::params::user,
   $log               = $foreman_proxy::params::log,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,6 @@
 class foreman_proxy::install {
   foreman::install::repos { 'foreman_proxy':
     use_testing    => $foreman_proxy::use_testing,
-    package_source => $foreman_proxy::package_source,
   }
 
   package {'foreman-proxy':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,8 +3,7 @@ class foreman_proxy::params {
   include tftp::params
 
   # Packaging
-  $use_testing    = true
-  $package_source = 'testing'
+  $use_testing    = false
 
   # variables
   $dir  = '/usr/share/foreman-proxy'


### PR DESCRIPTION
Also trims out the unused debian repo param from puppet-foreman/15
