### PR TITLE
refs #11081 - add DHCP split config files support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ version of this module (1.x).
 Since version 1.10 the DNS configuration files are split. If you wish to use
 prior versions with DNS, then you must set `dns_split_config_files` to `false`.
 
+Since version 1.11 the DHCP configuration files are split. If you wish to use
+prior versions with DHCP, then you must set `dhcp_split_config_files` to `false`.
+
 # Contributing
 
 * Fork the project

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -45,6 +45,11 @@ class foreman_proxy::config {
     enabled   => $::foreman_proxy::dhcp,
     listen_on => $::foreman_proxy::dhcp_listen_on,
   }
+  if $::foreman_proxy::dhcp_split_config_files {
+    foreman_proxy::settings_file { 'dhcp_isc':
+      module => false,
+    }
+  }
   foreman_proxy::settings_file { 'dns':
     enabled   => $::foreman_proxy::dns,
     listen_on => $::foreman_proxy::dns_listen_on,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -158,6 +158,9 @@
 # $dhcp::                       Enable DHCP feature
 #                               type:boolean
 #
+# $dhcp_split_config_files::    Split DHCP configuration files. This is needed since version 1.11.
+#                               type:boolean
+#
 # $dhcp_listen_on::             DHCP proxy to listen on https, http, or both
 #
 # $dhcp_managed::               DHCP is managed by Foreman proxy
@@ -327,6 +330,7 @@ class foreman_proxy (
   $tftp_dirs                  = $foreman_proxy::params::tftp_dirs,
   $tftp_servername            = $foreman_proxy::params::tftp_servername,
   $dhcp                       = $foreman_proxy::params::dhcp,
+  $dhcp_split_config_files    = $foreman_proxy::params::dhcp_split_config_files,
   $dhcp_listen_on             = $foreman_proxy::params::dhcp_listen_on,
   $dhcp_managed               = $foreman_proxy::params::dhcp_managed,
   $dhcp_option_domain         = $foreman_proxy::params::dhcp_option_domain,
@@ -413,7 +417,7 @@ class foreman_proxy (
   }
 
   # Validate dhcp params
-  validate_bool($dhcp_managed)
+  validate_bool($dhcp_managed, $dhcp_split_config_files)
   validate_array($dhcp_option_domain)
   validate_integer($dhcp_omapi_port)
   validate_string($dhcp_server)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -166,6 +166,10 @@
 # $dhcp_managed::               DHCP is managed by Foreman proxy
 #                               type:boolean
 #
+# $dhcp_provider::              DHCP provider
+#
+# $dhcp_vendor::                DHCP vendor (deprecated, use dhcp_provider)
+#
 # $dhcp_option_domain::         DHCP use the dhcpd config option domain-name
 #                               type:array
 #
@@ -178,8 +182,6 @@
 # $dhcp_nameservers::           DHCP nameservers
 #
 # $dhcp_server::                Address of DHCP server to manage 
-#
-# $dhcp_vendor::                DHCP vendor
 #
 # $dhcp_config::                DHCP config file path
 #
@@ -333,13 +335,14 @@ class foreman_proxy (
   $dhcp_split_config_files    = $foreman_proxy::params::dhcp_split_config_files,
   $dhcp_listen_on             = $foreman_proxy::params::dhcp_listen_on,
   $dhcp_managed               = $foreman_proxy::params::dhcp_managed,
+  $dhcp_provider              = $foreman_proxy::params::dhcp_provider,
+  $dhcp_vendor                = $foreman_proxy::params::dhcp_vendor,
   $dhcp_option_domain         = $foreman_proxy::params::dhcp_option_domain,
   $dhcp_interface             = $foreman_proxy::params::dhcp_interface,
   $dhcp_gateway               = $foreman_proxy::params::dhcp_gateway,
   $dhcp_range                 = $foreman_proxy::params::dhcp_range,
   $dhcp_nameservers           = $foreman_proxy::params::dhcp_nameservers,
   $dhcp_server                = $foreman_proxy::params::dhcp_server,
-  $dhcp_vendor                = $foreman_proxy::params::dhcp_vendor,
   $dhcp_config                = $foreman_proxy::params::dhcp_config,
   $dhcp_leases                = $foreman_proxy::params::dhcp_leases,
   $dhcp_key_name              = $foreman_proxy::params::dhcp_key_name,
@@ -420,7 +423,13 @@ class foreman_proxy (
   validate_bool($dhcp_managed, $dhcp_split_config_files)
   validate_array($dhcp_option_domain)
   validate_integer($dhcp_omapi_port)
-  validate_string($dhcp_server)
+  validate_string($dhcp_provider, $dhcp_server)
+  if $dhcp_vendor {
+    validate_string($dhcp_vendor)
+    warning("${::hostname}: foreman_proxy::dhcp_vendor is deprecated; please use dhcp_provider instead")
+  }
+  # dhcp_vendor is deprecated in favour of dhcp_provider
+  $dhcp_provider_real = pick($dhcp_vendor, $dhcp_provider)
 
   # Validate dns params
   validate_bool($dns, $dns_split_config_files)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -186,13 +186,14 @@ class foreman_proxy::params {
   $tftp_syslinux_files = undef
 
   # DHCP settings - requires optional DHCP puppet module
-  $dhcp                   = false
-  $dhcp_listen_on         = 'https'
-  $dhcp_managed           = true
-  $dhcp_interface         = 'eth0'
-  $dhcp_gateway           = '192.168.100.1'
-  $dhcp_range             = false
-  $dhcp_option_domain     = [$::domain]
+  $dhcp                    = false
+  $dhcp_split_config_files = true # smart-proxy 1.11+
+  $dhcp_listen_on          = 'https'
+  $dhcp_managed            = true
+  $dhcp_interface          = 'eth0'
+  $dhcp_gateway            = '192.168.100.1'
+  $dhcp_range              = false
+  $dhcp_option_domain      = [$::domain]
   # This will use the IP of the interface in $dhcp_interface, override
   # if you need to. You can make this a comma-separated string too - it
   # will be split into an array

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -190,6 +190,8 @@ class foreman_proxy::params {
   $dhcp_split_config_files = true # smart-proxy 1.11+
   $dhcp_listen_on          = 'https'
   $dhcp_managed            = true
+  $dhcp_provider           = 'isc'
+  $dhcp_vendor             = undef
   $dhcp_interface          = 'eth0'
   $dhcp_gateway            = '192.168.100.1'
   $dhcp_range              = false
@@ -203,7 +205,6 @@ class foreman_proxy::params {
   $dhcp_key_name   = undef
   $dhcp_key_secret = undef
   $dhcp_omapi_port = 7911
-  $dhcp_vendor     = 'isc'
 
   # DNS settings - requires optional DNS puppet module
   $dns                    = false

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -870,6 +870,22 @@ describe 'foreman_proxy::config' do
           ])
         end
 
+        context 'with dhcp_vendor' do
+          let :pre_condition do
+            'class {"foreman_proxy":
+              dhcp         => true,
+              dhcp_vendor  => "native_ms",
+              dhcp_managed => false,
+            }'
+          end
+
+          it 'should set :use_provider' do
+            verify_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/dhcp.yml", [
+              ':use_provider: dhcp_native_ms',
+            ])
+          end
+        end
+
         context 'when dhcp_split_config_files => false' do
           let :pre_condition do
             'class {"foreman_proxy":
@@ -891,6 +907,23 @@ describe 'foreman_proxy::config' do
             ])
 
             should_not contain_file("#{etc_dir}/foreman-proxy/settings.d/dhcp_isc.yml")
