### PR TITLE
Ensure foreman_proxy::service is refreshed after SSL certs change

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,7 +4,7 @@ class foreman_proxy::config {
   # Ensure SSL certs from the puppetmaster are available
   # Relationship is duplicated there as defined() is parse-order dependent
   if $foreman_proxy::ssl and defined(Class['puppet::server::config']) {
-    Class['puppet::server::config'] -> Class['foreman_proxy::config']
+    Class['puppet::server::config'] ~> Class['foreman_proxy::config', 'foreman_proxy::service']
   }
 
   if $foreman_proxy::puppetca  { include foreman_proxy::puppetca }


### PR DESCRIPTION
Seen with foreman-bats, when /var/lib/puppet/ssl gets wiped, a new cert's generated by the installer but the proxy is still active with the old one.
