### PR TITLE
Use ensure_packages for non-core wget package

### DIFF
--- a/manifests/tftp.pp
+++ b/manifests/tftp.pp
@@ -16,7 +16,5 @@ class foreman_proxy::tftp {
     require     => Class['tftp::install'];
   }
 
-  package { 'wget':
-    ensure => installed,
-  }
+  ensure_packages(['wget'])
 }


### PR DESCRIPTION
This enables users of this class to avoid resource conflicts.