+          end
+
+          context 'with dhcp_vendor' do
+            let :pre_condition do
+              'class {"foreman_proxy":
+                dhcp                    => true,
+                dhcp_vendor             => "native_ms",
+                dhcp_managed            => false,
+                dhcp_split_config_files => false,
+              }'
+            end
+
+            it 'should set :dhcp_vendor' do
+              verify_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/dhcp.yml", [
+                ':dhcp_vendor: native_ms',
+              ])
+            end
           end
         end
       end

--- a/templates/dhcp.yml.erb
+++ b/templates/dhcp.yml.erb
@@ -1,10 +1,19 @@
+<% dhcp_split_files = scope.lookupvar("foreman_proxy::dhcp_split_config_files") -%>
 ---
 # Enable DHCP management
+# Can be true, false, or http/https to enable just one of the protocols
 :enabled: <%= @module_enabled %>
-# valid vendors:
-#   - isc
-#   - native_ms (Microsoft native implementation)
-#   - virsh (simple implementation for libvirt)
+
+# valid providers:
+#   - <%= "dhcp_" if dhcp_split_files %>isc (ISC dhcp server)
+#   - <%= "dhcp_" if dhcp_split_files %>native_ms (Microsoft native implementation)
+#   - <%= "dhcp_" if dhcp_split_files %>virsh (simple implementation for libvirt)
+<% if dhcp_split_files -%>
+:use_provider: dhcp_<%= scope.lookupvar("foreman_proxy::dhcp_vendor") %>
+:server: <%= scope.lookupvar("foreman_proxy::dhcp_server") %>
+# subnets restricts the subnets queried to a subset, to reduce the query time.
+#:subnets: [192.168.205.0/255.255.255.128, 192.168.205.128/255.255.255.128]
+<% else -%>
 <% if scope.lookupvar("foreman_proxy::dhcp") == true -%>
 :dhcp_vendor: <%= scope.lookupvar("foreman_proxy::dhcp_vendor") %>
 :dhcp_server: <%= scope.lookupvar("foreman_proxy::dhcp_server") %>
