### PR TITLE
Fixes #10255 - syslinux 6.x also needs ldlinux.c32

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -96,6 +96,7 @@ class foreman_proxy::params {
         $tftp_syslinux_filenames = ['/usr/lib/PXELINUX/pxelinux.0',
                                     '/usr/lib/syslinux/memdisk',
                                     '/usr/lib/syslinux/modules/bios/chain.c32',
+                                    '/usr/lib/syslinux/modules/bios/ldlinux.c32',
                                     '/usr/lib/syslinux/modules/bios/menu.c32']
       } else {
         $tftp_syslinux_filenames = ['/usr/lib/syslinux/chain.c32',

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -303,6 +303,7 @@ describe 'foreman_proxy::config' do
       should contain_foreman_proxy__tftp__copy_file('/usr/lib/PXELINUX/pxelinux.0')
       should contain_foreman_proxy__tftp__copy_file('/usr/lib/syslinux/memdisk')
       should contain_foreman_proxy__tftp__copy_file('/usr/lib/syslinux/modules/bios/chain.c32')
+      should contain_foreman_proxy__tftp__copy_file('/usr/lib/syslinux/modules/bios/ldlinux.c32')
       should contain_foreman_proxy__tftp__copy_file('/usr/lib/syslinux/modules/bios/menu.c32')
     end
   end


### PR DESCRIPTION
I'd like to see a 2.2.2 after this has been merged before Foreman 1.8 release.