### PR TITLE
Set the puppetrun_cmd's sudo rule to use the puppet_user parameter

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -52,19 +52,26 @@ class foreman_proxy::config {
       owner   => 'root',
       group   => 'root',
       mode    => '0440',
-      content => "${foreman_proxy::user} ALL = NOPASSWD : ${foreman_proxy::puppetca_cmd} *, ${foreman_proxy::puppetrun_cmd} *
+      content => "${foreman_proxy::user} ALL = (root) NOPASSWD : ${foreman_proxy::puppetca_cmd} *
+${foreman_proxy::user} ALL = (${foreman_proxy::puppet_user}) NOPASSWD : ${foreman_proxy::puppetrun_cmd} *
 Defaults:${foreman_proxy::user} !requiretty\n",
       require => File['/etc/sudoers.d'],
     }
   } else {
     augeas { 'sudo-foreman-proxy':
-      context => '/files/etc/sudoers',
+      lens    => 'Sudoers.lns',
+      incl    => '/etc/sudoers',
       changes => [
-        "set spec[user = '${foreman_proxy::user}']/user ${foreman_proxy::user}",
-        "set spec[user = '${foreman_proxy::user}']/host_group/host ALL",
-        "set spec[user = '${foreman_proxy::user}']/host_group/command[1] '${foreman_proxy::puppetca_cmd} *'",
-        "set spec[user = '${foreman_proxy::user}']/host_group/command[2] '${foreman_proxy::puppetrun_cmd} *'",
-        "set spec[user = '${foreman_proxy::user}']/host_group/command[1]/tag NOPASSWD",
+        "set spec[user = '${foreman_proxy::user}'][1]/user ${foreman_proxy::user}",
+        "set spec[user = '${foreman_proxy::user}'][1]/host_group/host ALL",
+        "set spec[user = '${foreman_proxy::user}'][1]/host_group/command '${foreman_proxy::puppetca_cmd} *'",
+        "set spec[user = '${foreman_proxy::user}'][1]/host_group/command/tag NOPASSWD",
+        "set spec[user = '${foreman_proxy::user}'][1]/host_group/command/runas_user root",
+        "set spec[user = '${foreman_proxy::user}'][2]/user ${foreman_proxy::user}",
+        "set spec[user = '${foreman_proxy::user}'][2]/host_group/host ALL",
+        "set spec[user = '${foreman_proxy::user}'][2]/host_group/command '${foreman_proxy::puppetrun_cmd} *'",
+        "set spec[user = '${foreman_proxy::user}'][2]/host_group/command/tag NOPASSWD",
+        "set spec[user = '${foreman_proxy::user}'][2]/host_group/command/runas_user ${foreman_proxy::puppet_user}",
         "set Defaults[type = ':${foreman_proxy::user}']/type :${foreman_proxy::user}",
         "set Defaults[type = ':${foreman_proxy::user}']/requiretty/negate ''",
       ],


### PR DESCRIPTION
This is for when puppet_user is changed to something other than root.  I am unable to make the Augeas[sudo-foreman-proxy] resource work, even as-is in an EL6.5 VM.  I can manually run the "set" commands in augtool just fine.

Here's an example of what works in augtool, but not puppet's Augeas type.

```
augtool> set /files/etc/sudoers/Cmnd_Alias[alias/name = 'FOREMAN_PROXY_COMMANDS']/alias/name "FOREMAN_PROXY_COMMANDS"
augtool> set /files/etc/sudoers/Cmnd_Alias[alias/name = 'FOREMAN_PROXY_COMMANDS']/alias/command[1] "puppet cert *"
augtool> set /files/etc/sudoers/Cmnd_Alias[alias/name = 'FOREMAN_PROXY_COMMANDS']/alias/command[2] "puppet kick *"
augtool> set /files/etc/sudoers/Runas_Alias[alias/name = 'FOREMAN_PROXY_RUNAS']/alias/name "FOREMAN_PROXY_RUNAS"
augtool> set /files/etc/sudoers/Runas_Alias[alias/name = 'FOREMAN_PROXY_RUNAS']/alias/runas_user[1] "root"
augtool> set /files/etc/sudoers/Runas_Alias[alias/name = 'FOREMAN_PROXY_RUNAS']/alias/runas_user[2] "foreman-proxy"
augtool> set /files/etc/sudoers/spec[user = 'foreman-proxy']/user "foreman-proxy"
augtool> set /files/etc/sudoers/spec[user = 'foreman-proxy']/host_group/host "ALL"
augtool> set /files/etc/sudoers/spec[user = 'foreman-proxy']/host_group/command "FOREMAN_PROXY_COMMANDS"
augtool> set /files/etc/sudoers/spec[user = 'foreman-proxy']/host_group/command/runas_user "FOREMAN_PROXY_RUNAS"
augtool> set /files/etc/sudoers/spec[user = 'foreman-proxy']/host_group/command/tag "NOPASSWD"
```
