### PR TITLE
Adds OpenSCAP 0.5.3 params

### DIFF
--- a/manifests/plugin/openscap.pp
+++ b/manifests/plugin/openscap.pp
@@ -16,17 +16,33 @@
 #
 # $spooldir::                   Directory where OpenSCAP audits are stored
 #                               before they are forwarded to Foreman
+#
+# $contentdir::                 Directory where OpenSCAP content XML are stored
+#                               So we will not request the XML from Foreman each time
+#
+# $reportsdir::                 Directory where OpenSCAP report XML are stored
+#                               So Foreman can request arf xml reports
+#
+# $failed_dir::                 Directory where OpenSCAP report XML are stored
+#                               In case sending to Foreman succeeded, yet failed to save to reportsdir
+#
 class foreman_proxy::plugin::openscap (
   $enabled                = $::foreman_proxy::plugin::openscap::params::enabled,
   $version                = $::foreman_proxy::plugin::openscap::params::version,
   $listen_on              = $::foreman_proxy::plugin::openscap::params::listen_on,
   $openscap_send_log_file = $::foreman_proxy::plugin::openscap::params::openscap_send_log_file,
   $spooldir               = $::foreman_proxy::plugin::openscap::params::spooldir,
+  $contentdir             = $::foreman_proxy::plugin::openscap::params::contentdir,
+  $reportsdir             = $::foreman_proxy::plugin::openscap::params::reportsdir,
+  $failed_dir             = $::foreman_proxy::plugin::openscap::params::failed_dir,
 ) inherits foreman_proxy::plugin::openscap::params {
   validate_bool($enabled)
   validate_listen_on($listen_on)
   validate_absolute_path($spooldir)
   validate_absolute_path($openscap_send_log_file)
+  validate_absolute_path($contentdir)
+  validate_absolute_path($reportsdir)
+  validate_absolute_path($failed_dir)
 
   foreman_proxy::plugin { 'openscap':
     version => $version,

--- a/manifests/plugin/openscap/params.pp
+++ b/manifests/plugin/openscap/params.pp
@@ -6,4 +6,7 @@ class foreman_proxy::plugin::openscap::params {
   $listen_on               = 'https'
   $openscap_send_log_file  = '/var/log/foreman-proxy/openscap-send.log'
   $spooldir                = '/var/spool/foreman-proxy/openscap'
+  $contentdir              = '/var/lib/foreman-proxy/openscap/content'
+  $reportsdir              = '/var/lib/foreman-proxy/openscap/reports'
+  $failed_dir              = '/var/lib/foreman-proxy/openscap/failed'
 }

--- a/spec/classes/foreman_proxy__plugin__openscap_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__openscap_spec.rb
@@ -26,7 +26,11 @@ describe 'foreman_proxy::plugin::openscap' do
         '---',
         ':enabled: https',
         ':openscap_send_log_file: /var/log/foreman-proxy/openscap-send.log',
-        ":spooldir: /var/spool/foreman-proxy/openscap",
+        ':spooldir: /var/spool/foreman-proxy/openscap',
+        ':contentdir: /var/lib/foreman-proxy/openscap/content',
+        ':reportsdir: /var/lib/foreman-proxy/openscap/reports',
+        ':failed_dir: /var/lib/foreman-proxy/openscap/failed',
+
       ])
     end
   end
@@ -48,7 +52,10 @@ describe 'foreman_proxy::plugin::openscap' do
         '---',
         ':enabled: false',
         ':openscap_send_log_file: /var/log/foreman-proxy/openscap-send.log',
-        ":spooldir: /var/spool/foreman-proxy/openscap",
+        ':spooldir: /var/spool/foreman-proxy/openscap',
+        ':contentdir: /var/lib/foreman-proxy/openscap/content',
+        ':reportsdir: /var/lib/foreman-proxy/openscap/reports',
+        ':failed_dir: /var/lib/foreman-proxy/openscap/failed',
       ])
     end
   end

--- a/templates/plugin/openscap.yml.erb
+++ b/templates/plugin/openscap.yml.erb
@@ -5,5 +5,18 @@
 :openscap_send_log_file: <%= scope.lookupvar('::foreman_proxy::plugin::openscap::openscap_send_log_file') %>
 
 # Directory where OpenSCAP audits are stored
-# before they are forwarded to Foreman
+# if they failed to post to Foreman. smart_proxy_openscap_send will
+# try to re-send them.
 :spooldir: <%= scope.lookupvar('::foreman_proxy::plugin::openscap::spooldir') %>
+
+# Directory where OpenSCAP content XML are stored
+# So we will not request the XML from Foreman each time
+:contentdir: <%= scope.lookupvar('::foreman_proxy::plugin::openscap::contentdir') %>
+
+# Directory where OpenSCAP report XML are stored
+# So Foreman can request arf xml reports
+:reportsdir: <%= scope.lookupvar('::foreman_proxy::plugin::openscap::reportsdir') %>
+
+# Directory where OpenSCAP report XML are stored
+# In case sending to Foreman succeeded, yet failed to save to reportsdir
+:failed_dir: <%= scope.lookupvar('::foreman_proxy::plugin::openscap::failed_dir') %>


### PR DESCRIPTION
OpenSCAP introduces three new params: `contentdir`, `reportsdir` & `failed_dir`