### PR TITLE
Allow additional groups for the foreman-proxy user to be passed in

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,7 +24,7 @@ class foreman_proxy::config {
     include ::dns::params
     $groups = [$dns::params::group, $foreman_proxy::puppet_group]
   } else {
-    $groups = [$foreman_proxy::puppet_group]
+    $groups = concat($foreman_proxy::groups, $foreman_proxy::puppet_group)
   }
 
   user { $foreman_proxy::user:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,8 @@
 #
 # $user::                       User under which foreman proxy will run
 #
+# $groups::                     Array of additional groups for foreman proxy user
+#
 # $log::                        Foreman proxy log file, 'STDOUT' or 'SYSLOG'
 #
 # $log_level::                  Foreman proxy log level: WARN, DEBUG, ERROR, FATAL, INFO, UNKNOWN
@@ -295,6 +297,7 @@ class foreman_proxy (
   $ssl_port                   = $foreman_proxy::params::ssl_port,
   $dir                        = $foreman_proxy::params::dir,
   $user                       = $foreman_proxy::params::user,
+  $groups                     = $foreman_proxy::params::groups,
   $log                        = $foreman_proxy::params::log,
   $log_level                  = $foreman_proxy::params::log_level,
   $log_buffer                 = $foreman_proxy::params::log_buffer,
@@ -404,7 +407,7 @@ class foreman_proxy (
   # Validate misc params
   validate_string($bind_host)
   validate_bool($ssl, $manage_sudoersd, $use_sudoersd, $register_in_foreman, $manage_puppet_group)
-  validate_array($trusted_hosts, $ssl_disabled_ciphers)
+  validate_array($trusted_hosts, $ssl_disabled_ciphers, $groups)
   validate_re($log_level, '^(UNKNOWN|FATAL|ERROR|WARN|INFO|DEBUG)$')
   validate_re($plugin_version, '^(installed|present|latest|absent)$')
   validate_re($ensure_packages_version, '^(installed|present|latest|absent)$')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -139,6 +139,9 @@ class foreman_proxy::params {
   # Used to authenticate to Foreman, required if require_ssl_puppetmasters is enabled
   $client_ssl_cert = "${puppet_ssldir}/certs/${lower_fqdn}.pem"
   $client_ssl_key  = "${puppet_ssldir}/private_keys/${lower_fqdn}.pem"
+
+  $groups = []
+
   # Packaging
   $repo                    = 'stable'
   $gpgcheck                = true

--- a/manifests/tftp.pp
+++ b/manifests/tftp.pp
@@ -2,31 +2,35 @@
 class foreman_proxy::tftp (
   $tftp_managed = $foreman_proxy::tftp_managed,
 ) {
-  $required_tftp_classes = $tftp_managed ? {
-    true    => Class['foreman_proxy::install', 'tftp::install'],
-    default => Class['foreman_proxy::install'],
-  }
 
-  file{ $foreman_proxy::tftp_dirs:
-    ensure  => directory,
-    owner   => $foreman_proxy::user,
-    mode    => '0644',
-    require => $required_tftp_classes,
-    recurse => true;
-  }
+  if $tftp_managed {
 
-  foreman_proxy::tftp::copy_file{$foreman_proxy::tftp_syslinux_filenames:
-    target_path => $foreman_proxy::tftp_root,
-    require     => $required_tftp_classes;
+    $required_tftp_classes = $tftp_managed ? {
+      true    => Class['foreman_proxy::install', 'tftp::install'],
+      default => Class['foreman_proxy::install'],
+    }
+    
+    class { '::tftp':
+      root => $foreman_proxy::tftp_root,
+    }
+
+    file { $foreman_proxy::tftp_dirs:
+      ensure  => directory,
+      owner   => $foreman_proxy::user,
+      mode    => '0644',
+      require => $required_tftp_classes,
+      recurse => true;
+    }
+
+    foreman_proxy::tftp::copy_file { $foreman_proxy::tftp_syslinux_filenames:
+      target_path => $foreman_proxy::tftp_root,
+      require     => $required_tftp_classes;
+    }
+  
   }
 
   if $foreman_proxy::tftp_manage_wget {
     ensure_packages(['wget'], { ensure => $foreman_proxy::ensure_packages_version, })
   }
 
-  if $tftp_managed {
-    class { '::tftp':
-      root => $foreman_proxy::tftp_root,
-    }
-  }
 }


### PR DESCRIPTION
When using the module standalone it's likely you will need to add foreman proxy user into groups which may already exists, such as tftp or bind. This PR allows you to pass in an array of additional groups. 