### PR TITLE
fixes #12157 - provider name should be prefixed by dns_

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To use the PowerDNS plugin, the following variables need to be set on the main
 
     $dns          => true
     $dns_managed  => false
-    $dns_provider => 'dns_powerdns'
+    $dns_provider => 'powerdns'
 
 Then you also need to include `foreman_proxy::plugin::dns::powerdns`.
 

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -129,7 +129,7 @@ describe 'foreman_proxy::config' do
           verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/dns.yml", [
             '---',
             ':enabled: false',
-            ':use_provider: nsupdate',
+            ':use_provider: dns_nsupdate',
             ':dns_ttl: 86400',
           ])
 
@@ -423,7 +423,7 @@ describe 'foreman_proxy::config' do
           verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/dns.yml", [
             '---',
             ':enabled: false',
-            ':use_provider: nsupdate_gss',
+            ':use_provider: dns_nsupdate_gss',
             ':dns_ttl: 86400',
           ])
 

--- a/templates/dns.yml.erb
+++ b/templates/dns.yml.erb
@@ -1,13 +1,14 @@
+<% dns_split_files = scope.lookupvar("foreman_proxy::dns_split_config_files") -%>
 ---
 # DNS management
 :enabled: <%= @module_enabled %>
 # valid providers:
-#   dnscmd (Microsoft Windows native implementation)
-#   nsupdate
-#   nsupdate_gss (for GSS-TSIG support)
-#   virsh (simple implementation for libvirt)
-<% if scope.lookupvar("foreman_proxy::dns_split_config_files") -%>
-:use_provider: <%= scope.lookupvar("foreman_proxy::dns_provider") %>
+#   <%= "dns_" if dns_split_files %>dnscmd (Microsoft Windows native implementation)
+#   <%= "dns_" if dns_split_files %>nsupdate
+#   <%= "dns_" if dns_split_files %>nsupdate_gss (for GSS-TSIG support)
+#   <%= "dns_" if dns_split_files %>virsh (simple implementation for libvirt)
+<% if dns_split_files -%>
+:use_provider: dns_<%= scope.lookupvar("foreman_proxy::dns_provider") %>
 # use this setting if you want to override default TTL setting (86400)
 :dns_ttl: <%= scope.lookupvar("foreman_proxy::dns_ttl") %>
 <% else -%>


### PR DESCRIPTION
params.pp sets dns_provider to "nsupdate" which won't work with 1.10.  I do the prefixing in the template so (1) upgrades work, (2) the parameter works for 1.10 or not.
