### PR TITLE
Removed virsh network option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -225,8 +225,6 @@
 # $dns_forwarders::             DNS forwarders
 #                               type:array
 #
-# $virsh_network::              Network for virsh DNS/DHCP provider
-#
 # $bmc::                        Enable BMC feature
 #                               type:boolean
 #
@@ -362,7 +360,6 @@ class foreman_proxy (
   $dns_tsig_keytab            = $foreman_proxy::params::dns_tsig_keytab,
   $dns_tsig_principal         = $foreman_proxy::params::dns_tsig_principal,
   $dns_forwarders             = $foreman_proxy::params::dns_forwarders,
-  $virsh_network              = $foreman_proxy::params::virsh_network,
   $bmc                        = $foreman_proxy::params::bmc,
   $bmc_listen_on              = $foreman_proxy::params::bmc_listen_on,
   $bmc_default_provider       = $foreman_proxy::params::bmc_default_provider,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -227,9 +227,6 @@ class foreman_proxy::params {
 
   $dns_forwarders = []
 
-  # virsh options
-  $virsh_network = 'default'
-
   # BMC options
   $bmc                  = false
   $bmc_listen_on        = 'https'

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -98,7 +98,6 @@ describe 'foreman_proxy::config' do
             ':daemon: true',
             ':bind_host: \'*\'',
             ':https_port: 8443',
-            ':virsh_network: default',
             ':log_file: /var/log/foreman-proxy/proxy.log',
             ':log_level: ERROR',
             ':log_buffer: 2000',

--- a/templates/dhcp.yml.erb
+++ b/templates/dhcp.yml.erb
@@ -6,7 +6,7 @@
 # valid providers:
 #   - <%= "dhcp_" %>isc (ISC dhcp server)
 #   - <%= "dhcp_" %>native_ms (Microsoft native implementation)
-#   - <%= "dhcp_" %>virsh (simple implementation for libvirt)
+#   - <%= "dhcp_" %>libvirt (dnsmasq via libvirt API)
 :use_provider: dhcp_<%= scope.lookupvar("foreman_proxy::dhcp_provider") %>
 :server: <%= scope.lookupvar("foreman_proxy::dhcp_server") %>
 # subnets restricts the subnets queried to a subset, to reduce the query time.

--- a/templates/dns.yml.erb
+++ b/templates/dns.yml.erb
@@ -5,7 +5,7 @@
 #   <%= "dns_" %>dnscmd (Microsoft Windows native implementation)
 #   <%= "dns_" %>nsupdate
 #   <%= "dns_" %>nsupdate_gss (for GSS-TSIG support)
-#   <%= "dns_" %>virsh (simple implementation for libvirt)
+#   <%= "dns_" %>libvirt (dnsmasq via libvirt API)
 :use_provider: dns_<%= scope.lookupvar("foreman_proxy::dns_provider") %>
 # use this setting if you want to override default TTL setting (86400)
 :dns_ttl: <%= scope.lookupvar("foreman_proxy::dns_ttl") %>

--- a/templates/settings.yml.erb
+++ b/templates/settings.yml.erb
@@ -91,9 +91,6 @@
 <%= '#' unless ssl -%>:https_port: <%= scope.lookupvar("foreman_proxy::ssl_port") %>
 <%= '#' unless http -%>:http_port: <%= scope.lookupvar("foreman_proxy::http_port") %>
 
-# shared options for virsh DNS/DHCP provider
-:virsh_network: <%= scope.lookupvar("foreman_proxy::virsh_network") %>
-
 # Log configuration
 # Uncomment and modify if you want to change the location of the log file or use STDOUT or SYSLOG values
 :log_file: <%= scope.lookupvar("foreman_proxy::log") %>


### PR DESCRIPTION
It has been removed and replaced by libvirt.

https://github.com/theforeman/smart-proxy/commit/6798dc589b83eb601a135f914db5ec2308c492e1

I don't want to do puppet stuff for the new parameters, I will go ahead and
remove those from documentation as well.