### PR TITLE
Remove puppet_cache_location parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     * Add ssl_disabled_ciphers parameter for usage with 1.12 or later
     * Remove autosign_location parameter, note that `#{puppetdir}/autosign.conf`
       is used in the proxy code itself for the path.
+    * Remove puppet_cache_location parameter, no longer used by the smart proxy
 * New or changed parameters on smart proxy plugin classes:
     * Add contentdir, reportsdir and failed_dir to openscap class
 * Compatibility warnings:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -125,13 +125,4 @@ class foreman_proxy::config {
       }
     }
   }
-
-  if $foreman_proxy::puppet_use_cache {
-    file { $foreman_proxy::puppet_cache_location:
-      ensure => directory,
-      owner  => $foreman_proxy::user,
-      group  => 0,
-      mode   => '0750',
-    }
-  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -284,8 +284,6 @@
 # $puppet_use_cache::           Whether to enable caching of puppet classes
 #                               type:boolean
 #
-# $puppet_cache_location::      Location to store cached puppet classes
-#
 class foreman_proxy (
   $repo                       = $foreman_proxy::params::repo,
   $gpgcheck                   = $foreman_proxy::params::gpgcheck,
@@ -403,7 +401,6 @@ class foreman_proxy (
   $oauth_consumer_key         = $foreman_proxy::params::oauth_consumer_key,
   $oauth_consumer_secret      = $foreman_proxy::params::oauth_consumer_secret,
   $puppet_use_cache           = $foreman_proxy::params::puppet_use_cache,
-  $puppet_cache_location      = $foreman_proxy::params::puppet_cache_location,
 ) inherits foreman_proxy::params {
 
   # Validate misc params
@@ -423,6 +420,9 @@ class foreman_proxy (
   validate_string($ssldir, $puppetdir, $puppetca_cmd, $puppetrun_cmd)
   validate_string($puppet_url, $puppet_ssl_ca, $puppet_ssl_cert, $puppet_ssl_key)
   validate_string($mcollective_user, $salt_puppetrun_cmd)
+  if $puppet_use_cache != undef {
+    validate_bool($puppet_use_cache)
+  }
 
   # Validate template params
   validate_string($template_url)
@@ -460,12 +460,6 @@ class foreman_proxy (
   validate_bool($freeipa_remove_dns)
   validate_string($realm_provider, $realm_principal)
   validate_absolute_path($realm_keytab)
-
-  # puppet cache params
-  if $puppet_use_cache {
-    validate_bool($puppet_use_cache)
-  }
-  validate_absolute_path($puppet_cache_location)
 
   $real_registered_proxy_url = pick($registered_proxy_url, "https://${::fqdn}:${ssl_port}")
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -150,7 +150,6 @@ class foreman_proxy::params {
   $puppet_url                 = "https://${::fqdn}:8140"
   $puppet_use_environment_api = undef
   $puppet_use_cache           = undef
-  $puppet_cache_location      = '/var/cache/foreman-proxy'
 
   # puppetca settings
   $puppetca           = true

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -629,10 +629,6 @@ describe 'foreman_proxy::config' do
           }'
         end
 
-        it 'should create the cache_location' do
-          should contain_file('/var/cache/foreman-proxy').with_ensure('directory')
-        end
-
         it 'should set use_cache' do
           verify_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/puppet_proxy_legacy.yml", [
             ':use_cache: true',
@@ -1095,14 +1091,9 @@ describe 'foreman_proxy::config' do
             }'
           end
 
-          it 'should create the cache_location' do
-            should contain_file('/var/cache/foreman-proxy').with_ensure('directory')
-          end
-
-          it 'should set use_cache and cache_location' do
+          it 'should set use_cache' do
             verify_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/puppet.yml", [
               ':use_cache: true',
-              ":cache_location: '/var/cache/foreman-proxy'",
             ])
           end
         end

--- a/templates/puppet.yml.erb
+++ b/templates/puppet.yml.erb
@@ -84,11 +84,7 @@
 # Cache options
 <% if [nil, :undefined, :undef].include?(scope.lookupvar("foreman_proxy::puppet_use_cache")) -%>
 #:use_cache: true
-# default location of cache is relative to the installation dir
-#:cache_location: '/var/lib/smart-proxy/cache'
 <% else -%>
 :use_cache: <%= scope.lookupvar("foreman_proxy::puppet_use_cache") %>
-# default location of cache is relative to the installation dir
-:cache_location: '<%= scope.lookupvar("foreman_proxy::puppet_cache_location") %>'
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Unused by the smart proxy since 1.9.0.

Closes GH-250