### PR TITLE
Improved sudo management

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,0 +1,5 @@
+---
+spec/spec_helper.rb:
+  requires:
+    - lib/module_spec_helper
+

--- a/spec/lib/module_spec_helper.rb
+++ b/spec/lib/module_spec_helper.rb
@@ -1,0 +1,4 @@
+def verify_exact_contents(subject, title, expected_lines)
+  content = subject.resource('file', title).send(:parameters)[:content]
+  content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }.should == expected_lines
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 #   https://github.com/theforeman/foreman-installer-modulesync
 
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'lib/module_spec_helper'
 
 require 'rspec-puppet-facts'
 include RspecPuppetFacts

--- a/templates/sudo.erb
+++ b/templates/sudo.erb
@@ -1,0 +1,7 @@
+<% if scope.lookupvar("foreman_proxy::puppetca") -%>
+<%= scope.lookupvar("foreman_proxy::user") %> ALL = (root) NOPASSWD : <%= scope.lookupvar("foreman_proxy::puppetca_cmd") %> *
+<% end -%>
+<% if scope.lookupvar("foreman_proxy::puppetrun") -%>
+<%= scope.lookupvar("foreman_proxy::user") %> ALL = (<%= scope.lookupvar("foreman_proxy::puppet_user") %>) NOPASSWD : <%= scope.lookupvar("foreman_proxy::puppetrun_cmd") %> *
+<% end -%>
+Defaults:<%= scope.lookupvar("foreman_proxy::user") %> !requiretty

--- a/templates/sudo_augeas.erb
+++ b/templates/sudo_augeas.erb
@@ -1,0 +1,29 @@
+<% if scope.lookupvar('foreman_proxy::puppetca') and scope.lookupvar('foreman_proxy::puppetrun') -%>
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/user <%= scope.lookupvar('foreman_proxy::user') %>
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/host ALL
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/command '<%= scope.lookupvar('foreman_proxy::puppetca_cmd') %> *'
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/command/runas_user root
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/command/tag NOPASSWD
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][2]/user <%= scope.lookupvar('foreman_proxy::user') %>
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][2]/host_group/host ALL
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][2]/host_group/command '<%= scope.lookupvar('foreman_proxy::puppetrun_cmd') %> *'
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][2]/host_group/command/runas_user <%= scope.lookupvar('foreman_proxy::puppet_user') %>
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][2]/host_group/command/tag NOPASSWD
+rm spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/command[position() > 1]
+<% elsif scope.lookupvar('foreman_proxy::puppetca') -%>
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/user <%= scope.lookupvar('foreman_proxy::user') %>
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/host ALL
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command '<%= scope.lookupvar('foreman_proxy::puppetca_cmd') %> *'
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command/runas_user root
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command/tag NOPASSWD
+rm spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/command[position() > 1]
+<% elsif scope.lookupvar('foreman_proxy::puppetrun') -%>
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/user <%= scope.lookupvar('foreman_proxy::user') %>
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/host ALL
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command '<%= scope.lookupvar('foreman_proxy::puppetrun_cmd') %> *'
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command/runas_user <%= scope.lookupvar('foreman_proxy::puppet_user') %>
+set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command/tag NOPASSWD
+rm spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/command[position() > 1]
+<% end -%>
+set Defaults[type = ':<%= scope.lookupvar('foreman_proxy::user') %>']/type :<%= scope.lookupvar('foreman_proxy::user') %>
+set Defaults[type = ':<%= scope.lookupvar('foreman_proxy::user') %>']/requiretty/negate ''


### PR DESCRIPTION
* Set the puppetrun sudo command to match the user specified using puppetrun_user parameter
* Only manage the sudo rules if both puppetca and puppetrun are enabled

This is a refactor of #101 

The spec tests fail on my desktop, could use second pair of eyes as it appears like it shouldn't be failing.