### PR TITLE
Fully qualified class requirements

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -33,7 +33,7 @@ class foreman_proxy::config {
     comment => 'Foreman Proxy account',
     groups  => $groups,
     home    => $foreman_proxy::dir,
-    require => Class['foreman_proxy::install'],
+    require => Class['::foreman_proxy::install'],
     notify  => Class['foreman_proxy::service'],
   }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,7 +5,7 @@ class foreman_proxy::service {
     ensure    => running,
     enable    => true,
     hasstatus => true,
-    require   => Class['foreman_proxy::config'],
+    require   => Class['::foreman_proxy::config'],
   }
 
 }

--- a/manifests/settings_file.pp
+++ b/manifests/settings_file.pp
@@ -60,7 +60,7 @@ define foreman_proxy::settings_file (
     owner   => $owner,
     group   => $group,
     mode    => $mode,
-    require => Class['foreman_proxy::install'],
+    require => Class['::foreman_proxy::install'],
     notify  => Class['foreman_proxy::service'],
   }
 }


### PR DESCRIPTION
Getting these on my other PR's tests:

```
manifests/config.pp:36:WARNING: class included by relative name
manifests/service.pp:8:WARNING: class included by relative name
manifests/settings_file.pp:63:WARNING: class included by relative name
```

This is because a new puppet-lint-absolute_classname-check was released today.
