### PR TITLE
Register in foreman is a boolean

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,6 +122,7 @@
 # $keyfile::                DNS server keyfile path
 #
 # $register_in_foreman::    Register proxy back in Foreman
+#                           type:boolean
 #
 # $registered_name::        Proxy name which is registered in Foreman
 #


### PR DESCRIPTION
Currently it defaults to string which means you are not able to set value to false, since "false" is true.
