### PR TITLE
Enable smart-proxy logs feature by default

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -213,7 +213,7 @@ class foreman_proxy::params {
   $template_url        = "http://${::fqdn}:${http_port}"
 
   # Logs settings
-  $logs           = false
+  $logs           = true
   $logs_listen_on = 'https'
 
   # TFTP settings - requires optional TFTP puppet module

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -314,7 +314,7 @@ describe 'foreman_proxy::config' do
         it 'should generate correct logs.yml' do
           verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/logs.yml", [
             '---',
-            ':enabled: false'
+            ':enabled: https'
           ])
         end
 


### PR DESCRIPTION
The feature is turned off by default because I was worried about memory
consumption, but during testing period it turned out this is working well. I
suggest to turn on the feature now.