### PR TITLE
Add check for params dhcp_subnets

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -171,6 +171,9 @@
 #
 # $dhcp_provider::              DHCP provider
 #
+# $dhcp_subnets::               Subnets list to restrict DHCP management to
+#                               type:array
+#
 # $dhcp_option_domain::         DHCP use the dhcpd config option domain-name
 #                               type:array
 #
@@ -338,6 +341,7 @@ class foreman_proxy (
   $dhcp_listen_on             = $foreman_proxy::params::dhcp_listen_on,
   $dhcp_managed               = $foreman_proxy::params::dhcp_managed,
   $dhcp_provider              = $foreman_proxy::params::dhcp_provider,
+  $dhcp_subnets               = $foreman_proxy::params::dhcp_subnets,
   $dhcp_option_domain         = $foreman_proxy::params::dhcp_option_domain,
   $dhcp_search_domains        = $foreman_proxy::params::dhcp_search_domains,
   $dhcp_interface             = $foreman_proxy::params::dhcp_interface,
@@ -420,6 +424,7 @@ class foreman_proxy (
   validate_array($dhcp_option_domain)
   validate_integer($dhcp_omapi_port)
   validate_string($dhcp_provider, $dhcp_server)
+  validate_array($dhcp_subnets)
 
   # Validate dns params
   validate_bool($dns)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -195,6 +195,7 @@ class foreman_proxy::params {
   $dhcp_listen_on          = 'https'
   $dhcp_managed            = true
   $dhcp_provider           = 'isc'
+  $dhcp_subnets            = []
   $dhcp_interface          = 'eth0'
   $dhcp_gateway            = '192.168.100.1'
   $dhcp_range              = false

--- a/templates/dhcp.yml.erb
+++ b/templates/dhcp.yml.erb
@@ -10,4 +10,13 @@
 :use_provider: dhcp_<%= scope.lookupvar("foreman_proxy::dhcp_provider") %>
 :server: <%= scope.lookupvar("foreman_proxy::dhcp_server") %>
 # subnets restricts the subnets queried to a subset, to reduce the query time.
-#:subnets: [192.168.205.0/255.255.255.128, 192.168.205.128/255.255.255.128]
+<% if subnets = scope.lookupvar("foreman_proxy::dhcp_subnets") and subnets.any? -%>
+:subnets:
+<% subnets.each do |c| -%>
+<%= "  - #{c}" %>
+<% end -%>
+<% else -%>
+#:subnets:
+#  - 192.168.205.0/255.255.255.128
+#  - 192.168.205.128/255.255.255.128
+<% end -%>


### PR DESCRIPTION
Add new variable in params dhcp_subnets
Use validate_re to do a basic check if the IP addresses/masks are numbers
Set dhcp_subnets accordingly via template dhcp.yml.erb
Fixes GH-109