### PR TITLE
Only include params class, not top-level class in plugin params

### DIFF
--- a/manifests/plugin/chef/params.pp
+++ b/manifests/plugin/chef/params.pp
@@ -1,6 +1,6 @@
 # Default parameters for the Chef smart proxy plugin
 class foreman_proxy::plugin::chef::params {
-  include ::foreman_proxy
+  include ::foreman_proxy::params
 
   $enabled      = true
   $group        = undef
@@ -8,7 +8,7 @@ class foreman_proxy::plugin::chef::params {
   $version      = undef
   $server_url   = "https://${::fqdn}"
   $client_name  = $::fqdn
-  $private_key  = "${foreman_proxy::etc}/chef/client.pem"
+  $private_key  = "${foreman_proxy::params::etc}/chef/client.pem"
   $ssl_verify   = true
   $ssl_pem_file = undef
 }

--- a/manifests/plugin/salt/params.pp
+++ b/manifests/plugin/salt/params.pp
@@ -1,10 +1,10 @@
 # Default parameters for the Salt smart proxy plugin
 class foreman_proxy::plugin::salt::params {
-  include ::foreman_proxy
+  include ::foreman_proxy::params
 
   $enabled       = true
   $listen_on     = 'https'
-  $autosign_file = "${foreman_proxy::etc}/salt/autosign.conf"
+  $autosign_file = "${foreman_proxy::params::etc}/salt/autosign.conf"
   $user          = 'root'
   $group         = undef
 


### PR DESCRIPTION
The plugin params classes that rely on foreman_proxy parameters should
only include the foreman_proxy::params class rather than the top-level
foreman_proxy class.

Kafo loads the params classes to determine default parameter values on
startup and including foreman_proxy caused this pre-flight run of
Puppet to make actual changes to the system state of foreman_proxy,
using default configuration values.

---

This nearly drove me insane.  Every time I ran foreman-installer -v, it was apparently making changes, yet every time I checked the files before and after, they were identical!