### PR TITLE
fix path to dhcpd.conf on FreeBSD

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -80,7 +80,7 @@ class foreman_proxy::params {
 
       $puppetssh_command = '/usr/local/bin/puppet agent --onetime --no-usecacheonfailure'
 
-      $dhcp_config = '/usr/local/etc/dhcp/dhcpd.conf'
+      $dhcp_config = '/usr/local/etc/dhcpd.conf'
       $dhcp_leases = '/var/db/dhcpd/dhcpd.leases'
 
       $keyfile  = '/usr/local/etc/namedb/rndc.key'


### PR DESCRIPTION
The module currently uses `/usr/local/etc/dhcp/dhcpd.conf`as the path to the DHCP server configuration on FreeBSD, but according to [this](https://svnweb.freebsd.org/ports/head/net/isc-dhcp42-server/files/isc-dhcpd.in?revision=340872&view=markup#l36) and [this](https://github.com/theforeman/puppet-dhcp/blob/master/manifests/params.pp#L14) this is *not* the default path. This patch changes the value to use the default path instead.