### PR TITLE
Remove unused ssh_user param from plugin::remote_execution::ssh

### DIFF
--- a/manifests/plugin/remote_execution/ssh.pp
+++ b/manifests/plugin/remote_execution/ssh.pp
@@ -15,8 +15,6 @@
 #
 # $ssh_identity_file::  Provide an alternative name for the SSH keys
 #
-# $ssh_user::           SSH user to use
-#
 # $ssh_keygen::         Location of the ssh-keygen binary
 #
 class foreman_proxy::plugin::remote_execution::ssh (
@@ -25,7 +23,6 @@ class foreman_proxy::plugin::remote_execution::ssh (
   $generate_keys     = $::foreman_proxy::plugin::remote_execution::ssh::params::generate_keys,
   $ssh_identity_dir  = $::foreman_proxy::plugin::remote_execution::ssh::params::ssh_identity_dir,
   $ssh_identity_file = $::foreman_proxy::plugin::remote_execution::ssh::params::ssh_identity_file,
-  $ssh_user          = $::foreman_proxy::plugin::remote_execution::ssh::params::ssh_user,
   $ssh_keygen        = $::foreman_proxy::plugin::remote_execution::ssh::params::ssh_keygen,
 ) inherits foreman_proxy::plugin::remote_execution::ssh::params {
 
@@ -34,7 +31,6 @@ class foreman_proxy::plugin::remote_execution::ssh (
   validate_absolute_path($ssh_identity_path)
   validate_bool($enabled, $generate_keys)
   validate_listen_on($listen_on)
-  validate_string($ssh_user)
 
   include ::foreman_proxy::plugin::dynflow
 

--- a/manifests/plugin/remote_execution/ssh/params.pp
+++ b/manifests/plugin/remote_execution/ssh/params.pp
@@ -7,6 +7,5 @@ class foreman_proxy::plugin::remote_execution::ssh::params {
   $generate_keys     = true
   $ssh_identity_dir  = "${::foreman_proxy::params::dir}/.ssh"
   $ssh_identity_file = 'id_rsa_foreman_proxy'
-  $ssh_user          = 'root'
   $ssh_keygen        = '/usr/bin/ssh-keygen'
 }

--- a/spec/classes/foreman_proxy__plugin__remote_execution__ssh_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__remote_execution__ssh_spec.rb
@@ -18,7 +18,6 @@ describe 'foreman_proxy::plugin::remote_execution::ssh' do
       should contain_file('/etc/foreman-proxy/settings.d/remote_execution_ssh.yml').
         with_content(/^:enabled: https/).
         with_content(%r{:ssh_identity_key_file: /usr/share/foreman-proxy/.ssh/id_rsa_foreman_proxy}).
-        with_content(/^:ssh_user: root/).
         with({
           :ensure  => 'file',
           :owner   => 'root',
@@ -45,7 +44,6 @@ describe 'foreman_proxy::plugin::remote_execution::ssh' do
       :generate_keys     => false,
       :ssh_identity_dir  => '/usr/share/foreman-proxy/.ssh-rex',
       :ssh_identity_file => 'id_rsa',
-      :ssh_user          => 'foreman'
     } end
 
     it { should contain_foreman_proxy__plugin('dynflow') }
@@ -55,7 +53,6 @@ describe 'foreman_proxy::plugin::remote_execution::ssh' do
       should contain_file('/etc/foreman-proxy/settings.d/remote_execution_ssh.yml').
         with_content(/^:enabled: http/).
         with_content(%r{:ssh_identity_key_file: /usr/share/foreman-proxy/.ssh-rex/id_rsa}).
-        with_content(/^:ssh_user: foreman/).
         with({
           :ensure  => 'file',
           :owner   => 'root',

--- a/templates/plugin/remote_execution_ssh.yml.erb
+++ b/templates/plugin/remote_execution_ssh.yml.erb
@@ -1,4 +1,3 @@
 ---
 :enabled: <%= @module_enabled %>
 :ssh_identity_key_file: <%= scope.lookupvar('::foreman_proxy::plugin::remote_execution::ssh::ssh_identity_path') %>
-:ssh_user: <%= scope.lookupvar('::foreman_proxy::plugin::remote_execution::ssh::ssh_user') %>


### PR DESCRIPTION
Not a setting that's even looked at, the ssh_user will come from foreman as part of the job so it doesn't need to be configured on the proxy.  Currently hard coded in the code itself to 'root'.
