### PR TITLE
Fix nologin shell path on Debian

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -23,7 +23,7 @@ class foreman_proxy::config {
 
   user { $foreman_proxy::user:
     ensure  => 'present',
-    shell   => '/sbin/nologin',
+    shell   => '/bin/false',
     comment => 'Foreman Proxy account',
     groups  => $groups,
     home    => $foreman_proxy::dir,

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -36,7 +36,7 @@ describe 'foreman_proxy::config' do
     it 'should create the foreman-proxy user' do
       should contain_user('foreman-proxy').with({
         :ensure  => 'present',
-        :shell   => '/sbin/nologin',
+        :shell   => '/bin/false',
         :comment => 'Foreman Proxy account',
         :groups  => ['puppet'],
         :home    => '/usr/share/foreman-proxy',


### PR DESCRIPTION
This shouldn't break Fedora as they have a symlink /usr/sbin -> /sbin
