### PR TITLE
Do not use a default DHCP range

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -76,7 +76,7 @@ class foreman_proxy::params {
   $dhcp_managed     = true
   $dhcp_interface   = 'eth0'
   $dhcp_gateway     = '192.168.100.1'
-  $dhcp_range       = '192.168.100.50 192.168.100.200'
+  $dhcp_range       = false
   # This will use the IP of the interface in $dhcp_interface, override
   # if you need to. You can make this a comma-separated string too - it
   # will be split into an array


### PR DESCRIPTION
Providing a free lease by default is intrusive and not needed for
foreman to function.
