### PR TITLE
adding proxy registration REST code

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -115,54 +115,73 @@
 #
 # $keyfile::                DNS server keyfile path
 #
+# $register_in_foreman::    Register proxy back in Foreman
+#
+# $registered_proxy_url::   Proxy URL which is registered in Foreman
+#
+# $foreman_base_url::       Base Foreman URL used for REST interaction
+#
+# $oauth_effective_user::   User to be used for REST interaction
+#
+# $oauth_consumer_key::     OAuth key to be used for REST interaction
+#
+# $oauth_consumer_secret::  OAuth secret to be used for REST interaction
+#
 class foreman_proxy (
-  $repo                = $foreman_proxy::params::repo,
-  $gpgcheck            = $foreman_proxy::params::gpgcheck,
-  $custom_repo         = $foreman_proxy::params::custom_repo,
-  $port                = $foreman_proxy::params::port,
-  $dir                 = $foreman_proxy::params::dir,
-  $user                = $foreman_proxy::params::user,
-  $log                 = $foreman_proxy::params::log,
-  $ssl                 = $foreman_proxy::params::ssl,
-  $ssl_ca              = $foreman_proxy::params::ssl_ca,
-  $ssl_cert            = $foreman_proxy::params::ssl_cert,
-  $ssl_key             = $foreman_proxy::params::ssl_key,
-  $trusted_hosts       = $foreman_proxy::params::trusted_hosts,
-  $manage_sudoersd     = $foreman_proxy::params::manage_sudoersd,
-  $use_sudoersd        = $foreman_proxy::params::use_sudoersd,
-  $puppetca            = $foreman_proxy::params::puppetca,
-  $ssldir              = $foreman_proxy::params::ssldir,
-  $puppetdir           = $foreman_proxy::params::puppetdir,
-  $autosign_location   = $foreman_proxy::params::autosign_location,
-  $puppetca_cmd        = $foreman_proxy::params::puppetca_cmd,
-  $puppet_group        = $foreman_proxy::params::puppet_group,
-  $puppetrun           = $foreman_proxy::params::puppetrun,
-  $puppetrun_cmd       = $foreman_proxy::params::puppetrun_cmd,
-  $tftp                = $foreman_proxy::params::tftp,
-  $tftp_syslinux_root  = $foreman_proxy::params::tftp_syslinux_root,
-  $tftp_syslinux_files = $foreman_proxy::params::tftp_syslinux_files,
-  $tftp_root           = $foreman_proxy::params::tftp_root,
-  $tftp_dirs           = $foreman_proxy::params::tftp_dirs,
-  $tftp_servername     = $foreman_proxy::params::tftp_servername,
-  $dhcp                = $foreman_proxy::params::dhcp,
-  $dhcp_managed        = $foreman_proxy::params::dhcp_managed,
-  $dhcp_interface      = $foreman_proxy::params::dhcp_interface,
-  $dhcp_gateway        = $foreman_proxy::params::dhcp_gateway,
-  $dhcp_range          = $foreman_proxy::params::dhcp_range,
-  $dhcp_nameservers    = $foreman_proxy::params::dhcp_nameservers,
-  $dhcp_vendor         = $foreman_proxy::params::dhcp_vendor,
-  $dhcp_config         = $foreman_proxy::params::dhcp_config,
-  $dhcp_leases         = $foreman_proxy::params::dhcp_leases,
-  $dhcp_key_name       = $foreman_proxy::params::dhcp_key_name,
-  $dhcp_key_secret     = $foreman_proxy::params::dhcp_key_secret,
-  $dns                 = $foreman_proxy::params::dns,
-  $dns_managed         = $foreman_proxy::params::dns_managed,
-  $dns_interface       = $foreman_proxy::params::dns_interface,
-  $dns_reverse         = $foreman_proxy::params::dns_reverse,
-  $dns_server          = $foreman_proxy::params::dns_server,
-  $dns_forwarders      = $foreman_proxy::params::dns_forwarders,
-  $keyfile             = $foreman_proxy::params::keyfile
+  $repo                  = $foreman_proxy::params::repo,
+  $gpgcheck              = $foreman_proxy::params::gpgcheck,
+  $custom_repo           = $foreman_proxy::params::custom_repo,
+  $port                  = $foreman_proxy::params::port,
+  $dir                   = $foreman_proxy::params::dir,
+  $user                  = $foreman_proxy::params::user,
+  $log                   = $foreman_proxy::params::log,
+  $ssl                   = $foreman_proxy::params::ssl,
+  $ssl_ca                = $foreman_proxy::params::ssl_ca,
+  $ssl_cert              = $foreman_proxy::params::ssl_cert,
+  $ssl_key               = $foreman_proxy::params::ssl_key,
+  $trusted_hosts         = $foreman_proxy::params::trusted_hosts,
+  $manage_sudoersd       = $foreman_proxy::params::manage_sudoersd,
+  $use_sudoersd          = $foreman_proxy::params::use_sudoersd,
+  $puppetca              = $foreman_proxy::params::puppetca,
+  $ssldir                = $foreman_proxy::params::ssldir,
+  $puppetdir             = $foreman_proxy::params::puppetdir,
+  $autosign_location     = $foreman_proxy::params::autosign_location,
+  $puppetca_cmd          = $foreman_proxy::params::puppetca_cmd,
+  $puppet_group          = $foreman_proxy::params::puppet_group,
+  $puppetrun             = $foreman_proxy::params::puppetrun,
+  $puppetrun_cmd         = $foreman_proxy::params::puppetrun_cmd,
+  $tftp                  = $foreman_proxy::params::tftp,
+  $tftp_syslinux_root    = $foreman_proxy::params::tftp_syslinux_root,
+  $tftp_syslinux_files   = $foreman_proxy::params::tftp_syslinux_files,
+  $tftp_root             = $foreman_proxy::params::tftp_root,
+  $tftp_dirs             = $foreman_proxy::params::tftp_dirs,
+  $tftp_servername       = $foreman_proxy::params::tftp_servername,
+  $dhcp                  = $foreman_proxy::params::dhcp,
+  $dhcp_managed          = $foreman_proxy::params::dhcp_managed,
+  $dhcp_interface        = $foreman_proxy::params::dhcp_interface,
+  $dhcp_gateway          = $foreman_proxy::params::dhcp_gateway,
+  $dhcp_range            = $foreman_proxy::params::dhcp_range,
+  $dhcp_nameservers      = $foreman_proxy::params::dhcp_nameservers,
+  $dhcp_vendor           = $foreman_proxy::params::dhcp_vendor,
+  $dhcp_config           = $foreman_proxy::params::dhcp_config,
+  $dhcp_leases           = $foreman_proxy::params::dhcp_leases,
+  $dhcp_key_name         = $foreman_proxy::params::dhcp_key_name,
+  $dhcp_key_secret       = $foreman_proxy::params::dhcp_key_secret,
+  $dns                   = $foreman_proxy::params::dns,
+  $dns_managed           = $foreman_proxy::params::dns_managed,
+  $dns_interface         = $foreman_proxy::params::dns_interface,
+  $dns_reverse           = $foreman_proxy::params::dns_reverse,
+  $dns_server            = $foreman_proxy::params::dns_server,
+  $dns_forwarders        = $foreman_proxy::params::dns_forwarders,
+  $keyfile               = $foreman_proxy::params::keyfile,
+  $register_in_foreman   = $foreman_proxy::params::register_in_foreman,
+  $foreman_base_url      = $foreman_proxy::params::foreman_base_url,
+  $registered_proxy_url  = $foreman_proxy::params::registered_proxy_url,
+  $oauth_effective_user  = $foreman_proxy::params::oauth_effective_user,
+  $oauth_consumer_key    = $foreman_proxy::params::oauth_consumer_key,
+  $oauth_consumer_secret = $foreman_proxy::params::oauth_consumer_secret
 ) inherits foreman_proxy::params {
+
   # Validate misc params
   validate_bool($ssl, $manage_sudoersd, $use_sudoersd)
   validate_array($trusted_hosts)
@@ -184,5 +203,7 @@ class foreman_proxy (
 
   class { 'foreman_proxy::install': } ~>
   class { 'foreman_proxy::config': } ~>
-  class { 'foreman_proxy::service': }
+  class { 'foreman_proxy::service': } ~>
+  class { 'foreman_proxy::register': } ->
+  Class['foreman_proxy']
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,4 +16,12 @@ class foreman_proxy::install {
     ensure  => present,
     require => $repo,
   }
+
+  if $foreman_proxy::register_in_foreman {
+    package { $foreman_proxy::params::foreman_api_package:
+      ensure  => present,
+      require => $repo,
+    }
+  }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -132,4 +132,20 @@ class foreman_proxy::params {
 
   $dns_forwarders = []
 
+  # Proxy can register itself within a Foreman instance
+  $register_in_foreman = true
+  # Foreman instance URL for registration
+  $foreman_base_url = "https://${::fqdn}"
+  # Proxy URL to be regestered
+  $registered_proxy_url = "https://${::fqdn}:${port}"
+  # User to be used for registration
+  $oauth_effective_user = 'admin'
+  # OAuth credentials
+  $oauth_consumer_key = cache_data('oauth_consumer_key', random_password(32))
+  $oauth_consumer_secret = cache_data('oauth_consumer_secret', random_password(32))
+
+  $foreman_api_package = $osfamily ? {
+    Debian  => 'ruby-foreman-api',
+    default => 'rubygem-foreman_api',
+  }
 }

--- a/manifests/register.pp
+++ b/manifests/register.pp
@@ -1,0 +1,15 @@
+# Register the foreman proxy
+class foreman_proxy::register {
+
+  if $foreman_proxy::register_in_foreman {
+    foreman_smartproxy { $::fqdn:
+      ensure          => 'present',
+      base_url        => $foreman_proxy::foreman_base_url,
+      consumer_key    => $foreman_proxy::oauth_consumer_key,
+      consumer_secret => $foreman_proxy::oauth_consumer_secret,
+      effective_user  => $foreman_proxy::oauth_effective_user,
+      url             => $foreman_proxy::registered_proxy_url
+    }
+  }
+
+}

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -3,13 +3,26 @@ require 'spec_helper'
 describe 'foreman_proxy' do
 
   let (:facts) { {
-    :osfamily => 'RedHat',
-    :operatingsystem => 'CentOS',
+    :osfamily               => 'RedHat',
+    :operatingsystem        => 'CentOS',
     :operatingsystemrelease => '6',
+    :fqdn                   => 'my.host.example.com',
   } }
 
   it { should include_class('foreman_proxy::install') }
   it { should include_class('foreman_proxy::config') }
   it { should include_class('foreman_proxy::service') }
+
+  it 'should register the proxy' do
+    should include_class('foreman_proxy::register')
+    should contain_foreman_smartproxy(facts[:fqdn]).with({
+      'ensure'          => 'present',
+      'base_url'        => "https://#{facts[:fqdn]}",
+      'effective_user'  => 'admin',
+      'url'             => "https://#{facts[:fqdn]}:8443",
+      'consumer_key'    => /\w+/,
+      'consumer_secret' => /\w+/,
+    })
+  end
 
 end


### PR DESCRIPTION
Adding proxy registration, counterpart of https://github.com/theforeman/puppet-foreman/pull/88

We need at least this version of foreman_api non-SCL gem: http://koji.katello.org/koji/taskinfo?taskID=41407

This is working in progress. Please review.
