### PR TITLE
Fall back to $ipaddress if $ipaddress_eth0 missing

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -205,6 +205,7 @@ class foreman_proxy (
 
   # Validate tftp params
   validate_bool($tftp)
+  validate_string($tftp_servername)
 
   # Validate dhcp params
   validate_bool($dhcp, $dhcp_managed)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -73,7 +73,10 @@ class foreman_proxy::params {
   $tftp_syslinux_files = ['pxelinux.0','menu.c32','chain.c32','memdisk']
   $tftp_root           = $tftp::params::root
   $tftp_dirs           = ["${tftp_root}/pxelinux.cfg","${tftp_root}/boot"]
-  $tftp_servername     = $ipaddress_eth0
+  $tftp_servername     = $ipaddress_eth0 ? {
+    undef   => $ipaddress,
+    default => $ipaddress_eth0,
+  }
 
   # DHCP settings - requires optional DHCP puppet module
   $dhcp             = false

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -103,4 +103,29 @@ describe 'foreman_proxy::config' do
         with({})
     end
   end
+
+  context 'with TFTP and no $ipaddress_eth0 fact' do
+    let :facts do
+      {
+        :fqdn                   => 'host.example.org',
+        :ipaddress              => '127.0.1.2',
+        :operatingsystem        => 'RedHat',
+        :operatingsystemrelease => '6',
+        :osfamily               => 'RedHat',
+      }
+    end
+
+    let :pre_condition do
+      'class {"foreman_proxy":
+        tftp => true,
+      }'
+    end
+
+    it 'should set tftp_servername to $ipaddress' do
+      should contain_file('/etc/foreman-proxy/settings.yml').
+        with_content(%r{^:tftp: true$}).
+        with_content(%r{^:tftp_servername: 127.0.1.2$}).
+        with({})
+    end
+  end
 end


### PR DESCRIPTION
This keeps getting set to 'undef' in people's settings.yml files, so I think $ipaddress is a better fallback, even if the logic behind it is sometimes questionable.
