### PR TITLE
Do not add the served by to the header

### DIFF
--- a/templates/settings.yml.erb
+++ b/templates/settings.yml.erb
@@ -1,6 +1,5 @@
 ---
 ### File managed with puppet ###
-## Served by:        '<%= scope.lookupvar('::servername') %>'
 ## Module:           '<%= scope.to_hash['module_name'] %>'
 ## Template source:  'MODULES<%= template_source.gsub(Regexp.new("^#{Puppet::Node::Environment.current[:modulepath].gsub(':','|')}"),"") %>'
 


### PR DESCRIPTION
In our workflow we use a staging server and do a puppet agent -t
--server --noop to see what changed. The served by header changes all the 
files and triggers lots of refreshes. This makes it very hard to spot what 
changed and what not.
