### PR TITLE
Pass the dhcp_key_name and dhcp_key_secret to the dhcp module

### DIFF
--- a/manifests/proxydhcp.pp
+++ b/manifests/proxydhcp.pp
@@ -30,6 +30,8 @@ class foreman_proxy::proxydhcp {
     interfaces  => [$foreman_proxy::dhcp_interface],
     pxeserver   => $ip,
     pxefilename => 'pxelinux.0',
+    omapi_name  => $foreman_proxy::dhcp_key_name,
+    omapi_key   => $foreman_proxy::dhcp_key_secret,
   }
 
   ::dhcp::pool{ $::domain:


### PR DESCRIPTION
This will setup the dhcp server for OMAPI authentication when foreman_proxy is setup for the same.