### PR TITLE
Allow additional groups for the foreman-proxy user

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,7 +24,7 @@ class foreman_proxy::config {
     include ::dns::params
     $groups = [$dns::params::group, $foreman_proxy::puppet_group]
   } else {
-    $groups = [$foreman_proxy::puppet_group]
+    $groups = concat($foreman_proxy::groups, $foreman_proxy::puppet_group)
   }
 
   user { $foreman_proxy::user:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,8 @@
 #
 # $user::                       User under which foreman proxy will run
 #
+# $groups::                     Array of additional groups for the foreman proxy user
+#
 # $log::                        Foreman proxy log file, 'STDOUT' or 'SYSLOG'
 #
 # $log_level::                  Foreman proxy log level: WARN, DEBUG, ERROR, FATAL, INFO, UNKNOWN
@@ -295,6 +297,7 @@ class foreman_proxy (
   $ssl_port                   = $foreman_proxy::params::ssl_port,
   $dir                        = $foreman_proxy::params::dir,
   $user                       = $foreman_proxy::params::user,
+  $groups                     = $foreman_proxy::params::groups,
   $log                        = $foreman_proxy::params::log,
   $log_level                  = $foreman_proxy::params::log_level,
   $log_buffer                 = $foreman_proxy::params::log_buffer,
@@ -404,7 +407,7 @@ class foreman_proxy (
   # Validate misc params
   validate_string($bind_host)
   validate_bool($ssl, $manage_sudoersd, $use_sudoersd, $register_in_foreman, $manage_puppet_group)
-  validate_array($trusted_hosts, $ssl_disabled_ciphers)
+  validate_array($trusted_hosts, $ssl_disabled_ciphers, $groups)
   validate_re($log_level, '^(UNKNOWN|FATAL|ERROR|WARN|INFO|DEBUG)$')
   validate_re($plugin_version, '^(installed|present|latest|absent)$')
   validate_re($ensure_packages_version, '^(installed|present|latest|absent)$')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -133,6 +133,8 @@ class foreman_proxy::params {
 
   $puppet_cmd = "${puppet_bindir}/puppet"
 
+  $groups = []
+
   # Packaging
   $repo                    = 'stable'
   $gpgcheck                = true

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -418,6 +418,26 @@ describe 'foreman_proxy::config' do
           ])
         end
       end
+      
+      context 'with custom groups defined' do
+         let :pre_condition do
+          'class {"foreman_proxy":
+             groups   => [ "test_group1", "test_group2" ],
+          }'
+         end
+
+         it "should create the #{proxy_user_name} user" do
+          should contain_user("#{proxy_user_name}").with({
+            :ensure  => 'present',
+            :shell   => "#{shell}",
+            :comment => 'Foreman Proxy account',
+            :groups  => ['test_group1', 'test_group2', 'puppet'],
+            :home    => "#{home_dir}",
+            :require => 'Class[Foreman_proxy::Install]',
+            :notify  => 'Class[Foreman_proxy::Service]',
+          })
+        end
+      end
 
       context 'with custom tftp parameters' do
         let :pre_condition do


### PR DESCRIPTION
The primary use case for this is when managing DNS but not managing the deployment of the DNS server, the foreman proxy user needs to be a member of the bind group.