### PR TITLE
Add array doc for groups and fix value for dhcp_range

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,7 @@
 # $user::                       User under which foreman proxy will run
 #
 # $groups::                     Array of additional groups for the foreman proxy user
+#                               type:array
 #
 # $log::                        Foreman proxy log file, 'STDOUT' or 'SYSLOG'
 #

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -238,7 +238,7 @@ class foreman_proxy::params {
   $dhcp_subnets            = []
   $dhcp_interface          = 'eth0'
   $dhcp_gateway            = '192.168.100.1'
-  $dhcp_range              = false
+  $dhcp_range              = undef
   $dhcp_option_domain      = [$::domain]
   $dhcp_search_domains     = undef
   # This will use the IP of the interface in $dhcp_interface, override


### PR DESCRIPTION
Kafo + Puppet 3 is unhappy with these without a parser cache:

```
[ERROR 2016-10-12 13:19:30 verbose] Parameter foreman-proxy-groups invalid: [] is not a valid string
[ERROR 2016-10-12 13:19:30 verbose] Parameter foreman-proxy-dhcp-range invalid: false is not a valid string
```