### PR TITLE
pin puppetlabs-mysql to 3.9.0 for tests (4.0-stable)

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,7 +8,9 @@ fixtures:
       repo: 'git://github.com/puppet-community/puppet-extlib'
       ref:  'v0.11.3'
     foreman:  'git://github.com/theforeman/puppet-foreman'
-    mysql:    'git://github.com/puppetlabs/puppetlabs-mysql.git'
+    mysql:
+      repo: 'git://github.com/puppetlabs/puppetlabs-mysql'
+      ref:  '3.9.0'
     puppet:   'git://github.com/theforeman/puppet-puppet'
     stdlib:   'git://github.com/puppetlabs/puppetlabs-stdlib.git'
     tftp:     'git://github.com/theforeman/puppet-tftp'


### PR DESCRIPTION
newer versions are not compatible with Ruby 1.8.7