### PR TITLE
Per-provider DNS configuartion files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ configuration layout changed significantly.
 To configure older versions of the Smart Proxy (1.5 or older), use an older
 version of this module (1.x).
 
+Since version 1.10 the DNS configuration files are split. If you wish to use
+prior versions with DNS, then you must set `dns_split_config_files` to `false`.
+
 # Contributing
 
 * Fork the project

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -49,6 +49,11 @@ class foreman_proxy::config {
     enabled   => $::foreman_proxy::dns,
     listen_on => $::foreman_proxy::dns_listen_on,
   }
+  if $::foreman_proxy::dns_split_config_files {
+    foreman_proxy::settings_file { ['dns_nsupdate', 'dns_nsupdate_gss']:
+      module => false,
+    }
+  }
   foreman_proxy::settings_file { 'puppet':
     enabled   => $::foreman_proxy::puppetrun,
     listen_on => $::foreman_proxy::puppetrun_listen_on,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -188,6 +188,9 @@
 # $dns::                        Enable DNS feature
 #                               type:boolean
 #
+# $dns_split_config_files::     Split DNS configuration files. This is needed since version 1.10.
+#                               type:boolean
+#
 # $dns_listen_on::              DNS proxy to listen on https, http, or both
 #
 # $dns_managed::                DNS is managed by Foreman proxy
@@ -333,6 +336,7 @@ class foreman_proxy (
   $dhcp_key_secret            = $foreman_proxy::params::dhcp_key_secret,
   $dhcp_omapi_port            = $foreman_proxy::params::dhcp_omapi_port,
   $dns                        = $foreman_proxy::params::dns,
+  $dns_split_config_files     = $foreman_proxy::params::dns_split_config_files,
   $dns_listen_on              = $foreman_proxy::params::dns_listen_on,
   $dns_managed                = $foreman_proxy::params::dns_managed,
   $dns_provider               = $foreman_proxy::params::dns_provider,
@@ -407,6 +411,7 @@ class foreman_proxy (
   validate_integer($dhcp_omapi_port)
 
   # Validate dns params
+  validate_bool($dns, $dns_split_config_files)
   validate_string($dns_interface, $dns_provider, $dns_reverse, $dns_server, $keyfile)
   validate_array($dns_forwarders)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -173,19 +173,20 @@ class foreman_proxy::params {
   $dhcp_vendor     = 'isc'
 
   # DNS settings - requires optional DNS puppet module
-  $dns                = false
-  $dns_listen_on      = 'https'
-  $dns_managed        = true
-  $dns_provider       = 'nsupdate'
-  $dns_interface      = 'eth0'
-  $dns_zone           = $::domain
-  $dns_realm          = upcase($dns_zone)
-  $dns_reverse        = '100.168.192.in-addr.arpa'
+  $dns                    = false
+  $dns_split_config_files = true # smart-proxy 1.10+
+  $dns_listen_on          = 'https'
+  $dns_managed            = true
+  $dns_provider           = 'nsupdate'
+  $dns_interface          = 'eth0'
+  $dns_zone               = $::domain
+  $dns_realm              = upcase($dns_zone)
+  $dns_reverse            = '100.168.192.in-addr.arpa'
   # localhost can resolve to ipv6 which ruby doesn't handle well
-  $dns_server         = '127.0.0.1'
-  $dns_ttl            = '86400'
-  $dns_tsig_keytab    = "${etc}/foreman-proxy/dns.keytab"
-  $dns_tsig_principal = "foremanproxy/${::fqdn}@${dns_realm}"
+  $dns_server             = '127.0.0.1'
+  $dns_ttl                = '86400'
+  $dns_tsig_keytab        = "${etc}/foreman-proxy/dns.keytab"
+  $dns_tsig_principal     = "foremanproxy/${::fqdn}@${dns_realm}"
 
   $dns_forwarders = []
 

--- a/templates/dns.yml.erb
+++ b/templates/dns.yml.erb
@@ -6,6 +6,11 @@
 #   nsupdate
 #   nsupdate_gss (for GSS-TSIG support)
 #   virsh (simple implementation for libvirt)
+<% if scope.lookupvar("foreman_proxy::dns_split_config_files") -%>
+:use_provider: <%= scope.lookupvar("foreman_proxy::dns_provider") %>
+# use this setting if you want to override default TTL setting (86400)
+:dns_ttl: <%= scope.lookupvar("foreman_proxy::dns_ttl") %>
+<% else -%>
 :dns_provider: <%= scope.lookupvar("foreman_proxy::dns_provider") %>
 # use this setting if you are managing a dns server which is not localhost though this proxy
 :dns_server: <%= scope.lookupvar("foreman_proxy::dns_server") %>
@@ -22,4 +27,5 @@
 :dns_key: <%= scope.lookupvar("foreman_proxy::keyfile") %>
 #:dns_tsig_keytab: /usr/share/foreman-proxy/dns.keytab
 #:dns_tsig_principal: DNS/host.example.com@EXAMPLE.COM
+<% end -%>
 <% end -%>

--- a/templates/dns_nsupdate.yml.erb
+++ b/templates/dns_nsupdate.yml.erb
@@ -1,0 +1,8 @@
+---
+#
+# Configuration file for 'nsupdate' dns provider
+#
+
+:dns_key: <%= scope.lookupvar("foreman_proxy::keyfile") %>
+# use this setting if you are managing a dns server which is not localhost though this proxy
+:dns_server: <%= scope.lookupvar("foreman_proxy::dns_server") %>

--- a/templates/dns_nsupdate_gss.yml.erb
+++ b/templates/dns_nsupdate_gss.yml.erb
@@ -1,0 +1,11 @@
+---
+#
+# Configuration file for 'nsupdate_gss' dns provider with GSS-TSIG support
+#
+
+# use this setting if you are managing a dns server which is not localhost though this proxy
+:dns_server: <%= scope.lookupvar("foreman_proxy::dns_server") %>
+# use dns_tsig_* for GSS-TSIG updates using Kerberos.  Required for Windows MS DNS with
+# Secure Dynamic Updates, or BIND as used in FreeIPA.  Set dns_provider to nsupdate_gss.
+:dns_tsig_keytab: <%= scope.lookupvar("foreman_proxy::dns_tsig_keytab") %>
+:dns_tsig_principal: <%= scope.lookupvar("foreman_proxy::dns_tsig_principal") %>


### PR DESCRIPTION
Initial work to split the DNS config. Untested and it doesn't manage the settings files.