### PR TITLE
Parametrize dns

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@ class foreman_proxy (
   $dns_interface     = $foreman_proxy::params::dns_interface,
   $dns_reverse       = $foreman_proxy::params::dns_reverse,
   $dns_server        = $foreman_proxy::params::dns_server,
+  $dns_forwarders    = $foreman_proxy::params::dns_forwarders,
   $keyfile           = $foreman_proxy::params::keyfile
 ) inherits foreman_proxy::params {
   class { 'foreman_proxy::install': } ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -87,4 +87,6 @@ class foreman_proxy::params {
     }
   }
 
+  $dns_forwarders = []
+
 }

--- a/manifests/proxydns.pp
+++ b/manifests/proxydns.pp
@@ -1,5 +1,7 @@
 class foreman_proxy::proxydns {
-  include dns
+  class { dns:
+    forwarders => $dns_forwarders,
+  }
 
   package { $foreman_proxy::params::nsupdate:
     ensure => installed,


### PR DESCRIPTION
Dependent on theforeman/puppet-dns#3. Also exposes the dns_forwarders parameter.
