### PR TITLE
Module Smart Proxy Logs

### DIFF
--- a/manifests/plugin/logs.pp
+++ b/manifests/plugin/logs.pp
@@ -1,0 +1,28 @@
+# = Foreman Proxy Abrt plugin
+#
+# This class configures Logs buffer module.
+#
+# === Parameters:
+#
+# $enabled::                    Enables/disables the plugin
+#                               type:boolean
+#
+# $listen_on::                  Proxy feature listens on http, https, or both
+#
+class foreman_proxy::plugin::logs (
+  $enabled                 = $::foreman_proxy::plugin::logs::params::enabled,
+  $listen_on               = $::foreman_proxy::plugin::logs::params::listen_on,
+) inherits foreman_proxy::plugin::logs::params {
+
+  validate_bool($enabled)
+  validate_listen_on($listen_on)
+
+  foreman_proxy::plugin { 'logs':
+  } ->
+  foreman_proxy::settings_file { 'logs':
+    template_path => 'foreman_proxy/plugin/logs.yml.erb',
+    group         => $group,
+    listen_on     => $listen_on,
+    enabled       => $enabled,
+  }
+}

--- a/manifests/plugin/logs/params.pp
+++ b/manifests/plugin/logs/params.pp
@@ -1,0 +1,5 @@
+# Default parameters for the Logs smart proxy plugin
+class foreman_proxy::plugin::logs::params {
+  $enabled                 = true
+  $listen_on               = 'https'
+}

--- a/spec/classes/foreman_proxy__plugin__logs_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__logs_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'foreman_proxy::plugin::logs' do
+
+  describe 'with default settings' do
+    let :pre_condition do
+      "include foreman_proxy"
+    end
+
+    it { should contain_foreman_proxy__plugin('logs') }
+    it 'should configure logs.yml' do
+      should contain_file('/etc/foreman-proxy/settings.d/logs.yml').
+        with({
+          :ensure  => 'file',
+          :owner   => 'root',
+          :group   => 'foreman-proxy',
+          :mode    => '0640',
+          :content => /:enabled: https/
+        })
+    end
+  end
+end

--- a/templates/logs.yml.erb
+++ b/templates/logs.yml.erb
@@ -1,0 +1,4 @@
+---
+:enabled: <%= @module_enabled %>
+
+# To configure log buffer capacity, go to settings.yml


### PR DESCRIPTION
Smart Proxy received a log buffer (core feature) and Logs API (core module)
which allows to download latest N log entries via REST API. We present this in
the new set of Smart Proxy status screens.

This patch aims to add configuration of the Logs API module. The module itself
has zero configuration and the only purpose is to provide simple REST API to
download the entries in JSON format.

Currently both buffer and the API are in core, but there is a pending PR to
refactor it into a module: https://github.com/theforeman/smart-proxy/pull/367

I will follow up with a Puppet changes to allow configuration of the capacity:

https://github.com/theforeman/smart-proxy/blob/develop/config/settings.yml.example#L60-L63

I was not able to run the spec tests locally, all failed with some "override"
error.