### PR TITLE
Fix error referencing class that may not have been evaluated

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -7,7 +7,7 @@ summary 'Foreman Smart Proxy configuration'
 description 'Module for configuring the Foreman Smart Proxy and other services'
 project_page 'http://github.com/theforeman/foreman-installer'
 
-dependency 'puppetlabs/stdlib', '>= 2.3.0'
+dependency 'puppetlabs/stdlib', '>= 2.6.0'
 dependency 'theforeman/dns', '>= 1.3.0'
 dependency 'theforeman/dhcp', '>= 1.3.0'
 dependency 'theforeman/foreman', '>= 1.3.0'

--- a/manifests/plugin/pulp.pp
+++ b/manifests/plugin/pulp.pp
@@ -11,10 +11,12 @@
 # $pulp_url::     pulp url to use
 #
 class foreman_proxy::plugin::pulp (
-  $enabled  = $foreman_proxy::plugin::pulp::params::enabled,
-  $group = $foreman_proxy::plugin::pulp::params::group,
-  $pulp_url = $foreman_proxy::plugin::pulp::params::pulp_url,
+  $enabled  = $::foreman_proxy::plugin::pulp::params::enabled,
+  $group    = $::foreman_proxy::plugin::pulp::params::group,
+  $pulp_url = $::foreman_proxy::plugin::pulp::params::pulp_url,
 ) inherits foreman_proxy::plugin::pulp::params {
+  $group_real = pick($group, $::foreman_proxy::user)
+  validate_string($group_real)
 
   foreman_proxy::plugin {'pulp':
   } ->
@@ -22,7 +24,7 @@ class foreman_proxy::plugin::pulp (
     ensure  => file,
     content => template('foreman_proxy/plugin/pulp.yml.erb'),
     owner   => 'root',
-    group   => $group,
+    group   => $group_real,
     mode    => '0640',
   }
 }

--- a/manifests/plugin/pulp/params.pp
+++ b/manifests/plugin/pulp/params.pp
@@ -1,6 +1,6 @@
 # Default parameters for the Pulp smart proxy plugin
 class foreman_proxy::plugin::pulp::params {
   $enabled  = true
-  $group     = $::foreman_proxy::user
+  $group    = undef
   $pulp_url = "https://${::fqdn}/pulp"
 }

--- a/spec/classes/foreman_proxy__plugin__pulp_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__pulp_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe 'foreman_proxy::plugin::pulp' do
+
+  let :facts do {
+    :osfamily               => 'RedHat',
+    :operatingsystem        => 'CentOS',
+    :operatingsystemrelease => '6.5',
+    :fqdn                   => 'my.host.example.com',
+  } end
+
+  describe 'with default settings' do
+    let :pre_condition do
+      "include foreman_proxy"
+    end
+
+    it { should contain_foreman_proxy__plugin('pulp') }
+    it 'should configure pulp.yml' do
+      should contain_file('/etc/foreman-proxy/settings.d/pulp.yml').
+        with({
+          :ensure  => 'file',
+          :owner   => 'root',
+          :group   => 'foreman-proxy',
+          :mode    => '0640',
+          :content => /:enabled: true/
+        })
+    end
+  end
+
+  describe 'with group overridden' do
+    let :pre_condition do
+      "include foreman_proxy"
+    end
+    let :params do {
+      :group => 'example',
+    } end
+
+    it 'should change pulp.yml group' do
+      should contain_file('/etc/foreman-proxy/settings.d/pulp.yml').
+        with({
+          :owner   => 'root',
+          :group   => 'example'
+        })
+    end
+  end
+end


### PR DESCRIPTION
kafo/Puppet generates a warning when trying to determine default parameters otherwise:

```
[DEBUG 2014-09-09 13:50:30 main] Warning: Scope(Class[Foreman_proxy::Plugin::Pulp::Params]): Could not look up qualified variable '::foreman_proxy::user'; class ::foreman_proxy has not been evaluated
```
