### PR TITLE
refs #9896 - only validate tftp_servername when set

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -378,7 +378,9 @@ class foreman_proxy (
   validate_string($template_url)
 
   # Validate tftp params
-  validate_string($tftp_servername)
+  if $tftp_servername {
+    validate_string($tftp_servername)
+  }
 
   # Validate dhcp params
   validate_bool($dhcp_managed)


### PR DESCRIPTION
Nightly tests failed as validate_string was being called on `undef`: http://ci.theforeman.org/job/systest_foreman/6181/tapTestReport/fb-install-foreman.bats.out-11/