### PR TITLE
fixes #15556 - move some params to advanced

### DIFF
--- a/manifests/plugin/abrt.pp
+++ b/manifests/plugin/abrt.pp
@@ -4,16 +4,6 @@
 #
 # === Parameters:
 #
-# $group::                      group owner of the configuration file
-#
-# $version::                    plugin package version, it's passed to ensure parameter of package resource
-#                               can be set to specific version number, 'latest', 'present' etc.
-#
-# $enabled::                    Enables/disables the plugin
-#                               type:boolean
-#
-# $listen_on::                  Proxy feature listens on http, https, or both
-#
 # $abrt_send_log_file::         Log file for the forwarding script.
 #
 # $spooldir::                   Directory where uReports are stored before they are sent
@@ -32,6 +22,18 @@
 # $faf_server_ssl_cert::        Enable client authentication to FAF server: set ssl certificate
 #
 # $faf_server_ssl_key::         Enable client authentication to FAF server: set ssl key
+#
+# === Advanced parameters:
+#
+# $enabled::                    Enables/disables the plugin
+#                               type:boolean
+#
+# $group::                      group owner of the configuration file
+#
+# $listen_on::                  Proxy feature listens on http, https, or both
+#
+# $version::                    plugin package version, it's passed to ensure parameter of package resource
+#                               can be set to specific version number, 'latest', 'present' etc.
 #
 class foreman_proxy::plugin::abrt (
   $enabled                 = $::foreman_proxy::plugin::abrt::params::enabled,

--- a/manifests/plugin/chef.pp
+++ b/manifests/plugin/chef.pp
@@ -4,15 +4,6 @@
 #
 # === Parameters:
 #
-# $group::        group owner of the configuration file
-#
-# $version::      plugin package version, it's passed to ensure parameter of package resource
-#                 can be set to specific version number, 'latest', 'present' etc.
-#
-# $enabled::      enables/disables the plugin
-#
-# $listen_on::    Proxy feature listens on http, https, or both
-#
 # $server_url::   chef server url
 #
 # $client_name::  chef client name used for authentication of other client requests
@@ -26,6 +17,17 @@
 # $ssl_pem_file:: if $ssl_verify is true you can specify a path to a file which
 #                 contains certificate and related private key if the certificate
 #                 is not globally trusted
+#
+# === Advanced parameters:
+#
+# $enabled::      enables/disables the plugin
+#
+# $group::        group owner of the configuration file
+#
+# $listen_on::    Proxy feature listens on http, https, or both
+#
+# $version::      plugin package version, it's passed to ensure parameter of package resource
+#                 can be set to specific version number, 'latest', 'present' etc.
 #
 class foreman_proxy::plugin::chef (
   $enabled      = $::foreman_proxy::plugin::chef::params::enabled,

--- a/manifests/plugin/dynflow.pp
+++ b/manifests/plugin/dynflow.pp
@@ -4,15 +4,17 @@
 #
 # === Parameters:
 #
-# $enabled::         Enables/disables the plugin
-#                    type:boolean
-#
-# $listen_on::       Proxy feature listens on https, http, or both
-#
 # $database_path::   Path to the SQLite database file
 #
 # $console_auth::    Whether to enable trusted hosts and ssl for the dynflow console
 #                    type:boolean
+#
+# === Advanced parameters:
+#
+# $enabled::         Enables/disables the plugin
+#                    type:boolean
+#
+# $listen_on::       Proxy feature listens on https, http, or both
 #
 class foreman_proxy::plugin::dynflow (
   $enabled           = $::foreman_proxy::plugin::dynflow::params::enabled,

--- a/manifests/plugin/openscap.pp
+++ b/manifests/plugin/openscap.pp
@@ -4,16 +4,8 @@
 #
 # === Parameters:
 #
-# $version::                    plugin package version, it's passed to ensure parameter of package resource
-#                               can be set to specific version number, 'latest', 'present' etc.
-#
 # $configure_openscap_repo::    Enable custom yum repo with packages needed for smart_proxy_openscap,
 #                               type:boolean
-#
-# $enabled::                    enables/disables the plugin
-#                               type:boolean
-#
-# $listen_on::                  Proxy feature listens on http, https, or both
 #
 # $openscap_send_log_file::     Log file for the forwarding script
 #
@@ -28,6 +20,15 @@
 #
 # $failed_dir::                 Directory where OpenSCAP report XML are stored
 #                               In case sending to Foreman succeeded, yet failed to save to reportsdir
+# === Advanced parameters:
+#
+# $enabled::                    enables/disables the plugin
+#                               type:boolean
+#
+# $listen_on::                  Proxy feature listens on http, https, or both
+#
+# $version::                    plugin package version, it's passed to ensure parameter of package resource
+#                               can be set to specific version number, 'latest', 'present' etc.
 #
 class foreman_proxy::plugin::openscap (
   $configure_openscap_repo = $::foreman_proxy::plugin::openscap::params::configure_openscap_repo,

--- a/manifests/plugin/pulp.pp
+++ b/manifests/plugin/pulp.pp
@@ -4,16 +4,6 @@
 #
 # === Parameters:
 #
-# $group::            group owner of the configuration file
-#
-# $version::          plugin package version, it's passed to ensure parameter of package resource
-#                     can be set to specific version number, 'latest', 'present' etc.
-#
-# $enabled::          enables/disables the pulp plugin
-#                     type:boolean
-#
-# $listen_on::        Proxy feature listens on http, https, or both
-#
 # $pulpnode_enabled:: enables/disables the pulpnode plugin
 #                     type:boolean
 #
@@ -24,6 +14,18 @@
 # $pulp_content_dir:: directory for pulp content
 #
 # $mongodb_dir::      directory for Mongo DB
+#
+# === Advanced parameters:
+#
+# $enabled::          enables/disables the pulp plugin
+#                     type:boolean
+#
+# $group::            group owner of the configuration file
+#
+# $listen_on::        Proxy feature listens on http, https, or both
+#
+# $version::          plugin package version, it's passed to ensure parameter of package resource
+#                     can be set to specific version number, 'latest', 'present' etc.
 #
 class foreman_proxy::plugin::pulp (
   $enabled          = $::foreman_proxy::plugin::pulp::params::enabled,

--- a/manifests/plugin/remote_execution/ssh.pp
+++ b/manifests/plugin/remote_execution/ssh.pp
@@ -4,11 +4,6 @@
 #
 # === Parameters:
 #
-# $enabled::            Enables/disables the plugin
-#                       type:boolean
-#
-# $listen_on::          Proxy feature listens on https, http, or both
-#
 # $generate_keys::      Automatically generate SSH keys
 #                       type:boolean
 #
@@ -21,6 +16,13 @@
 # $local_working_dir::  Local working directory on the smart proxy
 #
 # $remote_working_dir:: Remote working directory on clients
+#
+# === Advanced parameters:
+#
+# $enabled::            Enables/disables the plugin
+#                       type:boolean
+#
+# $listen_on::          Proxy feature listens on https, http, or both
 #
 class foreman_proxy::plugin::remote_execution::ssh (
   $enabled            = $::foreman_proxy::plugin::remote_execution::ssh::params::enabled,

--- a/manifests/plugin/salt.pp
+++ b/manifests/plugin/salt.pp
@@ -4,16 +4,9 @@
 #
 # === Parameters:
 #
-# $enabled::         Enables/disables the plugin
-#                    type:boolean
-#
-# $listen_on::       Proxy feature listens on https, http, or both
-#
 # $autosign_file::   File to use for salt autosign
 #
 # $user::            User to run salt commands under
-#
-# $group::           Owner of plugin configuration
 #
 # $api::             Use Salt API
 #                    type:boolean
@@ -25,6 +18,15 @@
 # $api_username::    Salt API username
 #
 # $api_password::    Salt API password
+#
+# === Advanced parameters:
+#
+# $enabled::         Enables/disables the plugin
+#                    type:boolean
+#
+# $group::           Owner of plugin configuration
+#
+# $listen_on::       Proxy feature listens on https, http, or both
 #
 class foreman_proxy::plugin::salt (
   $autosign_file     = $::foreman_proxy::plugin::salt::params::autosign_file,


### PR DESCRIPTION
This reduces the amount of default help text and confusing options for
plugins.  This is especially confusing for 'enabled' as there are 2
options:

 --[no-]enable-foreman-proxy-plugin-remote-execution-ssh
 --foreman-proxy-plugin-remote-execution-ssh-enabled

The former REALLY enables the plugin puppet module, the latter
is only controlling The value in the .yml configuration which has a
sane default value. We should hide this, and some of the other
options like listen_on, group, etc which probably don't need
changing ever.