### PR TITLE
Remove a debug notify

### DIFF
--- a/manifests/proxydhcp.pp
+++ b/manifests/proxydhcp.pp
@@ -14,8 +14,6 @@ class foreman_proxy::proxydhcp {
     $nameservers = split($foreman_proxy::dhcp_nameservers,',')
   }
 
-  notify { $nameservers: }
-
   class { 'dhcp':
     dnsdomain    => [
       $::domain,


### PR DESCRIPTION
This notify will mark the server as active every run and adds little value.
