### PR TITLE
remove formerly deprecated parameters and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,11 @@ required.
 
 ## Compatibility
 
-This module only supports Smart Proxy 1.11 or higher as of version 3.0, as the
+This module only supports Smart Proxy 1.12 or higher as of version 4.0, as the
 configuration layout changed significantly.
 
-To configure older versions of the Smart Proxy (1.5 to 1.10), use version 2.x
-of this module.
-
-### 1.11 compatibility notes
-
-* Puppet users must set `puppet_split_config_files => false` to keep a single
-  puppet.yml configuration file.
-* If using the virsh DHCP/DNS provider, `libvirt_backend => "virsh"` must be set.
+To configure older versions of the Smart Proxy use version 2.x of this module
+for 1.5 to 1.10 and 3.x for 1.11.
 
 # Contributing
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -60,27 +60,23 @@ class foreman_proxy::config {
   foreman_proxy::settings_file { ['dns_nsupdate', 'dns_nsupdate_gss']:
     module => false,
   }
-  if $::foreman_proxy::libvirt_backend == 'libvirt' {
-    foreman_proxy::settings_file { ['dns_libvirt', 'dhcp_libvirt']:
-      module => false,
-    }
+  foreman_proxy::settings_file { ['dns_libvirt', 'dhcp_libvirt']:
+    module => false,
   }
   foreman_proxy::settings_file { 'puppet':
     enabled   => $::foreman_proxy::puppet,
     listen_on => $::foreman_proxy::puppet_listen_on,
   }
-  if $::foreman_proxy::puppet_split_config_files {
-    foreman_proxy::settings_file { [
-      'puppet_proxy_customrun',
-      'puppet_proxy_legacy',
-      'puppet_proxy_mcollective',
-      'puppet_proxy_puppet_api',
-      'puppet_proxy_puppetrun',
-      'puppet_proxy_salt',
-      'puppet_proxy_ssh',
-    ]:
-      module => false,
-    }
+  foreman_proxy::settings_file { [
+    'puppet_proxy_customrun',
+    'puppet_proxy_legacy',
+    'puppet_proxy_mcollective',
+    'puppet_proxy_puppet_api',
+    'puppet_proxy_puppetrun',
+    'puppet_proxy_salt',
+    'puppet_proxy_ssh',
+  ]:
+    module => false,
   }
   foreman_proxy::settings_file { 'puppetca':
     enabled   => $::foreman_proxy::puppetca,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,9 +93,6 @@
 # $puppet::                     Enable Puppet module for environment imports and Puppet runs
 #                               type:boolean
 #
-# $puppet_split_config_files::  Split Puppet configuration files. This is needed since version 1.12.
-#                               type:boolean
-#
 # $puppet_listen_on::           Puppet feature to listen on https, http, or both
 #
 # $puppetrun_provider::         Provider for running/kicking Puppet agents
@@ -237,8 +234,6 @@
 # $dns_forwarders::             DNS forwarders
 #                               type:array
 #
-# $libvirt_backend::            Backend of libvirt DNS/DHCP provider (virsh or libvirt)
-#
 # $libvirt_connection::         Connection string of libvirt DNS/DHCP provider (e.g. "qemu:///system")
 #
 # $libvirt_network::            Network for libvirt DNS/DHCP provider
@@ -319,7 +314,6 @@ class foreman_proxy (
   $puppetca_cmd               = $foreman_proxy::params::puppetca_cmd,
   $puppet_group               = $foreman_proxy::params::puppet_group,
   $puppet                     = $foreman_proxy::params::puppet,
-  $puppet_split_config_files  = $foreman_proxy::params::puppet_split_config_files,
   $puppet_listen_on           = $foreman_proxy::params::puppet_listen_on,
   $puppetrun_cmd              = $foreman_proxy::params::puppetrun_cmd,
   $puppetrun_provider         = $foreman_proxy::params::puppetrun_provider,
@@ -380,7 +374,6 @@ class foreman_proxy (
   $dns_tsig_keytab            = $foreman_proxy::params::dns_tsig_keytab,
   $dns_tsig_principal         = $foreman_proxy::params::dns_tsig_principal,
   $dns_forwarders             = $foreman_proxy::params::dns_forwarders,
-  $libvirt_backend            = $foreman_proxy::params::libvirt_backend,
   $libvirt_network            = $foreman_proxy::params::libvirt_network,
   $libvirt_connection         = $foreman_proxy::params::libvirt_connection,
   $bmc                        = $foreman_proxy::params::bmc,
@@ -416,7 +409,7 @@ class foreman_proxy (
   # lint:endignore
 
   # Validate puppet params
-  validate_bool($puppet, $puppet_split_config_files, $puppetssh_wait)
+  validate_bool($puppet, $puppetssh_wait)
   validate_string($ssldir, $puppetdir, $puppetca_cmd, $puppetrun_cmd)
   validate_string($puppet_url, $puppet_ssl_ca, $puppet_ssl_cert, $puppet_ssl_key)
   validate_string($mcollective_user, $salt_puppetrun_cmd)
@@ -425,12 +418,6 @@ class foreman_proxy (
   }
   if $puppetrun_provider {
     validate_string($puppetrun_provider)
-    if $puppetrun_provider == 'puppetssh' and $puppet_split_config_files {
-      $real_puppetrun_provider = 'ssh'
-      warning('foreman_proxy::puppetrun_provider should be "ssh", not "puppetssh" for 1.12 and above')
-    } else {
-      $real_puppetrun_provider = $puppetrun_provider
-    }
   }
 
   # Validate template params
@@ -459,7 +446,6 @@ class foreman_proxy (
   validate_array($dns_forwarders)
 
   # Validate libvirt params
-  validate_re($libvirt_backend, '^(libvirt|virsh)$')
   validate_string($libvirt_network, $libvirt_connection)
 
   # Validate bmc params

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,8 +50,13 @@ class foreman_proxy::params {
 
       $keyfile  = '/etc/bind/rndc.key'
       $nsupdate = 'dnsutils'
-      if  ($::operatingsystem == 'Debian') and (versioncmp($::operatingsystemrelease, '8.0') >= 0) or
-          ($::operatingsystem == 'Ubuntu') and (versioncmp($::operatingsystemrelease, '14.10') >= 0) {
+      if $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '14.04' {
+        $tftp_syslinux_filenames = ['/usr/lib/syslinux/chain.c32',
+                                    '/usr/lib/syslinux/mboot.c32',
+                                    '/usr/lib/syslinux/menu.c32',
+                                    '/usr/lib/syslinux/memdisk',
+                                    '/usr/lib/syslinux/pxelinux.0']
+      } else {
         $tftp_syslinux_filenames = ['/usr/lib/PXELINUX/pxelinux.0',
                                     '/usr/lib/syslinux/memdisk',
                                     '/usr/lib/syslinux/modules/bios/chain.c32',
@@ -60,12 +65,6 @@ class foreman_proxy::params {
                                     '/usr/lib/syslinux/modules/bios/libutil.c32',
                                     '/usr/lib/syslinux/modules/bios/mboot.c32',
                                     '/usr/lib/syslinux/modules/bios/menu.c32']
-      } else {
-        $tftp_syslinux_filenames = ['/usr/lib/syslinux/chain.c32',
-                                    '/usr/lib/syslinux/mboot.c32',
-                                    '/usr/lib/syslinux/menu.c32',
-                                    '/usr/lib/syslinux/memdisk',
-                                    '/usr/lib/syslinux/pxelinux.0']
       }
     }
     /^(FreeBSD|DragonFly)$/: {
@@ -160,7 +159,6 @@ class foreman_proxy::params {
 
   # puppetrun settings
   $puppet = true
-  $puppet_split_config_files = true
   $puppet_listen_on = 'https'
 
   $puppetrun_cmd       = $puppet::params::puppetrun_cmd
@@ -232,7 +230,6 @@ class foreman_proxy::params {
   $dns_forwarders = []
 
   # libvirt options
-  $libvirt_backend    = 'libvirt'
   $libvirt_connection = 'qemu:///system'
   $libvirt_network    = 'default'
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "theforeman-foreman_proxy",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "author": "theforeman",
   "summary": "Foreman Smart Proxy configuration",
   "license": "GPL-3.0+",
@@ -78,20 +78,18 @@
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "21"
+        "24"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "7",
         "8"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04",
         "14.04",
         "16.04"
       ]

--- a/templates/dhcp.yml.erb
+++ b/templates/dhcp.yml.erb
@@ -4,9 +4,9 @@
 :enabled: <%= @module_enabled %>
 
 # valid providers:
-#   - <%= "dhcp_" %>isc (ISC dhcp server)
-#   - <%= "dhcp_" %>native_ms (Microsoft native implementation)
-#   - <%= "dhcp_" %><%= scope.lookupvar("foreman_proxy::libvirt_backend") %> (dnsmasq via libvirt)
+#   - dhcp_isc (ISC dhcp server)
+#   - dhcp_native_ms (Microsoft native implementation)
+#   - dhcp_libvirt (dnsmasq via libvirt)
 :use_provider: dhcp_<%= scope.lookupvar("foreman_proxy::dhcp_provider") %>
 :server: <%= scope.lookupvar("foreman_proxy::dhcp_server") %>
 # subnets restricts the subnets queried to a subset, to reduce the query time.

--- a/templates/dns.yml.erb
+++ b/templates/dns.yml.erb
@@ -2,10 +2,10 @@
 # DNS management
 :enabled: <%= @module_enabled %>
 # valid providers:
-#   <%= "dns_" %>dnscmd (Microsoft Windows native implementation)
-#   <%= "dns_" %>nsupdate
-#   <%= "dns_" %>nsupdate_gss (for GSS-TSIG support)
-#   <%= "dns_" %><%= scope.lookupvar("foreman_proxy::libvirt_backend") %> (dnsmasq via libvirt)
+#   dns_dnscmd (Microsoft Windows native implementation)
+#   dns_nsupdate
+#   dns_nsupdate_gss (for GSS-TSIG support)
+#   dns_libvirt (dnsmasq via libvirt)
 :use_provider: dns_<%= scope.lookupvar("foreman_proxy::dns_provider") %>
 # use this setting if you want to override default TTL setting (86400)
 :dns_ttl: <%= scope.lookupvar("foreman_proxy::dns_ttl") %>

--- a/templates/puppet.yml.erb
+++ b/templates/puppet.yml.erb
@@ -1,94 +1,16 @@
 ---
-<% split_files = scope.lookupvar("foreman_proxy::puppet_split_config_files") -%>
 # Puppet management
 :enabled: <%= @module_enabled %>
 # valid providers:
-#   <%= "puppet_proxy_" if split_files %>puppetrun   (for puppetrun/kick, deprecated in Puppet 3)
-#   <%= "puppet_proxy_" if split_files %>mcollective (uses mco puppet)
-<% if split_files -%>
+#   puppet_proxy_puppetrun   (for puppetrun/kick, deprecated in Puppet 3)
+#   puppet_proxy_mcollective (uses mco puppet)
 #   puppet_proxy_ssh         (run puppet over ssh)
+#   puppet_proxy_salt        (uses salt puppet.run)
+#   puppet_proxy_customrun   (calls a custom command with args)
+<% unless [nil, :undefined, :undef, ''].include?(scope.lookupvar("foreman_proxy::puppetrun_provider")) -%>
+:use_provider: puppet_proxy_<%= scope.lookupvar("foreman_proxy::puppetrun_provider") %>
 <% else -%>
-#   puppetssh   (run puppet over ssh)
-<% end -%>
-#   <%= "puppet_proxy_" if split_files %>salt        (uses salt puppet.run)
-#   <%= "puppet_proxy_" if split_files %>customrun   (calls a custom command with args)
-<% unless [nil, :undefined, :undef, ''].include?(scope.lookupvar("foreman_proxy::real_puppetrun_provider")) -%>
-:<%= split_files ? 'use' : 'puppet' %>_provider: <%= "puppet_proxy_" if split_files %><%= scope.lookupvar("foreman_proxy::real_puppetrun_provider") %>
-<% else -%>
-#:<%= split_files ? 'use' : 'puppet' %>_provider: <%= "puppet_proxy_" if split_files %>puppetrun
+#:use_provider: puppet_proxy_puppetrun
 <% end -%>
 
-<% if split_files -%>
 :puppet_version: <%= @puppetversion %>
-<% else -%>
-:puppet_conf: <%= scope.lookupvar("foreman_proxy::puppetdir") %>/puppet.conf
-
-# customrun command details
-# Set :customrun_cmd to the full path of the script you want to run, instead of /bin/false
-:customrun_cmd: <%= scope.lookupvar("foreman_proxy::customrun_cmd") %>
-# Set :customrun_args to any args you want to pass to your custom script. The hostname of the
-# system to run against will be appended after the custom commands.
-:customrun_args: <%= scope.lookupvar("foreman_proxy::customrun_args") %>
-
-# whether to use sudo before the ssh command
-:puppetssh_sudo: <%= scope.lookupvar("foreman_proxy::puppetssh_sudo") %>
-# the command which will be sent to the host
-:puppetssh_command: <%= scope.lookupvar("foreman_proxy::puppetssh_command") %>
-# wait for the command to finish (and capture exit code), or detach process and return 0
-# Note: enabling this option causes the Foreman web UI to be blocked when executing puppetrun,
-# with timeout from the Browser and/or Foreman's REST client after 60 seconds.
-:puppetssh_wait: <%= scope.lookupvar("foreman_proxy::puppetssh_wait") %>
-# With which user should the proxy connect
-<% if scope.lookupvar("foreman_proxy::puppetrun_provider") == 'puppetssh' -%>
-:puppetssh_user: <%= scope.lookupvar("foreman_proxy::puppetssh_user") %>
-:puppetssh_keyfile: <%= scope.lookupvar("foreman_proxy::puppetssh_keyfile") %>
-<% else -%>
-#:puppetssh_user: root
-#:puppetssh_keyfile: /etc/foreman-proxy/id_rsa
-<% end -%>
-
-# Custom salt puppet.run command
-# Set :salt_puppetrun_cmd to 'puppet.run agent no-noop' to run in no-noop mode.
-# Default command is puppet.run
-<% if scope.lookupvar("foreman_proxy::puppetrun_provider") == 'salt' -%>
-:salt_puppetrun_cmd: <%= scope.lookupvar("foreman_proxy::salt_puppetrun_cmd") %>
-<% else -%>
-#:salt_puppetrun_cmd: puppet.run
-<% end -%>
-
-# Which user to invoke sudo as to run puppet commands
-<% if scope.lookupvar("foreman_proxy::puppetrun_provider") == 'puppetrun' -%>
-:puppet_user: <%= scope.lookupvar("foreman_proxy::puppet_user") %>
-<% else -%>
-#:puppet_user: root
-<% end -%>
-
-# If you want to override the puppet_user above just for mco commands
-<% if scope.lookupvar("foreman_proxy::puppetrun_provider") == 'mcollective' -%>
-:mcollective_user: <%= scope.lookupvar("foreman_proxy::mcollective_user") %>
-<% else -%>
-#:mcollective_user: peadmin
-<% end -%>
-
-# URL of the puppet master itself for API requests
-:puppet_url: <%= scope.lookupvar("foreman_proxy::puppet_url") %>
-# SSL certificates used to access the puppet master API
-:puppet_ssl_ca: <%= scope.lookupvar("foreman_proxy::puppet_ssl_ca") %>
-:puppet_ssl_cert: <%= scope.lookupvar("foreman_proxy::puppet_ssl_cert") %>
-:puppet_ssl_key: <%= scope.lookupvar("foreman_proxy::puppet_ssl_key") %>
-
-# Override use of Puppet's API to list environments, by default it will use only if
-# environmentpath is given in puppet.conf, else will look for environments in puppet.conf
-<% if [nil, :undefined, :undef].include?(scope.lookupvar("foreman_proxy::puppet_use_environment_api")) %>
-#:puppet_use_environment_api: true
-<% else %>
-:puppet_use_environment_api: <%= scope.lookupvar("foreman_proxy::puppet_use_environment_api") %>
-<% end %>
-
-# Cache options
-<% if [nil, :undefined, :undef].include?(scope.lookupvar("foreman_proxy::puppet_use_cache")) -%>
-#:use_cache: true
-<% else -%>
-:use_cache: <%= scope.lookupvar("foreman_proxy::puppet_use_cache") %>
-<% end -%>
-<% end -%>

--- a/templates/settings.yml.erb
+++ b/templates/settings.yml.erb
@@ -90,10 +90,6 @@
 # default values for https_port is 8443
 <%= '#' unless ssl -%>:https_port: <%= scope.lookupvar("foreman_proxy::ssl_port") %>
 <%= '#' unless http -%>:http_port: <%= scope.lookupvar("foreman_proxy::http_port") %>
-<%- if scope.lookupvar('foreman_proxy::libvirt_backend') == 'virsh' -%>
-# shared options for virsh DNS/DHCP provider
-:virsh_network: <%= scope.lookupvar('foreman_proxy::libvirt_network') %>
-<%- end -%>
 # Log configuration
 # Uncomment and modify if you want to change the location of the log file or use STDOUT or SYSLOG values
 :log_file: <%= scope.lookupvar("foreman_proxy::log") %>


### PR DESCRIPTION
- remove libvirt_backend parameter
- remove puppet_split_config_files parameter
- mark Fedora 24 supported instead of Fedora 21
- remove Debian 7 (wheezy) support
- remove Ubuntu 12.04 (precise) 

the changelog would also come in another PR here