### PR TITLE
Rename puppetrun/puppetrun_listen_on to puppet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
       is used in the proxy code itself for the path.
 * New or changed parameters on smart proxy plugin classes:
     * Add contentdir, reportsdir and failed_dir to openscap class
+* Compatibility warnings:
+    * Change puppetrun and puppetrun_listen_on parameters to puppet and
+      puppet_listen_on respectively
 
 ## 2.5.0
 * New or changed parameters:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -66,8 +66,8 @@ class foreman_proxy::config {
     }
   }
   foreman_proxy::settings_file { 'puppet':
-    enabled   => $::foreman_proxy::puppetrun,
-    listen_on => $::foreman_proxy::puppetrun_listen_on,
+    enabled   => $::foreman_proxy::puppet,
+    listen_on => $::foreman_proxy::puppet_listen_on,
   }
   foreman_proxy::settings_file { 'puppetca':
     enabled   => $::foreman_proxy::puppetca,
@@ -90,7 +90,7 @@ class foreman_proxy::config {
     listen_on => $::foreman_proxy::logs_listen_on,
   }
 
-  if $foreman_proxy::puppetca or $foreman_proxy::puppetrun {
+  if $foreman_proxy::puppetca or $foreman_proxy::puppet {
     if $foreman_proxy::use_sudoersd {
       if $foreman_proxy::manage_sudoersd {
         file { "${::foreman_proxy::sudoers}.d":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,10 +90,10 @@
 #
 # $puppet_group::               Groups of Foreman proxy user
 #
-# $puppetrun::                  Enable puppet run/kick feature
+# $puppet::                     Enable Puppet module for environment imports and Puppet runs
 #                               type:boolean
 #
-# $puppetrun_listen_on::        Puppet run proxy to listen on https, http, or both
+# $puppet_listen_on::           Puppet feature to listen on https, http, or both
 #
 # $puppetrun_provider::         Set puppet_provider to handle puppet run/kick via mcollective
 #
@@ -315,8 +315,8 @@ class foreman_proxy (
   $puppetdir                  = $foreman_proxy::params::puppetdir,
   $puppetca_cmd               = $foreman_proxy::params::puppetca_cmd,
   $puppet_group               = $foreman_proxy::params::puppet_group,
-  $puppetrun                  = $foreman_proxy::params::puppetrun,
-  $puppetrun_listen_on        = $foreman_proxy::params::puppetrun_listen_on,
+  $puppet                     = $foreman_proxy::params::puppet,
+  $puppet_listen_on           = $foreman_proxy::params::puppet_listen_on,
   $puppetrun_cmd              = $foreman_proxy::params::puppetrun_cmd,
   $puppetrun_provider         = $foreman_proxy::params::puppetrun_provider,
   $customrun_cmd              = $foreman_proxy::params::customrun_cmd,
@@ -412,7 +412,7 @@ class foreman_proxy (
   # lint:endignore
 
   # Validate puppet params
-  validate_bool($puppetssh_wait)
+  validate_bool($puppet, $puppetssh_wait)
   validate_string($ssldir, $puppetdir, $puppetca_cmd, $puppetrun_cmd)
   validate_string($puppet_url, $puppet_ssl_ca, $puppet_ssl_cert, $puppet_ssl_key)
   validate_string($salt_puppetrun_cmd)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -160,8 +160,8 @@ class foreman_proxy::params {
   $puppetdir          = $puppet::params::dir
 
   # puppetrun settings
-  $puppetrun           = true
-  $puppetrun_listen_on = 'https'
+  $puppet              = true
+  $puppet_listen_on    = 'https'
   $puppetrun_cmd       = $puppet::params::puppetrun_cmd
   $puppetrun_provider  = undef
   $customrun_cmd       = $shell

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -385,7 +385,7 @@ describe 'foreman_proxy::config' do
       context 'with pupppetrun_provider set to mcollective' do
         let :pre_condition do
           'class {"foreman_proxy":
-            puppetrun          => true,
+            puppet             => true,
             puppetrun_provider => "mcollective",
           }'
         end
@@ -656,10 +656,10 @@ describe 'foreman_proxy::config' do
         end
       end
 
-      context 'when puppetrun disabled' do
+      context 'when puppet disabled' do
         let :pre_condition do
           'class { "foreman_proxy":
-            puppetrun => false,
+            puppet => false,
           }'
         end
 
@@ -671,11 +671,11 @@ describe 'foreman_proxy::config' do
         end
       end
 
-      context 'when puppetca and puppetrun disabled' do
+      context 'when puppetca and puppet disabled' do
         let :pre_condition do
           'class { "foreman_proxy":
             puppetca  => false,
-            puppetrun => false,
+            puppet => false,
           }'
         end
 
@@ -744,11 +744,11 @@ describe 'foreman_proxy::config' do
           end
         end
 
-        context 'when puppetrun => false' do
+        context 'when puppet => false' do
           let :pre_condition do
             'class {"foreman_proxy":
               use_sudoersd => false,
-              puppetrun    => false,
+              puppet       => false,
             }'
           end
 

--- a/templates/sudo.erb
+++ b/templates/sudo.erb
@@ -1,7 +1,7 @@
 <% if scope.lookupvar("foreman_proxy::puppetca") -%>
 <%= scope.lookupvar("foreman_proxy::user") %> ALL = (root) NOPASSWD : <%= scope.lookupvar("foreman_proxy::puppetca_cmd") %> *
 <% end -%>
-<% if scope.lookupvar("foreman_proxy::puppetrun") -%>
+<% if scope.lookupvar("foreman_proxy::puppet") -%>
 <%= scope.lookupvar("foreman_proxy::user") %> ALL = (<%= scope.lookupvar("foreman_proxy::puppet_user") %>) NOPASSWD : <%= scope.lookupvar("foreman_proxy::puppetrun_cmd") %> *
 <% end -%>
 Defaults:<%= scope.lookupvar("foreman_proxy::user") %> !requiretty

--- a/templates/sudo_augeas.erb
+++ b/templates/sudo_augeas.erb
@@ -1,4 +1,4 @@
-<% if scope.lookupvar('foreman_proxy::puppetca') and scope.lookupvar('foreman_proxy::puppetrun') -%>
+<% if scope.lookupvar('foreman_proxy::puppetca') and scope.lookupvar('foreman_proxy::puppet') -%>
 set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/user <%= scope.lookupvar('foreman_proxy::user') %>
 set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/host ALL
 set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/command '<%= scope.lookupvar('foreman_proxy::puppetca_cmd') %> *'
@@ -17,7 +17,7 @@ set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/comm
 set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command/runas_user root
 set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command/tag NOPASSWD
 rm spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/command[position() > 1]
-<% elsif scope.lookupvar('foreman_proxy::puppetrun') -%>
+<% elsif scope.lookupvar('foreman_proxy::puppet') -%>
 set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/user <%= scope.lookupvar('foreman_proxy::user') %>
 set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/host ALL
 set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command '<%= scope.lookupvar('foreman_proxy::puppetrun_cmd') %> *'


### PR DESCRIPTION
The smart proxy module is simply called 'puppet' and is used for
environment importing as well as Puppet runs, so this should make the
relationship clearer.

---

As we're doing a major version we could just change it and remove the support for the deprecated parameters, would that be preferable?