### PR TITLE
Compatible with theforeman/dns 2.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "description":  "Module for configuring the Foreman Smart Proxy and other services",
   "tags":         ["foreman-proxy", "foreman", "proxy", "smart-proxy", "dns", "dhcp", "puppet"],
   "dependencies": [
-    { "name": "theforeman/dns",           "version_requirement": ">= 1.3.0 < 2.0.0" },
+    { "name": "theforeman/dns",           "version_requirement": ">= 1.3.0 < 3.0.0" },
     { "name": "theforeman/dhcp",          "version_requirement": ">= 1.3.0 < 2.0.0" },
     { "name": "theforeman/foreman",       "version_requirement": ">= 1.3.0 < 4.0.0" },
     { "name": "theforeman/puppet",        "version_requirement": ">= 3.0.0 < 4.0.0" },

--- a/spec/classes/foreman_proxy__proxydns__spec.rb
+++ b/spec/classes/foreman_proxy__proxydns__spec.rb
@@ -5,7 +5,7 @@ describe 'foreman_proxy::proxydns' do
   context 'on RedHat' do
     let :default_facts do
       {
-        :fqdn                   => 'localhost',
+        :fqdn                   => 'foreman.example.org',
         :domain                 => 'example.org',
         :operatingsystem        => 'CentOS',
         :operatingsystemrelease => '6.5',
@@ -123,7 +123,7 @@ describe 'foreman_proxy::proxydns' do
   context 'on Debian' do
     let :facts do
       {
-        :fqdn            => 'localhost',
+        :fqdn            => 'foreman.example.org',
         :domain          => 'example.org',
         :ipaddress_eth0  => '127.0.1.1',
         :operatingsystem => 'Debian',


### PR DESCRIPTION
I think our usage in foreman_proxy::proxydns is just fine with 2.0.0.