### PR TITLE
Use camptocamp sudo module

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,25 +39,11 @@ class foreman_proxy::config {
     notify  => Class['foreman_proxy::service'],
   }
 
-  if $foreman_proxy::use_sudoersd {
-    sudo::directive {'foreman-proxy':
-      ensure => present,
-      content => "foreman-proxy ALL = NOPASSWD : ${foreman_proxy::puppetca_cmd} *, ${foreman_proxy::puppetrun_cmd} *
+  include sudo
+  sudo::directive {'foreman-proxy':
+    ensure => present,
+    content => "foreman-proxy ALL = NOPASSWD : ${foreman_proxy::puppetca_cmd} *, ${foreman_proxy::puppetrun_cmd} *
 Defaults:foreman-proxy !requiretty\n",
-    }
-  } else {
-    augeas { 'sudo-foreman-proxy':
-      context => '/files/etc/sudoers',
-      changes => [
-        "set spec[user = '${foreman_proxy::user}']/user ${foreman_proxy::user}",
-        "set spec[user = '${foreman_proxy::user}']/host_group/host ALL",
-        "set spec[user = '${foreman_proxy::user}']/host_group/command[1] '${foreman_proxy::puppetca_cmd} *'",
-        "set spec[user = '${foreman_proxy::user}']/host_group/command[2] '${foreman_proxy::puppetrun_cmd} *'",
-        "set spec[user = '${foreman_proxy::user}']/host_group/command[1]/tag NOPASSWD",
-        "set Defaults[type = ':${foreman_proxy::user}']/type :${foreman_proxy::user}",
-        "set Defaults[type = ':${foreman_proxy::user}']/requiretty/negate ''",
-      ],
-    }
   }
 
 }


### PR DESCRIPTION
File resource /etc/sudoers.d should not be managed in foreman's scope, so this patch uses camtocamp sudo module to manage sudoers files.
