### PR TITLE
Handle rex ssh dependencies in packaging

### DIFF
--- a/manifests/plugin/remote_execution/ssh.pp
+++ b/manifests/plugin/remote_execution/ssh.pp
@@ -65,15 +65,4 @@ class foreman_proxy::plugin::remote_execution::ssh (
       creates => $ssh_identity_path,
     }
   }
-
-  if $::osfamily == 'RedHat' and $::operatingsystem != 'Fedora' {
-    $scl_prefix = 'tfm-'
-  } else {
-    $scl_prefix = '' # lint:ignore:empty_string_assignment
-  }
-
-  foreman_proxy::plugin { 'remote_execution_ssh_core':
-    package => "${scl_prefix}${::foreman_proxy::plugin_prefix}remote_execution_ssh_core",
-    notify  => Service['smart_proxy_dynflow_core'],
-  }
 }


### PR DESCRIPTION
smart_proxy_remote_execution_core was removed in 1.13
and even before, it was already handled in packaging.
No need to repeat ourselves here.

Fixes #287