### PR TITLE
Fix relationship specification, which fails under Puppet 2.7.11

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,7 +4,8 @@ class foreman_proxy::config {
   # Ensure SSL certs from the puppetmaster are available
   # Relationship is duplicated there as defined() is parse-order dependent
   if $foreman_proxy::ssl and defined(Class['puppet::server::config']) {
-    Class['puppet::server::config'] ~> Class['foreman_proxy::config', 'foreman_proxy::service']
+    Class['puppet::server::config'] ~> Class['foreman_proxy::config']
+    Class['puppet::server::config'] ~> Class['foreman_proxy::service']
   }
 
   if $foreman_proxy::puppetca  { include foreman_proxy::puppetca }


### PR DESCRIPTION
When using two class names, they get concatenated:

```
[ INFO 2014-08-15 09:04:41 verbose] Could not find resource
'Class[Foreman_proxy::Config]Class[Foreman_proxy::Service]' for relationship
from 'Class[Puppet::Server::Config]' on node foreman-precise.example.com
```

Paired with https://github.com/theforeman/puppet-puppet/pull/179
