### PR TITLE
Deploy split Puppet module configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
       is used in the proxy code itself for the path.
 * New or changed parameters on smart proxy plugin classes:
     * Add contentdir, reportsdir and failed_dir to openscap class
+* Compatibility warnings:
+    * Change puppetrun and puppetrun_listen_on parameters to puppet and
+      puppet_listen_on respectively
 
 ## 2.5.0
 * New or changed parameters:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ of this module.
 
 ### 1.11 compatibility notes
 
+* Puppet users must set `puppet_split_config_files => false` to keep a single
+  puppet.yml configuration file.
 * If using the virsh DHCP/DNS provider, `libvirt_backend => "virsh"` must be set.
 
 # Contributing

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -66,8 +66,8 @@ class foreman_proxy::config {
     }
   }
   foreman_proxy::settings_file { 'puppet':
-    enabled   => $::foreman_proxy::puppetrun,
-    listen_on => $::foreman_proxy::puppetrun_listen_on,
+    enabled   => $::foreman_proxy::puppet,
+    listen_on => $::foreman_proxy::puppet_listen_on,
   }
   foreman_proxy::settings_file { 'puppetca':
     enabled   => $::foreman_proxy::puppetca,
@@ -90,7 +90,7 @@ class foreman_proxy::config {
     listen_on => $::foreman_proxy::logs_listen_on,
   }
 
-  if $foreman_proxy::puppetca or $foreman_proxy::puppetrun {
+  if $foreman_proxy::puppetca or $foreman_proxy::puppet {
     if $foreman_proxy::use_sudoersd {
       if $foreman_proxy::manage_sudoersd {
         file { "${::foreman_proxy::sudoers}.d":

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -69,6 +69,19 @@ class foreman_proxy::config {
     enabled   => $::foreman_proxy::puppet,
     listen_on => $::foreman_proxy::puppet_listen_on,
   }
+  if $::foreman_proxy::puppet_split_config_files {
+    foreman_proxy::settings_file { [
+      'puppet_proxy_customrun',
+      'puppet_proxy_legacy',
+      'puppet_proxy_mcollective',
+      'puppet_proxy_puppet_api',
+      'puppet_proxy_puppetrun',
+      'puppet_proxy_salt',
+      'puppet_proxy_ssh',
+    ]:
+      module => false,
+    }
+  }
   foreman_proxy::settings_file { 'puppetca':
     enabled   => $::foreman_proxy::puppetca,
     listen_on => $::foreman_proxy::puppetca_listen_on,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,10 +90,10 @@
 #
 # $puppet_group::               Groups of Foreman proxy user
 #
-# $puppetrun::                  Enable puppet run/kick feature
+# $puppet::                     Enable Puppet module for environment imports and Puppet runs
 #                               type:boolean
 #
-# $puppetrun_listen_on::        Puppet run proxy to listen on https, http, or both
+# $puppet_listen_on::           Puppet feature to listen on https, http, or both
 #
 # $puppetrun_provider::         Set puppet_provider to handle puppet run/kick via mcollective
 #
@@ -315,8 +315,8 @@ class foreman_proxy (
   $puppetdir                  = $foreman_proxy::params::puppetdir,
   $puppetca_cmd               = $foreman_proxy::params::puppetca_cmd,
   $puppet_group               = $foreman_proxy::params::puppet_group,
-  $puppetrun                  = $foreman_proxy::params::puppetrun,
-  $puppetrun_listen_on        = $foreman_proxy::params::puppetrun_listen_on,
+  $puppet                     = $foreman_proxy::params::puppet,
+  $puppet_listen_on           = $foreman_proxy::params::puppet_listen_on,
   $puppetrun_cmd              = $foreman_proxy::params::puppetrun_cmd,
   $puppetrun_provider         = $foreman_proxy::params::puppetrun_provider,
   $customrun_cmd              = $foreman_proxy::params::customrun_cmd,
@@ -412,7 +412,7 @@ class foreman_proxy (
   # lint:endignore
 
   # Validate puppet params
-  validate_bool($puppetssh_wait)
+  validate_bool($puppet, $puppetssh_wait)
   validate_string($ssldir, $puppetdir, $puppetca_cmd, $puppetrun_cmd)
   validate_string($puppet_url, $puppet_ssl_ca, $puppet_ssl_cert, $puppet_ssl_key)
   validate_string($salt_puppetrun_cmd)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,6 +93,9 @@
 # $puppet::                     Enable Puppet module for environment imports and Puppet runs
 #                               type:boolean
 #
+# $puppet_split_config_files::  Split Puppet configuration files. This is needed since version 1.12.
+#                               type:boolean
+#
 # $puppet_listen_on::           Puppet feature to listen on https, http, or both
 #
 # $puppetrun_provider::         Set puppet_provider to handle puppet run/kick via mcollective
@@ -102,6 +105,8 @@
 # $customrun_cmd::              Puppet customrun command
 #
 # $customrun_args::             Puppet customrun command arguments
+#
+# $mcollective_user::           The user for puppetrun_provider mcollective
 #
 # $puppetssh_sudo::             Whether to use sudo before commands when using puppetrun_provider puppetssh
 #                               type:boolean
@@ -316,11 +321,13 @@ class foreman_proxy (
   $puppetca_cmd               = $foreman_proxy::params::puppetca_cmd,
   $puppet_group               = $foreman_proxy::params::puppet_group,
   $puppet                     = $foreman_proxy::params::puppet,
+  $puppet_split_config_files  = $foreman_proxy::params::puppet_split_config_files,
   $puppet_listen_on           = $foreman_proxy::params::puppet_listen_on,
   $puppetrun_cmd              = $foreman_proxy::params::puppetrun_cmd,
   $puppetrun_provider         = $foreman_proxy::params::puppetrun_provider,
   $customrun_cmd              = $foreman_proxy::params::customrun_cmd,
   $customrun_args             = $foreman_proxy::params::customrun_args,
+  $mcollective_user           = $foreman_proxy::params::mcollective_user,
   $puppetssh_sudo             = $foreman_proxy::params::puppetssh_sudo,
   $puppetssh_command          = $foreman_proxy::params::puppetssh_command,
   $puppetssh_user             = $foreman_proxy::params::puppetssh_user,
@@ -412,10 +419,10 @@ class foreman_proxy (
   # lint:endignore
 
   # Validate puppet params
-  validate_bool($puppet, $puppetssh_wait)
+  validate_bool($puppet, $puppet_split_config_files, $puppetssh_wait)
   validate_string($ssldir, $puppetdir, $puppetca_cmd, $puppetrun_cmd)
   validate_string($puppet_url, $puppet_ssl_ca, $puppet_ssl_cert, $puppet_ssl_key)
-  validate_string($salt_puppetrun_cmd)
+  validate_string($mcollective_user, $salt_puppetrun_cmd)
 
   # Validate template params
   validate_string($template_url)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -160,8 +160,8 @@ class foreman_proxy::params {
   $puppetdir          = $puppet::params::dir
 
   # puppetrun settings
-  $puppetrun           = true
-  $puppetrun_listen_on = 'https'
+  $puppet              = true
+  $puppet_listen_on    = 'https'
   $puppetrun_cmd       = $puppet::params::puppetrun_cmd
   $puppetrun_provider  = undef
   $customrun_cmd       = $shell

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -160,12 +160,15 @@ class foreman_proxy::params {
   $puppetdir          = $puppet::params::dir
 
   # puppetrun settings
-  $puppet              = true
-  $puppet_listen_on    = 'https'
+  $puppet = true
+  $puppet_split_config_files = true
+  $puppet_listen_on = 'https'
+
   $puppetrun_cmd       = $puppet::params::puppetrun_cmd
   $puppetrun_provider  = undef
   $customrun_cmd       = $shell
   $customrun_args      = '-ay -f -s'
+  $mcollective_user    = 'root'
   $puppetssh_sudo      = false
   $puppetssh_user      = 'root'
   $puppetssh_keyfile   = "${etc}/foreman-proxy/id_rsa"

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -385,7 +385,7 @@ describe 'foreman_proxy::config' do
       context 'with pupppetrun_provider set to mcollective' do
         let :pre_condition do
           'class {"foreman_proxy":
-            puppetrun          => true,
+            puppet             => true,
             puppetrun_provider => "mcollective",
           }'
         end
@@ -656,10 +656,10 @@ describe 'foreman_proxy::config' do
         end
       end
 
-      context 'when puppetrun disabled' do
+      context 'when puppet disabled' do
         let :pre_condition do
           'class { "foreman_proxy":
-            puppetrun => false,
+            puppet => false,
           }'
         end
 
@@ -671,11 +671,11 @@ describe 'foreman_proxy::config' do
         end
       end
 
-      context 'when puppetca and puppetrun disabled' do
+      context 'when puppetca and puppet disabled' do
         let :pre_condition do
           'class { "foreman_proxy":
             puppetca  => false,
-            puppetrun => false,
+            puppet => false,
           }'
         end
 
@@ -744,11 +744,11 @@ describe 'foreman_proxy::config' do
           end
         end
 
-        context 'when puppetrun => false' do
+        context 'when puppet => false' do
           let :pre_condition do
             'class {"foreman_proxy":
               use_sudoersd => false,
-              puppetrun    => false,
+              puppet       => false,
             }'
           end
 

--- a/templates/puppet.yml.erb
+++ b/templates/puppet.yml.erb
@@ -1,18 +1,23 @@
 ---
+<% split_files = scope.lookupvar("foreman_proxy::puppet_split_config_files") -%>
 # Puppet management
 :enabled: <%= @module_enabled %>
-:puppet_conf: <%= scope.lookupvar("foreman_proxy::puppetdir") %>/puppet.conf
 # valid providers:
-#   puppetrun   (for puppetrun/kick, deprecated in Puppet 3)
-#   mcollective (uses mco puppet)
-#   puppetssh   (run puppet over ssh)
-#   salt        (uses salt puppet.run)
-#   customrun   (calls a custom command with args)
+#   <%= "puppet_proxy_" if split_files %>puppetrun   (for puppetrun/kick, deprecated in Puppet 3)
+#   <%= "puppet_proxy_" if split_files %>mcollective (uses mco puppet)
+#   <%= "puppet_proxy_" if split_files %>puppetssh   (run puppet over ssh)
+#   <%= "puppet_proxy_" if split_files %>salt        (uses salt puppet.run)
+#   <%= "puppet_proxy_" if split_files %>customrun   (calls a custom command with args)
 <% unless [nil, :undefined, :undef, ''].include?(scope.lookupvar("foreman_proxy::puppetrun_provider")) -%>
-:puppet_provider: <%= scope.lookupvar("foreman_proxy::puppetrun_provider") %>
+:<%= split_files ? 'use' : 'puppet' %>_provider: <%= "puppet_proxy_" if split_files %><%= scope.lookupvar("foreman_proxy::puppetrun_provider") %>
 <% else -%>
-#:puppet_provider: puppetrun
+#:<%= split_files ? 'use' : 'puppet' %>_provider: <%= "puppet_proxy_" if split_files %>puppetrun
 <% end -%>
+
+<% if split_files -%>
+:puppet_version: <%= @puppetversion %>
+<% else -%>
+:puppet_conf: <%= scope.lookupvar("foreman_proxy::puppetdir") %>/puppet.conf
 
 # customrun command details
 # Set :customrun_cmd to the full path of the script you want to run, instead of /bin/false
@@ -48,10 +53,17 @@
 <% end -%>
 
 # Which user to invoke sudo as to run puppet commands
-<% if scope.lookupvar("foreman_proxy::puppetrun_provider") =~ /(mcollective|puppetrun)/ -%>
+<% if scope.lookupvar("foreman_proxy::puppetrun_provider") == 'puppetrun' -%>
 :puppet_user: <%= scope.lookupvar("foreman_proxy::puppet_user") %>
 <% else -%>
 #:puppet_user: root
+<% end -%>
+
+# If you want to override the puppet_user above just for mco commands
+<% if scope.lookupvar("foreman_proxy::puppetrun_provider") == 'mcollective' -%>
+:mcollective_user: <%= scope.lookupvar("foreman_proxy::mcollective_user") %>
+<% else -%>
+#:mcollective_user: peadmin
 <% end -%>
 
 # URL of the puppet master itself for API requests
@@ -78,4 +90,5 @@
 :use_cache: <%= scope.lookupvar("foreman_proxy::puppet_use_cache") %>
 # default location of cache is relative to the installation dir
 :cache_location: '<%= scope.lookupvar("foreman_proxy::puppet_cache_location") %>'
+<% end -%>
 <% end -%>

--- a/templates/puppet_proxy_customrun.yml.erb
+++ b/templates/puppet_proxy_customrun.yml.erb
@@ -1,0 +1,7 @@
+---
+# Set :command to the full path of the script you want to run, instead of /bin/false
+:command: <%= scope.lookupvar("foreman_proxy::customrun_cmd") %>
+#
+# Set :command_arguments to any args you want to pass to your custom script. The hostname of the
+# system to run against will be appended after the custom commands.
+:command_arguments: <%= scope.lookupvar("foreman_proxy::customrun_args") %>

--- a/templates/puppet_proxy_legacy.yml.erb
+++ b/templates/puppet_proxy_legacy.yml.erb
@@ -1,0 +1,33 @@
+#
+# puppet_proxy_legacy module is used for puppet versions prior to 4.0
+#
+# puppet_proxy_legacy is configured automatcially based on
+# :puppet_version setting in smart-proxy's puppet.yml configuration file.
+#
+---
+:puppet_conf: <%= scope.lookupvar("foreman_proxy::puppetdir") %>/puppet.conf
+#
+# Override use of Puppet's API to list environments, by default it will use only if
+# environmentpath is given in puppet.conf, else will look for environments in puppet.conf
+# (Puppet versions prior to 4.0 only)
+<% if [nil, :undefined, :undef].include?(scope.lookupvar("foreman_proxy::puppet_use_environment_api")) %>
+#:use_environment_api: true
+<% else %>
+:use_environment_api: <%= scope.lookupvar("foreman_proxy::puppet_use_environment_api") %>
+<% end %>
+#
+# URL of the puppet master itself for API requests. Required if puppet_use_environment_api is set to true.
+:puppet_url: <%= scope.lookupvar("foreman_proxy::puppet_url") %>
+#
+# SSL certificates used to access the environment API. Required if puppet_use_environment_api is set to true.
+:puppet_ssl_ca: <%= scope.lookupvar("foreman_proxy::puppet_ssl_ca") %>
+:puppet_ssl_cert: <%= scope.lookupvar("foreman_proxy::puppet_ssl_cert") %>
+:puppet_ssl_key: <%= scope.lookupvar("foreman_proxy::puppet_ssl_key") %>
+#
+# Enable/disable puppet class cache
+# Cache options
+<% if [nil, :undefined, :undef].include?(scope.lookupvar("foreman_proxy::puppet_use_cache")) -%>
+#:use_cache: true
+<% else -%>
+:use_cache: <%= scope.lookupvar("foreman_proxy::puppet_use_cache") %>
+<% end -%>

--- a/templates/puppet_proxy_mcollective.yml.erb
+++ b/templates/puppet_proxy_mcollective.yml.erb
@@ -1,0 +1,12 @@
+---
+#
+# User for execution of mco commands
+#
+# sudo permission needs to be added to ensure
+# smart-proxy can execute 'sudo' command
+#
+# For Puppet Enterprise this means
+# Defaults:foreman-proxy !requiretty
+# foreman-proxy ALL=(peadmin) NOPASSWD: /opt/puppet/bin/mco *',
+#
+:user: <%= scope.lookupvar("foreman_proxy::mcollective_user") %>

--- a/templates/puppet_proxy_puppet_api.yml.erb
+++ b/templates/puppet_proxy_puppet_api.yml.erb
@@ -1,0 +1,14 @@
+#
+# puppet_proxy_pupppet_api module is used for puppet versions 4.0 and higher
+#
+# puppet_proxy_pupppet_api is configured automatcially based on
+# :puppet_version setting in smart-proxy's puppet.yml configuration file.
+#
+---
+# URL of the puppet master itself for API requests.
+:puppet_url: <%= scope.lookupvar("foreman_proxy::puppet_url") %>
+#
+# SSL certificates used to access the puppet API
+:puppet_ssl_ca: <%= scope.lookupvar("foreman_proxy::puppet_ssl_ca") %>
+:puppet_ssl_cert: <%= scope.lookupvar("foreman_proxy::puppet_ssl_cert") %>
+:puppet_ssl_key: <%= scope.lookupvar("foreman_proxy::puppet_ssl_key") %>

--- a/templates/puppet_proxy_puppetrun.yml.erb
+++ b/templates/puppet_proxy_puppetrun.yml.erb
@@ -1,0 +1,16 @@
+---
+#
+# User for execution of puppetrun commands
+#
+# sudo permission needs to be added to ensure
+# smart-proxy can execute 'sudo' command
+#
+# Defaults:foreman-proxy !requiretty
+# foreman-proxy ALL=(peadmin) NOPASSWD: /opt/puppet/bin/puppet *',
+#
+# or
+#
+# Defaults:foreman-proxy !requiretty
+# foreman-proxy ALL=(peadmin) NOPASSWD: /opt/puppet/bin/puppetrun *',
+#
+:user: <%= scope.lookupvar("foreman_proxy::puppet_user") %>

--- a/templates/puppet_proxy_salt.yml.erb
+++ b/templates/puppet_proxy_salt.yml.erb
@@ -1,0 +1,3 @@
+---
+# Set :command to 'puppet.run agent no-noop' to run in no-noop mode. Default command is puppet.run.
+:command: <%= scope.lookupvar("foreman_proxy::salt_puppetrun_cmd") %>

--- a/templates/puppet_proxy_ssh.yml.erb
+++ b/templates/puppet_proxy_ssh.yml.erb
@@ -1,0 +1,15 @@
+---
+# the command which will be sent to the host
+:command: <%= scope.lookupvar("foreman_proxy::puppetssh_command") %>
+#
+# whether to use sudo before the ssh command
+:use_sudo: <%= scope.lookupvar("foreman_proxy::puppetssh_sudo") %>
+#
+# wait for the command to finish (and capture exit code), or detach process and return 0
+# Note: enabling this option causes the Foreman web UI to be blocked when executing puppetrun,
+# with timeout from the Browser and/or Foreman's REST client after 60 seconds.
+:wait: <%= scope.lookupvar("foreman_proxy::puppetssh_wait") %>
+#
+# With which user should the proxy connect
+:user: <%= scope.lookupvar("foreman_proxy::puppetssh_user") %>
+:keyfile: <%= scope.lookupvar("foreman_proxy::puppetssh_keyfile") %>

--- a/templates/sudo.erb
+++ b/templates/sudo.erb
@@ -1,7 +1,7 @@
 <% if scope.lookupvar("foreman_proxy::puppetca") -%>
 <%= scope.lookupvar("foreman_proxy::user") %> ALL = (root) NOPASSWD : <%= scope.lookupvar("foreman_proxy::puppetca_cmd") %> *
 <% end -%>
-<% if scope.lookupvar("foreman_proxy::puppetrun") -%>
+<% if scope.lookupvar("foreman_proxy::puppet") -%>
 <%= scope.lookupvar("foreman_proxy::user") %> ALL = (<%= scope.lookupvar("foreman_proxy::puppet_user") %>) NOPASSWD : <%= scope.lookupvar("foreman_proxy::puppetrun_cmd") %> *
 <% end -%>
 Defaults:<%= scope.lookupvar("foreman_proxy::user") %> !requiretty

--- a/templates/sudo_augeas.erb
+++ b/templates/sudo_augeas.erb
@@ -1,4 +1,4 @@
-<% if scope.lookupvar('foreman_proxy::puppetca') and scope.lookupvar('foreman_proxy::puppetrun') -%>
+<% if scope.lookupvar('foreman_proxy::puppetca') and scope.lookupvar('foreman_proxy::puppet') -%>
 set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/user <%= scope.lookupvar('foreman_proxy::user') %>
 set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/host ALL
 set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/command '<%= scope.lookupvar('foreman_proxy::puppetca_cmd') %> *'
@@ -17,7 +17,7 @@ set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/comm
 set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command/runas_user root
 set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command/tag NOPASSWD
 rm spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/command[position() > 1]
-<% elsif scope.lookupvar('foreman_proxy::puppetrun') -%>
+<% elsif scope.lookupvar('foreman_proxy::puppet') -%>
 set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/user <%= scope.lookupvar('foreman_proxy::user') %>
 set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/host ALL
 set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command '<%= scope.lookupvar('foreman_proxy::puppetrun_cmd') %> *'


### PR DESCRIPTION
1.12 splits the Puppet module up into many config files per puppetrun
provider and per environment import provider. 1.11 users must set the
`puppet_split_config_files` parameter to false to keep the single
puppet.yml.

A `mcollective_user` parameter has been added to expose the setting that
was introduced in 1.9.0 and is now in puppet_proxy_mcollective.yml.

Contains the commit from #249 as it conflicted and was helpful in keeping order.