### PR TITLE
Strict variables

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -75,7 +75,9 @@ class foreman_proxy::params {
 
   # puppetrun settings
   $puppetrun           = true
+  $puppet              = $puppetrun
   $puppetrun_listen_on = 'https'
+  $puppet_listen_on    = $puppetrun_listen_on
   $puppetrun_cmd       = $puppet::params::puppetrun_cmd
   $puppetrun_provider  = ''
   $customrun_cmd       = '/bin/false'


### PR DESCRIPTION
Fixes:
Undefined variable "foreman_proxy::puppet"; Undefined variable "puppet" at .../modules/foreman_proxy/manifests/settings_file.pp:44 on node XXX