### PR TITLE
Don't print empty strings for dhcp_key_name/secret

### DIFF
--- a/templates/settings.yml.erb
+++ b/templates/settings.yml.erb
@@ -64,7 +64,7 @@
 :dhcp_vendor: <%= scope.lookupvar("foreman_proxy::dhcp_vendor") %>
 :dhcp_config: <%= scope.lookupvar("foreman_proxy::dhcp_config") %>
 :dhcp_leases: <%= scope.lookupvar("foreman_proxy::dhcp_leases") %>
-<% if scope.lookupvar("foreman_proxy::dhcp_key_name") && scope.lookupvar("foreman_proxy::dhcp_key_secret") -%>
+<% if !scope.lookupvar("foreman_proxy::dhcp_key_name").empty? && !scope.lookupvar("foreman_proxy::dhcp_key_secret").empty? -%>
 :dhcp_key_name: <%= scope.lookupvar("foreman_proxy::dhcp_key_name") %>
 :dhcp_key_secret: <%= scope.lookupvar("foreman_proxy::dhcp_key_secret") %>
 <% else -%>


### PR DESCRIPTION
It's currently taking the first path of code since the defaults are empty strings and ERB is ruby, not puppet, where empty strings are true.
