### PR TITLE
Use `ensure_packages()` for third-party packages

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,9 +25,7 @@ class foreman_proxy::install {
   }
 
   if $foreman_proxy::bmc and $foreman_proxy::bmc_default_provider != 'shell' {
-    package { $foreman_proxy::bmc_default_provider:
-      ensure => present,
-    }
+    ensure_packages([$foreman_proxy::bmc_default_provider])
   }
 
 }

--- a/manifests/proxydns.pp
+++ b/manifests/proxydns.pp
@@ -4,9 +4,7 @@ class foreman_proxy::proxydns {
     forwarders => $foreman_proxy::dns_forwarders,
   }
 
-  package { $foreman_proxy::params::nsupdate:
-    ensure => installed,
-  }
+  ensure_packages([$foreman_proxy::params::nsupdate])
 
   # puppet fact names are converted from ethX.X and ethX:X to ethX_X
   # so for alias and vlan interfaces we have to modify the name accordingly

--- a/spec/classes/foreman_proxy__proxydns__spec.rb
+++ b/spec/classes/foreman_proxy__proxydns__spec.rb
@@ -29,7 +29,7 @@ describe 'foreman_proxy::proxydns' do
       end
 
       it 'should install nsupdate' do
-        should contain_package('bind-utils').with_ensure('installed')
+        should contain_package('bind-utils').with_ensure('present')
       end
 
       it 'should include the forward zone' do
@@ -136,7 +136,7 @@ describe 'foreman_proxy::proxydns' do
     end
 
     it 'should install nsupdate' do
-      should contain_package('dnsutils').with_ensure('installed')
+      should contain_package('dnsutils').with_ensure('present')
     end
   end
 


### PR DESCRIPTION
Third-party packages are frequently managed with other modules causing
duplicate resource errors.  This changes management of the *bmc
provider* and *nsupdate* packages to be "soft" with the
`ensure_packages()` function, similar to GH-92.