### PR TITLE
refs #10255 - syslinux 6.x also needs libutil.c32

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -97,6 +97,7 @@ class foreman_proxy::params {
                                     '/usr/lib/syslinux/memdisk',
                                     '/usr/lib/syslinux/modules/bios/chain.c32',
                                     '/usr/lib/syslinux/modules/bios/ldlinux.c32',
+                                    '/usr/lib/syslinux/modules/bios/libutil.c32',
                                     '/usr/lib/syslinux/modules/bios/menu.c32']
       } else {
         $tftp_syslinux_filenames = ['/usr/lib/syslinux/chain.c32',

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -292,6 +292,7 @@ describe 'foreman_proxy::config' do
       should contain_foreman_proxy__tftp__copy_file('/usr/lib/syslinux/memdisk')
       should contain_foreman_proxy__tftp__copy_file('/usr/lib/syslinux/modules/bios/chain.c32')
       should contain_foreman_proxy__tftp__copy_file('/usr/lib/syslinux/modules/bios/ldlinux.c32')
+      should contain_foreman_proxy__tftp__copy_file('/usr/lib/syslinux/modules/bios/libutil.c32')
       should contain_foreman_proxy__tftp__copy_file('/usr/lib/syslinux/modules/bios/menu.c32')
     end
   end


### PR DESCRIPTION
for menu.c32 to really work.