### PR TITLE
Ensure the `puppet` group exists

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -120,5 +120,26 @@ class foreman_proxy::config {
         changes => template('foreman_proxy/sudo_augeas.erb'),
       }
     }
+  } else {
+    # The puppet-agent (puppet 4 AIO package) doesn't create a puppet user and group
+    # but the foreman proxy still needs to be able to read the agent's private key
+    if $foreman_proxy::manage_puppet_group and $foreman_proxy::ssl {
+      if !defined(Group[$foreman_proxy::puppet_group]) {
+        group { $foreman_proxy::puppet_group:
+          ensure => 'present',
+          before => User[$foreman_proxy::user],
+        }
+      }
+      $ssl_dirs_and_files = [
+        $foreman_proxy::ssldir,
+        "${foreman_proxy::ssldir}/private_keys",
+        $foreman_proxy::ssl_ca,
+        $foreman_proxy::ssl_key,
+        $foreman_proxy::ssl_cert,
+      ]
+      file { $ssl_dirs_and_files:
+        group => $foreman_proxy::puppet_group,
+      }
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,6 +90,10 @@
 #
 # $puppet_group::               Groups of Foreman proxy user
 #
+# $manage_puppet_group::        Whether to ensure the $puppet_group exists.  Also ensures group owner of ssl keys and certs is $puppet_group
+#                               Not applicable when ssl is false.
+#                               type:boolean
+#
 # $puppet::                     Enable Puppet module for environment imports and Puppet runs
 #                               type:boolean
 #
@@ -313,6 +317,7 @@ class foreman_proxy (
   $puppetdir                  = $foreman_proxy::params::puppetdir,
   $puppetca_cmd               = $foreman_proxy::params::puppetca_cmd,
   $puppet_group               = $foreman_proxy::params::puppet_group,
+  $manage_puppet_group        = $foreman_proxy::params::manage_puppet_group,
   $puppet                     = $foreman_proxy::params::puppet,
   $puppet_listen_on           = $foreman_proxy::params::puppet_listen_on,
   $puppetrun_cmd              = $foreman_proxy::params::puppetrun_cmd,
@@ -398,7 +403,7 @@ class foreman_proxy (
 
   # Validate misc params
   validate_string($bind_host)
-  validate_bool($ssl, $manage_sudoersd, $use_sudoersd, $register_in_foreman)
+  validate_bool($ssl, $manage_sudoersd, $use_sudoersd, $register_in_foreman, $manage_puppet_group)
   validate_array($trusted_hosts, $ssl_disabled_ciphers)
   validate_re($log_level, '^(UNKNOWN|FATAL|ERROR|WARN|INFO|DEBUG)$')
   validate_re($plugin_version, '^(installed|present|latest|absent)$')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -157,6 +157,9 @@ class foreman_proxy::params {
   $puppet_group       = 'puppet'
   $puppetdir          = $puppet::params::dir
 
+  # The puppet-agent package, (puppet 4 AIO) doesn't create a puppet group
+  $manage_puppet_group = versioncmp($::puppetversion, '4.0') > 0
+
   # puppetrun settings
   $puppet = true
   $puppet_listen_on = 'https'


### PR DESCRIPTION
In puppet 4 AIO packaging, it's the `puppetserver` package that creates
a `puppet` user and group.

The `puppet-agent` package doesn't create the group and unless
`puppetserver` is also installed the ssl keys and certs are owned by
`root:root` and are not readable by the foreman proxy. (It's the
installation of `puppetserver` that chowns the ssldir to
`puppet:puppet`)

With this commit, the module ensures that the `puppet_group` group
exists even on puppet 4.  It also makes sure the ssl_key/cert/ca files
are group owned by the `puppet_group`

The change is hopefully quite conservative.  Only if both `$puppet` and
`$puppetca` are false will it have any effect.  By default, it also
only applies to puppet 4 and can be turned off completely by setting
`manage_puppet_group` to `false`.

Users who already manage the creation of the puppet group, (for instance
to workaround https://tickets.puppetlabs.com/browse/SERVER-1381) are
further protected by the `if !defined`.