### PR TITLE
Remove getvar() so it runs under strict variables

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -37,18 +37,38 @@ class foreman_proxy::config {
     module => false,
   }
 
+  foreman_proxy::settings_file { 'bmc':
+    enabled   => $::foreman_proxy::bmc,
+    listen_on => $::foreman_proxy::bmc_listen_on,
+  }
+  foreman_proxy::settings_file { 'dhcp':
+    enabled   => $::foreman_proxy::dhcp,
+    listen_on => $::foreman_proxy::dhcp_listen_on,
+  }
+  foreman_proxy::settings_file { 'dns':
+    enabled   => $::foreman_proxy::dns,
+    listen_on => $::foreman_proxy::dns_listen_on,
+  }
   foreman_proxy::settings_file { 'puppet':
     enabled   => $::foreman_proxy::puppetrun,
     listen_on => $::foreman_proxy::puppetrun_listen_on,
   }
-
-  foreman_proxy::settings_file { 'bmc': }
-  foreman_proxy::settings_file { 'dhcp': }
-  foreman_proxy::settings_file { 'dns': }
-  foreman_proxy::settings_file { 'puppetca': }
-  foreman_proxy::settings_file { 'tftp': }
-  foreman_proxy::settings_file { 'realm': }
-  foreman_proxy::settings_file { 'templates': }
+  foreman_proxy::settings_file { 'puppetca':
+    enabled   => $::foreman_proxy::puppetca,
+    listen_on => $::foreman_proxy::puppetca_listen_on,
+  }
+  foreman_proxy::settings_file { 'realm':
+    enabled   => $::foreman_proxy::realm,
+    listen_on => $::foreman_proxy::realm_listen_on,
+  }
+  foreman_proxy::settings_file { 'tftp':
+    enabled   => $::foreman_proxy::tftp,
+    listen_on => $::foreman_proxy::tftp_listen_on,
+  }
+  foreman_proxy::settings_file { 'templates':
+    enabled   => $::foreman_proxy::templates,
+    listen_on => $::foreman_proxy::templates_listen_on,
+  }
 
   if $foreman_proxy::puppetca or $foreman_proxy::puppetrun {
     if $foreman_proxy::use_sudoersd {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -370,40 +370,29 @@ class foreman_proxy (
   validate_re($plugin_version, '^(installed|present|latest|absent)$')
 
   # Validate puppet params
-  validate_listen_on($puppetca_listen_on, $puppetrun_listen_on)
-  validate_bool($puppetca, $puppetrun, $puppetssh_wait)
+  validate_bool($puppetssh_wait)
   validate_string($ssldir, $puppetdir, $autosign_location, $puppetca_cmd, $puppetrun_cmd)
   validate_string($puppet_url, $puppet_ssl_ca, $puppet_ssl_cert, $puppet_ssl_key)
 
   # Validate template params
-  validate_bool($templates)
-  validate_listen_on($templates_listen_on)
   validate_string($template_url)
 
   # Validate tftp params
-  validate_bool($tftp)
-  validate_listen_on($tftp_listen_on)
   validate_string($tftp_servername)
 
   # Validate dhcp params
-  validate_bool($dhcp, $dhcp_managed)
-  validate_listen_on($dhcp_listen_on)
+  validate_bool($dhcp_managed)
   validate_array($dhcp_option_domain)
 
   # Validate dns params
-  validate_listen_on($dns_listen_on)
-  validate_bool($dns)
   validate_string($dns_interface, $dns_provider, $dns_reverse, $dns_server, $keyfile)
   validate_array($dns_forwarders)
 
   # Validate bmc params
-  validate_bool($bmc)
-  validate_listen_on($bmc_listen_on)
   validate_re($bmc_default_provider, '^(freeipmi|ipmitool|shell)$')
 
   # Validate realm params
-  validate_listen_on($realm_listen_on)
-  validate_bool($realm, $freeipa_remove_dns)
+  validate_bool($freeipa_remove_dns)
   validate_string($realm_provider, $realm_principal)
   validate_absolute_path($realm_keytab)
 

--- a/manifests/settings_file.pp
+++ b/manifests/settings_file.pp
@@ -8,11 +8,10 @@
 # $module::        Whether the config file is a proxy module or not
 #                  type:boolean
 #
-# $enabled::       If module is enabled or not. If undefined, take from
-#                  $::foreman_proxy
+# $enabled::       If module is enabled or not
 #                  type:boolean
 #
-# $listen_on::     Whether to listen on https, http, or both
+# $listen_on::     Whether the module listens on https, http, or both
 #
 # $path::          Path to module's settings file, by default
 #                  '/etc/foreman-proxy/settings.d/<module name>.yml
@@ -26,26 +25,25 @@
 # $mode:           Settings file's mode
 #
 define foreman_proxy::settings_file (
-    $module        = true,
-    $enabled       = undef,
-    $listen_on     = undef,
-    $path          = "/etc/foreman-proxy/settings.d/${title}.yml",
-    $owner         = 'root',
-    $group         = $::foreman_proxy::user,
-    $mode          = '0640',
-    $template_path = "foreman_proxy/${title}.yml.erb",
-  ) {
+  $module        = true,
+  $enabled       = true,
+  $listen_on     = 'https',
+  $path          = "/etc/foreman-proxy/settings.d/${title}.yml",
+  $owner         = 'root',
+  $group         = $::foreman_proxy::user,
+  $mode          = '0640',
+  $template_path = "foreman_proxy/${title}.yml.erb",
+) {
+  validate_bool($module, $enabled)
+  validate_listen_on($listen_on)
 
   # If the config file is for a proxy module, then we need to know
   # whether it's enabled, and if so, where to listen (https, http, or both).
   # If undefined here, look up the values from the foreman_proxy class.
 
   if $module {
-    $real_enabled = pick($enabled, getvar("foreman_proxy::${title}"))
-    $real_listen_on = pick($listen_on, getvar("foreman_proxy::${title}_listen_on"))
-
-    if $real_enabled {
-      $module_enabled = $real_listen_on ? {
+    if $enabled {
+      $module_enabled = $listen_on ? {
         'both'  => true,
         'https' => 'https',
         'http'  => 'http',


### PR DESCRIPTION
Replaces #147 with the longer, but more explicit method discussed.