### PR TITLE
Rename 'puppetssh' Puppet run provider to 'ssh'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,7 +98,7 @@
 #
 # $puppet_listen_on::           Puppet feature to listen on https, http, or both
 #
-# $puppetrun_provider::         Set puppet_provider to handle puppet run/kick via mcollective
+# $puppetrun_provider::         Provider for running/kicking Puppet agents
 #
 # $puppetrun_cmd::              Puppet run/kick command to be allowed in sudoers
 #
@@ -422,6 +422,15 @@ class foreman_proxy (
   validate_string($mcollective_user, $salt_puppetrun_cmd)
   if $puppet_use_cache != undef {
     validate_bool($puppet_use_cache)
+  }
+  if $puppetrun_provider {
+    validate_string($puppetrun_provider)
+    if $puppetrun_provider == 'puppetssh' and $puppet_split_config_files {
+      $real_puppetrun_provider = 'ssh'
+      warning('foreman_proxy::puppetrun_provider should be "ssh", not "puppetssh" for 1.12 and above')
+    } else {
+      $real_puppetrun_provider = $puppetrun_provider
+    }
   }
 
   # Validate template params

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -570,19 +570,39 @@ describe 'foreman_proxy::config' do
         end
       end
 
-      context 'when puppetrun_provider => puppetssh and user/key overridden' do
+      context 'when puppetrun_provider => ssh and user/key overridden' do
         let :pre_condition do
           'class {"foreman_proxy":
-            puppetrun_provider => "puppetssh",
+            puppetrun_provider => "ssh",
             puppetssh_user => "example",
             puppetssh_keyfile => "/home/example/.ssh/id_rsa",
           }'
+        end
+
+        it 'should set provider to puppet_proxy_ssh' do
+          verify_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/puppet.yml", [
+            ':use_provider: puppet_proxy_ssh',
+          ])
         end
 
         it 'should set puppetssh_user and puppetssh_keyfile' do
           verify_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/puppet_proxy_ssh.yml", [
             ':user: example',
             ':keyfile: /home/example/.ssh/id_rsa',
+          ])
+        end
+      end
+
+      context 'when puppetrun_provider => puppetssh' do
+        let :pre_condition do
+          'class {"foreman_proxy":
+            puppetrun_provider => "puppetssh",
+          }'
+        end
+
+        it 'should set provider to puppet_proxy_ssh' do
+          verify_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/puppet.yml", [
+            ':use_provider: puppet_proxy_ssh',
           ])
         end
       end
@@ -1042,6 +1062,12 @@ describe 'foreman_proxy::config' do
               puppet_split_config_files => false,
               puppetrun_provider => "puppetssh",
             }'
+          end
+
+          it 'should set provider to puppetssh' do
+            verify_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/puppet.yml", [
+              ':puppet_provider: puppetssh',
+            ])
           end
 
           it 'should set puppetssh_user and puppetssh_keyfile' do

--- a/templates/puppet.yml.erb
+++ b/templates/puppet.yml.erb
@@ -5,11 +5,15 @@
 # valid providers:
 #   <%= "puppet_proxy_" if split_files %>puppetrun   (for puppetrun/kick, deprecated in Puppet 3)
 #   <%= "puppet_proxy_" if split_files %>mcollective (uses mco puppet)
-#   <%= "puppet_proxy_" if split_files %>puppetssh   (run puppet over ssh)
+<% if split_files -%>
+#   puppet_proxy_ssh         (run puppet over ssh)
+<% else -%>
+#   puppetssh   (run puppet over ssh)
+<% end -%>
 #   <%= "puppet_proxy_" if split_files %>salt        (uses salt puppet.run)
 #   <%= "puppet_proxy_" if split_files %>customrun   (calls a custom command with args)
-<% unless [nil, :undefined, :undef, ''].include?(scope.lookupvar("foreman_proxy::puppetrun_provider")) -%>
-:<%= split_files ? 'use' : 'puppet' %>_provider: <%= "puppet_proxy_" if split_files %><%= scope.lookupvar("foreman_proxy::puppetrun_provider") %>
+<% unless [nil, :undefined, :undef, ''].include?(scope.lookupvar("foreman_proxy::real_puppetrun_provider")) -%>
+:<%= split_files ? 'use' : 'puppet' %>_provider: <%= "puppet_proxy_" if split_files %><%= scope.lookupvar("foreman_proxy::real_puppetrun_provider") %>
 <% else -%>
 #:<%= split_files ? 'use' : 'puppet' %>_provider: <%= "puppet_proxy_" if split_files %>puppetrun
 <% end -%>


### PR DESCRIPTION
When using Puppet split config files, the provider name should be
'puppet_proxy_ssh' so when puppetrun_provider is given as 'puppetssh',
it's changed to 'ssh' to help migrations.

Fixes GH-254