### PR TITLE
Fixes #289 - Fix grub_efi_path on CentOS 6

### DIFF
--- a/manifests/tftp.pp
+++ b/manifests/tftp.pp
@@ -49,7 +49,11 @@ class foreman_proxy::tftp {
       $grub_efi_path = 'fedora'
     }
     'CentOS': {
-      $grub_efi_path = 'centos'
+      if versioncmp($osreleasemajor, '6') <= 0 {
+        $grub_efi_path = 'redhat'
+      } else {
+        $grub_efi_path = 'centos'
+      }
     }
     /^(RedHat|Scientific|OracleLinux)$/: {
       $grub_efi_path = 'redhat'


### PR DESCRIPTION
```bash
[weeks@ns1 ~]$ repoquery -l grub | grep grub.efi
/boot/efi/EFI/redhat/grub.efi
[weeks@ns1 ~]$
```

I'm a little confused why this didn't get caught by `spec/classes/foreman_proxy__config__spec.rb:346`.