### PR TITLE
We have to specify requirements for librarian

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -7,7 +7,7 @@ summary 'Foreman Smart Proxy configuration'
 description 'Module for configuring the Foreman Smart Proxy and other services'
 project_page 'http://github.com/theforeman/foreman-installer'
 
-dependency 'puppetlabs/stdlib'
+dependency 'puppetlabs/stdlib', '>= 0'
 dependency 'theforeman/dns', '>= 1.3.0'
 dependency 'theforeman/dhcp', '>= 1.3.0'
 dependency 'theforeman/puppet', '>= 1.3.0'


### PR DESCRIPTION
Otherwise librarian-puppet fails to read version. It may vary on
different rubygems version which are used for version parsing however on
ruby 1.8.7 with rubygems 1.8 this is required.
