### PR TITLE
Change manage_sudoers parameter to only exclude the /etc/sudoers.d resource

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,34 +39,34 @@ class foreman_proxy::config {
     notify  => Class['foreman_proxy::service'],
   }
 
-  if $foreman_proxy::manage_sudoers {
-    if $foreman_proxy::use_sudoersd {
+  if $foreman_proxy::use_sudoersd {
+    if $foreman_proxy::manage_sudoersd {
       file { '/etc/sudoers.d':
         ensure => directory,
       }
+    }
 
-      file { '/etc/sudoers.d/foreman-proxy':
-        ensure  => present,
-        owner   => 'root',
-        group   => 'root',
-        mode    => 0440,
-        content => "foreman-proxy ALL = NOPASSWD : ${foreman_proxy::puppetca_cmd} *, ${foreman_proxy::puppetrun_cmd} *
+    file { '/etc/sudoers.d/foreman-proxy':
+      ensure  => present,
+      owner   => 'root',
+      group   => 'root',
+      mode    => 0440,
+      content => "foreman-proxy ALL = NOPASSWD : ${foreman_proxy::puppetca_cmd} *, ${foreman_proxy::puppetrun_cmd} *
 Defaults:foreman-proxy !requiretty\n",
-        require => File['/etc/sudoers.d'],
-      }
-    } else {
-      augeas { 'sudo-foreman-proxy':
-        context => '/files/etc/sudoers',
-        changes => [
-          "set spec[user = '${foreman_proxy::user}']/user ${foreman_proxy::user}",
-          "set spec[user = '${foreman_proxy::user}']/host_group/host ALL",
-          "set spec[user = '${foreman_proxy::user}']/host_group/command[1] '${foreman_proxy::puppetca_cmd} *'",
-          "set spec[user = '${foreman_proxy::user}']/host_group/command[2] '${foreman_proxy::puppetrun_cmd} *'",
-          "set spec[user = '${foreman_proxy::user}']/host_group/command[1]/tag NOPASSWD",
-          "set Defaults[type = ':${foreman_proxy::user}']/type :${foreman_proxy::user}",
-          "set Defaults[type = ':${foreman_proxy::user}']/requiretty/negate ''",
-        ],
-      }
+      require => File['/etc/sudoers.d'],
+    }
+  } else {
+    augeas { 'sudo-foreman-proxy':
+      context => '/files/etc/sudoers',
+      changes => [
+        "set spec[user = '${foreman_proxy::user}']/user ${foreman_proxy::user}",
+        "set spec[user = '${foreman_proxy::user}']/host_group/host ALL",
+        "set spec[user = '${foreman_proxy::user}']/host_group/command[1] '${foreman_proxy::puppetca_cmd} *'",
+        "set spec[user = '${foreman_proxy::user}']/host_group/command[2] '${foreman_proxy::puppetrun_cmd} *'",
+        "set spec[user = '${foreman_proxy::user}']/host_group/command[1]/tag NOPASSWD",
+        "set Defaults[type = ':${foreman_proxy::user}']/type :${foreman_proxy::user}",
+        "set Defaults[type = ':${foreman_proxy::user}']/requiretty/negate ''",
+      ],
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@ class foreman_proxy (
   $ssl_cert            = $foreman_proxy::params::ssl_cert,
   $ssl_key             = $foreman_proxy::params::ssl_key,
   $trusted_hosts       = $foreman_proxy::params::trusted_hosts,
-  $manage_sudoers      = $foreman_proxy::params::manage_sudoers,
+  $manage_sudoersd     = $foreman_proxy::params::manage_sudoersd,
   $use_sudoersd        = $foreman_proxy::params::use_sudoersd,
   $puppetca            = $foreman_proxy::params::puppetca,
   $autosign_location   = $foreman_proxy::params::autosign_location,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,9 +28,9 @@ class foreman_proxy::params {
   # Only hosts listed will be permitted, empty array to disable authorization
   $trusted_hosts = []
 
-  # Whether to manage sudo rules or not.  When reusing this module, this may be
-  # disabled to use a dedicated sudo module instead.
-  $manage_sudoers = true
+  # Whether to manage File['/etc/sudoers.d'] or not.  When reusing this module, this may be
+  # disabled to let a dedicated sudo module manage it instead.
+  $manage_sudoersd = true
 
   # Should we assume a sudoers.d dir exists ( 'false' will use augeas instead )
   case $::operatingsystem {


### PR DESCRIPTION
I think this will be more helpful, having just run into the problem that @mcanevet did in GH-41 myself!  This allows the proxy module then to manage the foreman_proxy sudoers file, but for an external sudo module (if used) to manage the directory it's in.
