### PR TITLE
SSL disable support

### DIFF
--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -159,4 +159,19 @@ describe 'foreman_proxy::config' do
         })
     end
   end
+
+  context 'ssl disabled' do
+    let :pre_condition do
+      'class {"foreman_proxy":
+        ssl => false,
+      }'
+    end
+
+    it 'should comment out ssl configuration files' do
+      should contain_file('/etc/foreman-proxy/settings.yml').
+        with_content(%r{^#:ssl_ca_file: ssl/certs/ca.pem$}).
+        with_content(%r{^#:ssl_certificate: ssl/certs/fqdn.pem$}).
+        with_content(%r{^#:ssl_private_key: ssl/private_keys/fqdn.key$})
+    end
+  end
 end

--- a/templates/settings.yml.erb
+++ b/templates/settings.yml.erb
@@ -8,22 +8,20 @@
 # if enabled, all communication would be verfied via SSL
 # NOTE that both certificates need to be signed by the same CA in order for this to work
 # see http://theforeman.org/projects/smart-proxy/wiki/SSL for more information
-<% if scope.lookupvar('foreman_proxy::ssl') -%>
-  <% if scope.lookupvar("foreman_proxy::ssl_ca") -%>
-    :ssl_ca_file: <%= scope.lookupvar("foreman_proxy::ssl_ca") %>
-  <% else -%>
-    #:ssl_ca_file: ssl/certs/ca.pem
-  <% end -%>
-  <% if scope.lookupvar("foreman_proxy::ssl_cert") -%>
-    :ssl_certificate: <%= scope.lookupvar("foreman_proxy::ssl_cert") %>
-  <% else -%>
-    #:ssl_certificate: ssl/certs/fqdn.pem
-  <% end -%>
-  <% if scope.lookupvar("foreman_proxy::ssl_key") -%>
-    :ssl_private_key: <%= scope.lookupvar("foreman_proxy::ssl_key") %>
-  <% else -%>
-    #:ssl_private_key: ssl/private_keys/fqdn.key
-  <% end -%>
+<% if ssl = scope.lookupvar("foreman_proxy::ssl") && scope.lookupvar("foreman_proxy::ssl_ca") -%>
+:ssl_ca_file: <%= scope.lookupvar("foreman_proxy::ssl_ca") %>
+<% else -%>
+#:ssl_ca_file: ssl/certs/ca.pem
+<% end -%>
+<% if ssl && scope.lookupvar("foreman_proxy::ssl_cert") -%>
+:ssl_certificate: <%= scope.lookupvar("foreman_proxy::ssl_cert") %>
+<% else -%>
+#:ssl_certificate: ssl/certs/fqdn.pem
+<% end -%>
+<% if ssl && scope.lookupvar("foreman_proxy::ssl_key") -%>
+:ssl_private_key: <%= scope.lookupvar("foreman_proxy::ssl_key") %>
+<% else -%>
+#:ssl_private_key: ssl/private_keys/fqdn.key
 <% end -%>
 
 # the hosts which the proxy accepts connections from


### PR DESCRIPTION
Currently whether ssl is set to true or false, it does not matter at
all. In both case the ssl_key, cacert, etc.. are printed in the template
forcing the smart-proxy to use SSL. This pull request fixes that and
avoids SSL certs being printed on the template.
