### PR TITLE
Fix min version of stdlib for validate_integer

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 2.6.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
I forgot it was from a very new (April '15) version, which is probably why we hadn't hit the kafo bug before.