### PR TITLE
Remove validate_integer, due to Kafo bug

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -404,7 +404,6 @@ class foreman_proxy (
   # Validate dhcp params
   validate_bool($dhcp_managed)
   validate_array($dhcp_option_domain)
-  validate_integer($dhcp_omapi_port)
 
   # Validate dns params
   validate_string($dns_interface, $dns_provider, $dns_reverse, $dns_server, $keyfile)


### PR DESCRIPTION
     [ERROR 2015-06-10 13:50:44 verbose] Parameter foreman-proxy-dhcp-omapi-port invalid

http://ci.theforeman.org/job/systest_foreman/6508/tapResults/

Seems this is kafo misinterpreting the return values from validate_integer, I'll send a fix in there to handle it properly, but we should probably remove it for the time being.