### PR TITLE
Fix grub_efi_path for CentOS

### DIFF
--- a/manifests/tftp.pp
+++ b/manifests/tftp.pp
@@ -48,10 +48,7 @@ class foreman_proxy::tftp {
     'Fedora': {
       $grub_efi_path = 'fedora'
     }
-    'CentOS': {
-      $grub_efi_path = 'centos'
-    }
-    /^(RedHat|Scientific|OracleLinux)$/: {
+    /^(CentOS|RedHat|Scientific|OracleLinux)$/: {
       $grub_efi_path = 'redhat'
     }
     default: {


### PR DESCRIPTION
The file is /boot/efi/EFI/redhat/grub.efi at least in CentOS 6 with grub-0.97-94.el6_7.1.x86_64
