### PR TITLE
Pass ssl_ca into foreman_smartproxy during registration

### DIFF
--- a/manifests/register.pp
+++ b/manifests/register.pp
@@ -8,6 +8,7 @@ class foreman_proxy::register {
       consumer_key    => $foreman_proxy::oauth_consumer_key,
       consumer_secret => $foreman_proxy::oauth_consumer_secret,
       effective_user  => $foreman_proxy::oauth_effective_user,
+      ssl_ca          => pick($foreman_proxy::foreman_ssl_ca, $foreman_proxy::ssl_ca),
       url             => $foreman_proxy::real_registered_proxy_url,
     }
   }

--- a/spec/classes/foreman_proxy__register__spec.rb
+++ b/spec/classes/foreman_proxy__register__spec.rb
@@ -21,6 +21,7 @@ describe 'foreman_proxy::register' do
             'url'             => "https://#{facts[:fqdn]}:8443",
             'consumer_key'    => /\w+/,
             'consumer_secret' => /\w+/,
+            'ssl_ca'          => /\A\/.+\.pem\z/,
           })
         end
       end
@@ -73,6 +74,40 @@ describe 'foreman_proxy::register' do
             'url'             => "https://#{facts[:fqdn]}:1234",
             'consumer_key'    => 'key',
             'consumer_secret' => 'secret',
+          })
+        end
+      end
+
+      describe 'with foreman_ssl_ca override' do
+        let :pre_condition do
+          "class {'foreman_proxy':
+            register_in_foreman => true,
+            foreman_ssl_ca      => '/etc/foreman/ssl/ca.pem',
+          }"
+        end
+
+        it 'should register the proxy' do
+          should contain_class('foreman_proxy::register')
+          should contain_foreman_smartproxy(facts[:fqdn]).with({
+            'ensure' => 'present',
+            'ssl_ca' => '/etc/foreman/ssl/ca.pem',
+          })
+        end
+      end
+
+      describe 'with ssl_ca override' do
+        let :pre_condition do
+          "class {'foreman_proxy':
+            register_in_foreman => true,
+            ssl_ca              => '/etc/foreman/ssl/ca.pem',
+          }"
+        end
+
+        it 'should register the proxy' do
+          should contain_class('foreman_proxy::register')
+          should contain_foreman_smartproxy(facts[:fqdn]).with({
+            'ensure' => 'present',
+            'ssl_ca' => '/etc/foreman/ssl/ca.pem',
           })
         end
       end


### PR DESCRIPTION
Depends on https://github.com/theforeman/puppet-foreman/pull/432 for the new type parameter.