### PR TITLE
Fix Discovery plugin test to define foreman_proxy::plugin_version

### DIFF
--- a/spec/classes/foreman_proxy__plugin__discovery_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__discovery_spec.rb
@@ -7,6 +7,10 @@ describe 'foreman_proxy::plugin::discovery' do
     context "on #{os}" do
       let(:facts) { facts }
 
+      let :pre_condition do
+        "include foreman_proxy"
+      end
+
       case facts[:operatingsystem]
         when 'Debian'
           tftproot = '/srv/tftp'


### PR DESCRIPTION
Required when testing under strict variables.

(Should fix the new test failures under Puppet 4.)