### PR TITLE
Make the proxy registration name variable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -176,6 +176,7 @@ class foreman_proxy (
   $keyfile               = $foreman_proxy::params::keyfile,
   $register_in_foreman   = $foreman_proxy::params::register_in_foreman,
   $foreman_base_url      = $foreman_proxy::params::foreman_base_url,
+  $registered_name       = $foreman_proxy::params::registered_name,
   $registered_proxy_url  = $foreman_proxy::params::registered_proxy_url,
   $oauth_effective_user  = $foreman_proxy::params::oauth_effective_user,
   $oauth_consumer_key    = $foreman_proxy::params::oauth_consumer_key,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -136,7 +136,9 @@ class foreman_proxy::params {
   $register_in_foreman = true
   # Foreman instance URL for registration
   $foreman_base_url = "https://${::fqdn}"
-  # Proxy URL to be regestered
+  # Name the proxy should be registered with
+  $registered_name = $::fqdn
+  # Proxy URL to be registered
   $registered_proxy_url = "https://${::fqdn}:${port}"
   # User to be used for registration
   $oauth_effective_user = 'admin'

--- a/manifests/register.pp
+++ b/manifests/register.pp
@@ -2,7 +2,7 @@
 class foreman_proxy::register {
 
   if $foreman_proxy::register_in_foreman {
-    foreman_smartproxy { $::fqdn:
+    foreman_smartproxy { $foreman_proxy::registered_name:
       ensure          => present,
       base_url        => $foreman_proxy::foreman_base_url,
       consumer_key    => $foreman_proxy::oauth_consumer_key,

--- a/spec/classes/foreman_proxy__register__spec.rb
+++ b/spec/classes/foreman_proxy__register__spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe 'foreman_proxy::register' do
+
+  let :facts do {
+    :osfamily               => 'RedHat',
+    :operatingsystem        => 'CentOS',
+    :operatingsystemrelease => '6',
+    :fqdn                   => 'my.host.example.com',
+  } end
+
+  describe 'with default settings' do
+    let :pre_condition do
+      "include foreman_proxy"
+    end
+
+    it 'should register the proxy' do
+      should include_class('foreman_proxy::register')
+      should contain_foreman_smartproxy(facts[:fqdn]).with({
+        'ensure'          => 'present',
+        'base_url'        => "https://#{facts[:fqdn]}",
+        'effective_user'  => 'admin',
+        'url'             => "https://#{facts[:fqdn]}:8443",
+        'consumer_key'    => /\w+/,
+        'consumer_secret' => /\w+/,
+      })
+    end
+  end
+
+  describe 'with overrides' do
+    let :pre_condition do
+      "class {'foreman_proxy':
+        register_in_foreman   => true,
+        foreman_base_url      => 'my_base',
+        registered_name       => 'my_proxy',
+        registered_proxy_url  => 'my_url',
+        oauth_consumer_key    => 'key',
+        oauth_consumer_secret => 'secret',
+        oauth_effective_user  => 'smartproxy',
+      }"
+    end
+
+    it 'should register the proxy' do
+      should include_class('foreman_proxy::register')
+      should contain_foreman_smartproxy('my_proxy').with({
+        'ensure'          => 'present',
+        'base_url'        => 'my_base',
+        'effective_user'  => 'smartproxy',
+        'url'             => 'my_url',
+        'consumer_key'    => 'key',
+        'consumer_secret' => 'secret',
+      })
+    end
+  end
+
+  describe 'disabled' do
+    let :pre_condition do
+      "class {'foreman_proxy': register_in_foreman => false}"
+    end
+
+    it 'should not register the proxy' do
+      should include_class('foreman_proxy::register')
+      should_not contain_foreman_smartproxy(facts[:fqdn])
+    end
+  end
+end

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -2,27 +2,18 @@ require 'spec_helper'
 
 describe 'foreman_proxy' do
 
-  let (:facts) { {
+  let :facts do {
     :osfamily               => 'RedHat',
     :operatingsystem        => 'CentOS',
     :operatingsystemrelease => '6',
     :fqdn                   => 'my.host.example.com',
-  } }
+  } end
 
-  it { should include_class('foreman_proxy::install') }
-  it { should include_class('foreman_proxy::config') }
-  it { should include_class('foreman_proxy::service') }
-
-  it 'should register the proxy' do
+  it 'should include classes' do
+    should include_class('foreman_proxy::install')
+    should include_class('foreman_proxy::config')
+    should include_class('foreman_proxy::service')
     should include_class('foreman_proxy::register')
-    should contain_foreman_smartproxy(facts[:fqdn]).with({
-      'ensure'          => 'present',
-      'base_url'        => "https://#{facts[:fqdn]}",
-      'effective_user'  => 'admin',
-      'url'             => "https://#{facts[:fqdn]}:8443",
-      'consumer_key'    => /\w+/,
-      'consumer_secret' => /\w+/,
-    })
   end
 
 end


### PR DESCRIPTION
If you have the convention to use the shortname in your foreman, it's
currently impossible to use the registration. By making it variable, you can
make a wrapper class or use hiera to do this for you.
