### PR TITLE
#2577 syslinux memdisk support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -68,7 +68,7 @@ class foreman_proxy::params {
       $tftp_syslinux_root = '/usr/share/syslinux'
     }
   }
-  $tftp_syslinux_files = ['pxelinux.0','menu.c32','chain.c32']
+  $tftp_syslinux_files = ['pxelinux.0','menu.c32','chain.c32','memdisk']
   $tftp_root           = $tftp::params::root
   $tftp_dirs           = ["${tftp_root}/pxelinux.cfg","${tftp_root}/boot"]
   $tftp_servername     = $ipaddress_eth0


### PR DESCRIPTION
Added memdisk kernel to the list so it will be copied, too in order for memdisk support -#2577
http://projects.theforeman.org/issues/2577

Change is required for Ticket #2572
http://projects.theforeman.org/issues/2572
