### PR TITLE
Fixes #16050 - link dynflow_core settings to proxy

### DIFF
--- a/manifests/plugin/dynflow.pp
+++ b/manifests/plugin/dynflow.pp
@@ -64,6 +64,10 @@ class foreman_proxy::plugin::dynflow (
       ensure  => file,
       content => template('foreman_proxy/plugin/dynflow_core.yml.erb'),
     } ~>
+    file { '/etc/smart_proxy_dynflow_core/settings.d':
+      ensure => link,
+      target => '/etc/foreman-proxy/settings.d',
+    } ~>
     service { 'smart_proxy_dynflow_core':
       ensure => running,
       enable => true,

--- a/manifests/plugin/remote_execution/ssh.pp
+++ b/manifests/plugin/remote_execution/ssh.pp
@@ -65,4 +65,9 @@ class foreman_proxy::plugin::remote_execution::ssh (
       creates => $ssh_identity_path,
     }
   }
+
+  if $::osfamily == 'RedHat' and $::operatingsystem != 'Fedora' {
+    Foreman_proxy::Settings_file['remote_execution_ssh']
+      ~> Service['smart_proxy_dynflow_core']
+  }
 }

--- a/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
@@ -21,6 +21,11 @@ describe 'foreman_proxy::plugin::dynflow' do
       ])
     end
 
+    it 'should create settings.d symlink' do
+      should contain_file("/etc/smart_proxy_dynflow_core/settings.d").
+        with_ensure('link').with_target('/etc/foreman-proxy/settings.d')
+    end
+
     it 'should generate correct dynflow core settings.yml' do
       verify_exact_contents(catalogue, "/etc/smart_proxy_dynflow_core/settings.yml", [
           "---",


### PR DESCRIPTION
We need to link the proxy settings dir to make sure the config
is loaded properly. Needs https://github.com/theforeman/foreman-packaging/pull/1321
to work properly, without it it has no effect.