### PR TITLE
fixes #8875- support installation/configuration of smart_proxy_salt

### DIFF
--- a/manifests/plugin/salt.pp
+++ b/manifests/plugin/salt.pp
@@ -1,0 +1,39 @@
+# = Foreman Proxy Salt plugin
+#
+# This class installs Salt support for Foreman proxy
+#
+# === Parameters:
+#
+# $enabled::         Enables/disables the plugin
+#                    type:boolean
+#
+# $listen_on::       Proxy feature listens on https, http, or both
+#
+# $autosign_file::   File to use for salt autosign
+#
+# $user::            User to run salt commands under
+#
+# $group::           Owner of plugin configuration
+#
+class foreman_proxy::plugin::salt (
+  $autosign_file     = $::foreman_proxy::plugin::salt::params::autosign_file,
+  $enabled           = $::foreman_proxy::plugin::salt::params::enabled,
+  $listen_on         = $::foreman_proxy::plugin::salt::params::listen_on,
+  $user              = $::foreman_proxy::plugin::salt::params::user,
+  $group             = $::foreman_proxy::plugin::salt::params::group,
+) inherits foreman_proxy::plugin::salt::params {
+
+  validate_bool($enabled)
+  validate_listen_on($listen_on)
+  validate_absolute_path($autosign_file)
+  validate_string($user, $group)
+
+  foreman_proxy::plugin { 'salt':
+  } ->
+  foreman_proxy::settings_file { 'salt':
+    enabled       => $enabled,
+    listen_on     => $listen_on,
+    template_path => 'foreman_proxy/plugin/salt.yml.erb',
+    group         => $group,
+  }
+}

--- a/manifests/plugin/salt/params.pp
+++ b/manifests/plugin/salt/params.pp
@@ -1,0 +1,8 @@
+# Default parameters for the Salt smart proxy plugin
+class foreman_proxy::plugin::salt::params {
+  $enabled           = true
+  $listen_on         = 'https'
+  $autosign_file     = '/etc/salt/autosign.conf'
+  $user              = 'root'
+  $group             = undef
+}

--- a/spec/classes/foreman_proxy__plugin__salt_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__salt_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe 'foreman_proxy::plugin::salt' do
+
+  let :facts do {
+    :osfamily               => 'RedHat',
+    :operatingsystem        => 'CentOS',
+    :operatingsystemrelease => '6.5',
+    :fqdn                   => 'my.host.example.com',
+  } end
+
+  describe 'with default settings' do
+    let :pre_condition do
+      "include foreman_proxy"
+    end
+
+    it { should contain_foreman_proxy__plugin('salt') }
+    it 'should configure salt.yml' do
+      should contain_file('/etc/foreman-proxy/settings.d/salt.yml').
+        with({
+          :ensure  => 'file',
+          :owner   => 'root',
+          :group   => 'foreman-proxy',
+          :mode    => '0640',
+          :content => /:enabled: https/
+        })
+    end
+  end
+
+  describe 'with overwritten parameters' do
+    let :pre_condition do
+      "include foreman_proxy"
+    end
+    let :params do {
+      :user          => 'example',
+      :autosign_file => '/etc/salt/example.conf',
+    } end
+
+    it 'should change salt.yml parameters' do
+      should contain_file('/etc/foreman-proxy/settings.d/salt.yml').
+        with_content(/:salt_command_user: example/).
+        with_content(/:autosign_file: \/etc\/salt\/example.conf/)
+    end
+  end
+
+  describe 'with group overridden' do
+    let :pre_condition do
+      "include foreman_proxy"
+    end
+    let :params do {
+      :group => 'example',
+    } end
+
+    it 'should change salt.yml group' do
+      should contain_file('/etc/foreman-proxy/settings.d/salt.yml').
+        with({
+          :owner   => 'root',
+          :group   => 'example'
+        })
+    end
+  end
+end

--- a/templates/plugin/salt.yml.erb
+++ b/templates/plugin/salt.yml.erb
@@ -1,0 +1,4 @@
+---
+:enabled: <%= @module_enabled %>
+:autosign_file: <%= @autosign_file %>
+:salt_command_user: <%= @user %>


### PR DESCRIPTION
Configures the Smart Proxy plugin.  If https://github.com/theforeman/puppet-foreman_proxy/pull/122 will be merged soon, I'd like to include the sudo rules for salt here as well.