### PR TITLE
Update log_file/level docs, add log_buffer_* parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,9 +39,9 @@
 #
 # $user::                       User under which foreman proxy will run
 #
-# $log::                        Foreman proxy log file
+# $log::                        Foreman proxy log file, 'STDOUT' or 'SYSLOG'
 #
-# $log_level::                  Foreman proxy log level, e.g. INFO, DEBUG, FATAL etc.
+# $log_level::                  Foreman proxy log level: WARN, DEBUG, ERROR, FATAL, INFO, UNKNOWN
 #
 # $ssl_ca::                     SSL CA to validate the client certificates used to access the proxy
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,12 @@
 #
 # $log_level::                  Foreman proxy log level: WARN, DEBUG, ERROR, FATAL, INFO, UNKNOWN
 #
+# $log_buffer::                 Log buffer size
+#                               type:integer
+#
+# $log_buffer_errors::          Additional log buffer size for errors
+#                               type:integer
+#
 # $ssl_ca::                     SSL CA to validate the client certificates used to access the proxy
 #
 # $ssl_cert::                   SSL certificate to be used to run the foreman proxy via https.
@@ -283,6 +289,8 @@ class foreman_proxy (
   $user                       = $foreman_proxy::params::user,
   $log                        = $foreman_proxy::params::log,
   $log_level                  = $foreman_proxy::params::log_level,
+  $log_buffer                 = $foreman_proxy::params::log_buffer,
+  $log_buffer_errors          = $foreman_proxy::params::log_buffer_errors,
   $http                       = $foreman_proxy::params::http,
   $ssl                        = $foreman_proxy::params::ssl,
   $ssl_ca                     = $foreman_proxy::params::ssl_ca,
@@ -403,6 +411,10 @@ class foreman_proxy (
   validate_array($trusted_hosts)
   validate_re($log_level, '^(UNKNOWN|FATAL|ERROR|WARN|INFO|DEBUG)$')
   validate_re($plugin_version, '^(installed|present|latest|absent)$')
+  # lint:ignore:undef_in_function
+  validate_integer($log_buffer, undef, 0)
+  validate_integer($log_buffer_errors, undef, 0)
+  # lint:endignore
 
   # Validate puppet params
   validate_bool($puppetssh_wait)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -104,15 +104,17 @@ class foreman_proxy::params {
   $version        = 'present'
   $plugin_version = 'installed'
 
-  # variables
+  # Enable listening on http
   $bind_host = '*'
   $port      = undef # deprecated in favor of $ssl_port/$http_port
-  $log       = '/var/log/foreman-proxy/proxy.log'
-  $log_level = 'ERROR'
-
-  # Enable listening on http
   $http      = false
   $http_port = '8000'
+
+  # Logging settings
+  $log               = '/var/log/foreman-proxy/proxy.log'
+  $log_level         = 'ERROR'
+  $log_buffer        = 2000
+  $log_buffer_errors = 1000
 
   # Enable SSL, ensure proxy is added with "https://" protocol if true
   $ssl      = true

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -102,6 +102,8 @@ describe 'foreman_proxy::config' do
             ':virsh_network: default',
             ':log_file: /var/log/foreman-proxy/proxy.log',
             ':log_level: ERROR',
+            ':log_buffer: 2000',
+            ':log_buffer_errors: 1000',
           ])
         end
 

--- a/templates/settings.yml.erb
+++ b/templates/settings.yml.erb
@@ -81,9 +81,9 @@
 # shared options for virsh DNS/DHCP provider
 :virsh_network: <%= scope.lookupvar("foreman_proxy::virsh_network") %>
 
-# Where our proxy log files are stored
-# filename or STDOUT
+# Log configuration
+# Uncomment and modify if you want to change the location of the log file or use STDOUT or SYSLOG values
 :log_file: <%= scope.lookupvar("foreman_proxy::log") %>
-# valid options are
-# WARN, DEBUG, Error, Fatal, INFO, UNKNOWN
+# Uncomment and modify if you want to change the log level
+# WARN, DEBUG, ERROR, FATAL, INFO, UNKNOWN
 :log_level: <%= scope.lookupvar("foreman_proxy::log_level") %>

--- a/templates/settings.yml.erb
+++ b/templates/settings.yml.erb
@@ -87,3 +87,8 @@
 # Uncomment and modify if you want to change the log level
 # WARN, DEBUG, ERROR, FATAL, INFO, UNKNOWN
 :log_level: <%= scope.lookupvar("foreman_proxy::log_level") %>
+
+# Log buffer size and extra buffer size (for errors). Defaults to 3000 messages in total,
+# which is about 500 kB request.
+:log_buffer: <%= scope.lookupvar("foreman_proxy::log_buffer") %>
+:log_buffer_errors: <%= scope.lookupvar("foreman_proxy::log_buffer_errors") %>


### PR DESCRIPTION
I fixed the smart proxy default settings file over in https://github.com/theforeman/smart-proxy/pull/368 and included the same in the template here, so you may wish to wait until that's reviewed before merging this.