### PR TITLE
Fixes #13024 - Should create dirs for ZTP and POAP files

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -178,7 +178,7 @@ class foreman_proxy::params {
   $tftp_listen_on   = 'https'
   $tftp_manage_wget = true
   $tftp_root        = $tftp::params::root
-  $tftp_dirs        = ["${tftp_root}/pxelinux.cfg","${tftp_root}/boot"]
+  $tftp_dirs        = ["${tftp_root}/pxelinux.cfg","${tftp_root}/boot","${tftp_root}/ztp.cfg","${tftp_root}/poap.cfg"]
   $tftp_servername  = undef
 
   # TODO: remove these on the next major version bump


### PR DESCRIPTION
This patch ensures that the directories used for storing ZTP and POAP config files are created when the TFTP proxy is installed.