### PR TITLE
Use defaults from foreman_proxy::params in Pulp plugin params

### DIFF
--- a/manifests/plugin/pulp/params.pp
+++ b/manifests/plugin/pulp/params.pp
@@ -1,5 +1,7 @@
 # Default parameters for the Pulp smart proxy plugin
 class foreman_proxy::plugin::pulp::params {
+  include ::foreman_proxy::params
+
   $enabled            = true
   $listen_on          = 'https'
   $version            = undef
@@ -8,6 +10,6 @@ class foreman_proxy::plugin::pulp::params {
   $pulp_url           = "https://${::fqdn}/pulp"
   $pulp_dir           = '/var/lib/pulp'
   $pulp_content_dir   = '/var/lib/pulp/content'
-  $puppet_content_dir = $::foreman_proxy::puppet_envdir
+  $puppet_content_dir = $::foreman_proxy::params::puppet_envdir
   $mongodb_dir        = '/var/lib/mongodb'
 }


### PR DESCRIPTION
Kafo loads params manifests independently of the main manifests to
determine parameter defaults, and also parse order may not permit using
foreman_proxy parameters directly.

---

Will fix nightly test failures running the installer with 79e36af:

<pre>
# [ INFO 2016-09-08 07:39:16 verbose] Running validation checks
# [ERROR 2016-09-08 07:39:16 verbose] Validation error: nil is not an absolute path
# [ERROR 2016-09-08 07:39:16 verbose] Parameter foreman-proxy-plugin-pulp-puppet-content-dir invalid: nil is not an absolute path
</pre>