@@ -35,4 +44,5 @@
 #:dhcp_key_name: secret_key_name
 #:dhcp_key_secret: secret_key
 #:dhcp_omapi_port: 7911
+<% end -%>
 <% end -%>

--- a/templates/dhcp.yml.erb
+++ b/templates/dhcp.yml.erb
@@ -9,13 +9,13 @@
 #   - <%= "dhcp_" if dhcp_split_files %>native_ms (Microsoft native implementation)
 #   - <%= "dhcp_" if dhcp_split_files %>virsh (simple implementation for libvirt)
 <% if dhcp_split_files -%>
-:use_provider: dhcp_<%= scope.lookupvar("foreman_proxy::dhcp_vendor") %>
+:use_provider: dhcp_<%= scope.lookupvar("foreman_proxy::dhcp_provider_real") %>
 :server: <%= scope.lookupvar("foreman_proxy::dhcp_server") %>
 # subnets restricts the subnets queried to a subset, to reduce the query time.
 #:subnets: [192.168.205.0/255.255.255.128, 192.168.205.128/255.255.255.128]
 <% else -%>
 <% if scope.lookupvar("foreman_proxy::dhcp") == true -%>
-:dhcp_vendor: <%= scope.lookupvar("foreman_proxy::dhcp_vendor") %>
+:dhcp_vendor: <%= scope.lookupvar("foreman_proxy::dhcp_provider_real") %>
 :dhcp_server: <%= scope.lookupvar("foreman_proxy::dhcp_server") %>
 :dhcp_config: <%= scope.lookupvar("foreman_proxy::dhcp_config") %>
 :dhcp_leases: <%= scope.lookupvar("foreman_proxy::dhcp_leases") %>

--- a/templates/dhcp_isc.yml.erb
+++ b/templates/dhcp_isc.yml.erb
@@ -1,0 +1,30 @@
+---
+#
+# Configuration file for ISC dhcp provider
+#
+
+:config: <%= scope.lookupvar("foreman_proxy::dhcp_config") %>
+:leases: <%= scope.lookupvar("foreman_proxy::dhcp_leases") %>
+
+# Redhat 5
+#
+#:config: /etc/dhcpd.conf
+#
+# Settings for Ubuntu
+#
+#:config: /etc/dhcp3/dhcpd.conf
+#:leases: /var/lib/dhcp3/dhcpd.leases
+
+# Specifies TSIG key name and secret
+<% unless [nil, :undefined, :undef, ''].include?(scope.lookupvar("foreman_proxy::dhcp_key_name")) ||
+     [nil, :undefined, :undef, ''].include?(scope.lookupvar("foreman_proxy::dhcp_key_secret")) -%>
+:key_name: <%= scope.lookupvar("foreman_proxy::dhcp_key_name") %>
+:key_secret: <%= scope.lookupvar("foreman_proxy::dhcp_key_secret") %>
+<% else %>
+#:key_name: secret_key_name
+#:key_secret: secret_key
+<% end %>
+
+:omapi_port: <%= scope.lookupvar("foreman_proxy::dhcp_omapi_port") %>
+
+# use :server setting in dhcp.yml if you are managing a dhcp server which is not localhost


### PR DESCRIPTION
Two parts - first is to split up the config files in the same way as DNS works, secondly to rename the dhcp_vendor parameter to dhcp_provider for consistency with other modules and the new config files.