### PR TITLE
use_testing parameter has been replaced by repo in puppet-foreman module

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,5 @@
 class foreman_proxy (
-  $use_testing         = $foreman_proxy::params::use_testing,
+  $repo                = $foreman_proxy::params::repo,
   $port                = $foreman_proxy::params::port,
   $dir                 = $foreman_proxy::params::dir,
   $user                = $foreman_proxy::params::user,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,6 +1,6 @@
 class foreman_proxy::install {
   foreman::install::repos { 'foreman_proxy':
-    use_testing    => $foreman_proxy::use_testing,
+    repo    => $foreman_proxy::repo,
   }
 
   package {'foreman-proxy':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@ class foreman_proxy::params {
   include puppet::params
 
   # Packaging
-  $use_testing    = false
+  $repo = stable
 
   # variables
   $port = "8443"


### PR DESCRIPTION
This https://github.com/theforeman/puppet-foreman/commit/c7b3916ddd78f278767c8ac7768ce96ffb0a6327 commit has broken puppet-foreman_proxy module.

use_testing parameter has been replaced by repo
