### PR TITLE
BMC smart-proxy configuration support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -152,4 +152,15 @@ class foreman_proxy::params {
     Debian  => 'ruby-foreman-api',
     default => 'rubygem-foreman_api',
   }
+
+  #BMC settings
+  $bmc = false
+  $bmc_default_provider = 'ipmitool' # 'freeipmi' is a valid option as well
+
+  # Install the default provider
+  if $bmc {
+    package { $bmc_default_provider:
+      ensure => present,
+    }
+  }
 }

--- a/templates/settings.yml.erb
+++ b/templates/settings.yml.erb
@@ -93,6 +93,13 @@
 :puppet: <%= scope.lookupvar("foreman_proxy::puppetrun") %>
 :puppet_conf: <%= scope.lookupvar("foreman_proxy::puppetdir") %>/puppet.conf
 
+# enable BMC management  (Bare metal power and bios controls)
+# Available providers:
+# - freeipmi / ipmitool - requires the appropriate package installed, and the rubyipmi gem
+# - shell - for local reboot control (requires sudo access to /sbin/shutdown for the proxy user)
+:bmc: <%= scope.lookupvar("foreman_proxy::bmc") %>
+:bmc_default_provider:  <%= scope.lookupvar("foreman_proxy::bmc_default_provider") %>
+
 # Where our proxy log files are stored
 # filename or STDOUT
 :log_file: <%= scope.lookupvar("foreman_proxy::log") %>


### PR DESCRIPTION
The smart proxy provides an interface for BMC microcontrollers, this
commit adds the necessary steps and packages to the smart-proxy puppet
module to configure it to accept BMC requests.
