### PR TITLE
Making sudoers for puppetrun_cmd conditional

### DIFF
--- a/templates/sudo.erb
+++ b/templates/sudo.erb
@@ -1,7 +1,7 @@
 <% if scope.lookupvar("foreman_proxy::puppetca") -%>
 <%= scope.lookupvar("foreman_proxy::user") %> ALL = (root) NOPASSWD : <%= scope.lookupvar("foreman_proxy::puppetca_cmd") %> *
 <% end -%>
-<% if scope.lookupvar("foreman_proxy::puppet") -%>
+<% if scope.lookupvar("foreman_proxy::puppet") and scope.lookupvar("foreman_proxy::puppetrun_provider") == 'puppetrun' -%>
 <%= scope.lookupvar("foreman_proxy::user") %> ALL = (<%= scope.lookupvar("foreman_proxy::puppet_user") %>) NOPASSWD : <%= scope.lookupvar("foreman_proxy::puppetrun_cmd") %> *
 <% end -%>
 Defaults:<%= scope.lookupvar("foreman_proxy::user") %> !requiretty

--- a/templates/sudo_augeas.erb
+++ b/templates/sudo_augeas.erb
@@ -1,29 +1,27 @@
-<% if scope.lookupvar('foreman_proxy::puppetca') and scope.lookupvar('foreman_proxy::puppet') -%>
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/user <%= scope.lookupvar('foreman_proxy::user') %>
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/host ALL
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/command '<%= scope.lookupvar('foreman_proxy::puppetca_cmd') %> *'
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/command/runas_user root
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/command/tag NOPASSWD
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][2]/user <%= scope.lookupvar('foreman_proxy::user') %>
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][2]/host_group/host ALL
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][2]/host_group/command '<%= scope.lookupvar('foreman_proxy::puppetrun_cmd') %> *'
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][2]/host_group/command/runas_user <%= scope.lookupvar('foreman_proxy::puppet_user') %>
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][2]/host_group/command/tag NOPASSWD
-rm spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/command[position() > 1]
-<% elsif scope.lookupvar('foreman_proxy::puppetca') -%>
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/user <%= scope.lookupvar('foreman_proxy::user') %>
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/host ALL
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command '<%= scope.lookupvar('foreman_proxy::puppetca_cmd') %> *'
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command/runas_user root
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command/tag NOPASSWD
-rm spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/command[position() > 1]
-<% elsif scope.lookupvar('foreman_proxy::puppet') -%>
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/user <%= scope.lookupvar('foreman_proxy::user') %>
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/host ALL
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command '<%= scope.lookupvar('foreman_proxy::puppetrun_cmd') %> *'
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command/runas_user <%= scope.lookupvar('foreman_proxy::puppet_user') %>
-set spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>']/host_group/command/tag NOPASSWD
-rm spec[user = '<%= scope.lookupvar('foreman_proxy::user') %>'][1]/host_group/command[position() > 1]
+<%-
+  user = scope.lookupvar('foreman_proxy::user')
+  index = 0
+-%>
+<% if scope.lookupvar('foreman_proxy::puppetca')
+  index += 1
+-%>
+set spec[user = '<%= user %>'][<%=index%>]/user <%= user %>
+set spec[user = '<%= user %>'][<%=index%>]/host_group/host ALL
+set spec[user = '<%= user %>'][<%=index%>]/host_group/command '<%= scope.lookupvar('foreman_proxy::puppetca_cmd') %> *'
+set spec[user = '<%= user %>'][<%=index%>]/host_group/command/runas_user root
+set spec[user = '<%= user %>'][<%=index%>]/host_group/command/tag NOPASSWD
+rm spec[user = '<%= user %>'][<%=index%>]/host_group/command[position() > 1]<%# delete any other command in the rule %>
 <% end -%>
-set Defaults[type = ':<%= scope.lookupvar('foreman_proxy::user') %>']/type :<%= scope.lookupvar('foreman_proxy::user') %>
-set Defaults[type = ':<%= scope.lookupvar('foreman_proxy::user') %>']/requiretty/negate ''
+<% if scope.lookupvar("foreman_proxy::puppet") and scope.lookupvar("foreman_proxy::puppetrun_provider") == 'puppetrun'
+  index += 1
+-%>
+set spec[user = '<%= user %>'][<%=index%>]/user <%= user %>
+set spec[user = '<%= user %>'][<%=index%>]/host_group/host ALL
+set spec[user = '<%= user %>'][<%=index%>]/host_group/command '<%= scope.lookupvar('foreman_proxy::puppetrun_cmd') %> *'
+set spec[user = '<%= user %>'][<%=index%>]/host_group/command/runas_user <%= scope.lookupvar('foreman_proxy::puppet_user') %>
+set spec[user = '<%= user %>'][<%=index%>]/host_group/command/tag NOPASSWD
+rm spec[user = '<%= user %>'][<%=index%>]/host_group/command[position() > 1]<%# delete any other command in the rule %>
+<% end -%>
+rm spec[user = '<%= user %>'][position() > <%= index %>]<%# delete any other rule for the user %>
+set Defaults[type = ':<%= user %>']/type :<%= user %>
+set Defaults[type = ':<%= user %>']/requiretty/negate ''


### PR DESCRIPTION
Not yet done, but to be the base of discussion.

It would be a good idea to only setup the sudo command if `puppetrun_provider` is actually `puppet`. Which is not set by default.

I'd like to get the opinion of the team.

intend to fix #269