### PR TITLE
Fix comparison of operatingsystemrelease for CentOS 7.0.1406

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,4 @@
+--format documentation
+--color
+--tty
+--backtrace

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,7 +37,7 @@ class foreman_proxy::params {
   # Add a file to /etc/sudoers.d (true) or uses augeas (false)
   case $::operatingsystem {
     redhat,centos,Scientific: {
-      if $::operatingsystemrelease >= 6 {
+      if versioncmp($::operatingsystemrelease, '6.0') >= 0 {
         $use_sudoersd = true
       } else {
         $use_sudoersd = false

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -7,7 +7,7 @@ describe 'foreman_proxy::config' do
       :domain                 => 'example.org',
       :ipaddress_eth0         => '127.0.1.1',
       :operatingsystem        => 'RedHat',
-      :operatingsystemrelease => '6',
+      :operatingsystemrelease => '6.5',
       :osfamily               => 'RedHat',
     }
   end
@@ -162,6 +162,40 @@ describe 'foreman_proxy::config' do
         :require => 'File[/etc/sudoers.d]',
       })
     end
+
+    context 'when operatingsystemrelease is 7.0.1406' do
+      let :facts do
+        {
+          :fqdn                   => 'host.example.org',
+          :domain                 => 'example.org',
+          :ipaddress_eth0         => '127.0.1.1',
+          :operatingsystem        => 'CentOS',
+          :operatingsystemrelease => '7.0.1406',
+          :osfamily               => 'RedHat',
+        }
+      end
+
+      it 'should not manage /etc/sudoers.d' do
+        should contain_file('/etc/sudoers.d').with_ensure('directory')
+      end
+    end
+
+    context 'when operatingsystemrelease is 5.10' do
+      let :facts do
+        {
+          :fqdn                   => 'host.example.org',
+          :domain                 => 'example.org',
+          :ipaddress_eth0         => '127.0.1.1',
+          :operatingsystem        => 'RedHat',
+          :operatingsystemrelease => '5.10',
+          :osfamily               => 'RedHat',
+        }
+      end
+
+      it 'should not manage /etc/sudoers.d' do
+        should_not contain_file('/etc/sudoers.d')
+      end
+    end
   end
 
   context 'with bmc' do
@@ -186,7 +220,7 @@ describe 'foreman_proxy::config' do
         :fqdn                   => 'host.example.org',
         :ipaddress              => '127.0.1.2',
         :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => '6',
+        :operatingsystemrelease => '6.5',
         :osfamily               => 'RedHat',
       }
     end
@@ -211,7 +245,7 @@ describe 'foreman_proxy::config' do
         :fqdn                   => 'host.example.org',
         :ipaddress              => '127.0.1.2',
         :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => '6',
+        :operatingsystemrelease => '6.5',
         :osfamily               => 'RedHat',
       }
     end

--- a/spec/classes/foreman_proxy__proxydhcp__spec.rb
+++ b/spec/classes/foreman_proxy__proxydhcp__spec.rb
@@ -9,7 +9,7 @@ describe 'foreman_proxy::proxydhcp' do
       :netmask_eth0           => '255.0.0.0',
       :network_eth0           => '127.0.0.0',
       :operatingsystem        => 'CentOS',
-      :operatingsystemrelease => '6',
+      :operatingsystemrelease => '6.5',
       :osfamily               => 'RedHat',
     }
   end

--- a/spec/classes/foreman_proxy__proxydns__spec.rb
+++ b/spec/classes/foreman_proxy__proxydns__spec.rb
@@ -9,7 +9,7 @@ describe 'foreman_proxy::proxydns' do
         :domain                 => 'example.org',
         :ipaddress_eth0         => '127.0.1.1',
         :operatingsystem        => 'CentOS',
-        :operatingsystemrelease => '6',
+        :operatingsystemrelease => '6.5',
         :osfamily               => 'RedHat',
       }
     end

--- a/spec/classes/foreman_proxy__register__spec.rb
+++ b/spec/classes/foreman_proxy__register__spec.rb
@@ -5,7 +5,7 @@ describe 'foreman_proxy::register' do
   let :facts do {
     :osfamily               => 'RedHat',
     :operatingsystem        => 'CentOS',
-    :operatingsystemrelease => '6',
+    :operatingsystemrelease => '6.5',
     :fqdn                   => 'my.host.example.com',
   } end
 

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -5,7 +5,7 @@ describe 'foreman_proxy' do
   let :facts do {
     :osfamily               => 'RedHat',
     :operatingsystem        => 'CentOS',
-    :operatingsystemrelease => '6',
+    :operatingsystemrelease => '6.5',
     :fqdn                   => 'my.host.example.com',
   } end
 

--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,1 +1,0 @@
---format documentation --colour --backtrace


### PR DESCRIPTION
Changes:
- Fix comparison of operatingsystemrelease for CentOS 7.0.1406
- Move spec/spec.opts to .rspec to support RSpec >= 2.0 option file method

Error received without this change (also observed with unit test changes without change to params.pp):

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: comparison of String with 6 failed at /etc/puppet/environments/production/modules/foreman_proxy/manifests/params.pp:40 on node puppetmaster02.<DOMAIN>
```

```
# facter operatingsystemrelease
7.0.1406
```
