### PR TITLE
Export and Collect DNS Zones, multiple reverse's

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -451,7 +451,7 @@ class foreman_proxy (
 
   # Validate dns params
   validate_bool($dns)
-  validate_string($dns_interface, $dns_provider, $dns_reverse, $dns_server, $keyfile)
+  validate_string($dns_interface, $dns_provider, $dns_server, $keyfile)
   validate_array($dns_forwarders)
 
   # Validate libvirt params

--- a/manifests/proxydns.pp
+++ b/manifests/proxydns.pp
@@ -28,11 +28,11 @@ class foreman_proxy::proxydns {
       soaip   => $ip,
     }
     @@dns::zone { "${::fqdn}_reverse_${reverse}":
-      zonetype => 'slave',
-      masters  => [ $ip ],
+      zonetype    => 'slave',
+      masters     => [ $ip ],
       manage_file => false,
       soaip       => $ip,
-      zone        => $reverse
+      zone        => $reverse,
     }
   }
 
@@ -41,7 +41,7 @@ class foreman_proxy::proxydns {
     masters     => [ $ip ],
     manage_file => false,
     soaip       => $ip,
-    zone        => $foreman_proxy::dns_zone
+    zone        => $foreman_proxy::dns_zone,
   }
 
   Dns::Zone <<| soaip != $ip |>>


### PR DESCRIPTION
Export Forward and Reverse DNS Zones so other Proxies collect them. This automatically creates slave DNS zones on other proxies.
This also supports multiple reverse Zones, for example if one Smart Proxy is managing multiple subnets.
