### PR TITLE
Fix Grub1 EFI path on EL6

### DIFF
--- a/manifests/tftp.pp
+++ b/manifests/tftp.pp
@@ -49,7 +49,11 @@ class foreman_proxy::tftp {
       $grub_efi_path = 'fedora'
     }
     'CentOS': {
-      $grub_efi_path = 'centos'
+      if versioncmp($osreleasemajor, '6') <= 0 {
+        $grub_efi_path = 'redhat'
+      } else {
+        $grub_efi_path = 'centos'
+      }
     }
     /^(RedHat|Scientific|OracleLinux)$/: {
       $grub_efi_path = 'redhat'


### PR DESCRIPTION
It looks like in EL6 the folder name is preserved while on EL7 it's renamed to
"centos".