### PR TITLE
Allow $dns_reverse to be a string or an array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,38 +2,25 @@
 # This file is managed centrally by modulesync
 #   https://github.com/theforeman/foreman-installer-modulesync
 rvm:
-  - 1.9.3
-  - 2.0.0
   - 2.1.5
 env:
   # First test the major distros
-  - PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64
-  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
-  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64
-  # Test operating systems with ruby 1.8.7 explicitly so we can exclude ruby 1.8.7 tests for other OS
-  - PUPPET_VERSION=4.0 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64
-  - PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
-  - PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64
+  - PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64
+  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64
   # Test the rest of the supported platforms
-  - PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
-  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
-  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
+  - PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,scientific-6-x86_64
+  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,scientific-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,scientific-6-x86_64
 matrix:
   fast_finish: true
-  exclude:
-    # No support for Ruby 1.9.3 on Puppet 4.x
-    - rvm: 1.9.3
-      env: PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64
-    - rvm: 1.9.3
-      env: PUPPET_VERSION=4.0 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64
-    - rvm: 1.9.3
-      env: PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
   include:
-    # Only platforms left to support ruby 1.8.7
-    - rvm: 1.8.7
-      env: PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64
-    - rvm: 1.8.7
-      env: PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+    # Only Ubuntu 14.04 uses Ruby 1.9.3 to run Puppet 3.x
+    - rvm: 1.9.3
+      env: PUPPET_VERSION=3.5 ONLY_OS="ubuntu-14-x86_64,ubuntu-14.04-x86_64"
+    # Only EL7 uses Ruby 2.0.0 to run Puppet 3.x
+    - rvm: 2.0.0
+      env: PUPPET_VERSION=3.5 ONLY_OS="centos-7-x86_64"
     # Only Puppet 4.x supports Ruby 2.2. Also limit the OS set we test Ruby 2.2 with.
     - rvm: 2.2.3
       env: PUPPET_VERSION=4.0 ONLY_OS="debian-8-x86_64,centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,freebsd-10-amd64,windows-2012 R2-x64"

--- a/Gemfile
+++ b/Gemfile
@@ -5,16 +5,10 @@ source 'https://rubygems.org'
 
 gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '>= 2.7'
 
-if RUBY_VERSION.start_with? '1.8'
-  gem 'rake', '< 11'
-  gem 'rspec', '>= 3', '< 3.2'
-  gem 'rspec-puppet-facts', '< 1.4.0'
-else
-  gem 'rake'
-  gem 'rspec', '~> 3.0'
-  gem 'rspec-puppet-facts', '>= 1.5'
-end
+gem 'rake'
+gem 'rspec', '~> 3.0'
 gem 'rspec-puppet', '~> 2.3'
+gem 'rspec-puppet-facts', '>= 1.5'
 gem 'puppetlabs_spec_helper', '>= 0.8.0'
 gem 'puppet-lint', '>= 2'
 gem 'puppet-lint-unquoted_string-check'
@@ -29,10 +23,8 @@ gem 'puppet-lint-file_ensure-check'
 gem 'puppet-lint-param-docs', '>= 1.3.0'
 gem 'simplecov'
 gem 'puppet-blacksmith', '>= 3.1.0', {"groups"=>["development"]}
-gem 'rest-client', '< 1.7', {"platforms"=>["ruby_18"], "groups"=>["development"]}
-gem 'mime-types', '~> 1.0', {"platforms"=>["ruby_18"], "groups"=>["development"]}
-gem 'json', '~> 1.0', {"platforms"=>["ruby_18", "ruby_19"], "groups"=>["test"]}
-gem 'json_pure', '~> 1.0', {"platforms"=>["ruby_18", "ruby_19"], "groups"=>["test"]}
+gem 'json', '~> 1.0', {"platforms"=>["ruby_19"], "groups"=>["test"]}
+gem 'json_pure', '~> 1.0', {"platforms"=>["ruby_19"], "groups"=>["test"]}
 gem 'metadata-json-lint'
 
 # vim:ft=ruby

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -451,8 +451,12 @@ class foreman_proxy (
 
   # Validate dns params
   validate_bool($dns)
-  validate_string($dns_interface, $dns_provider, $dns_reverse, $dns_server, $keyfile)
+  validate_string($dns_interface, $dns_provider, $dns_server, $keyfile)
   validate_array($dns_forwarders)
+  # $dns_reverse can be a string or an array of strings (to cover /23 networks for example)
+  if ! is_string($dns_reverse) and ! is_array($dns_reverse) {
+    fail('$dns_reverse must be a string or an array of strings')
+  }
 
   # Validate libvirt params
   validate_string($libvirt_network, $libvirt_connection)

--- a/spec/classes/foreman_proxy__proxydns__spec.rb
+++ b/spec/classes/foreman_proxy__proxydns__spec.rb
@@ -126,6 +126,34 @@ describe 'foreman_proxy::proxydns' do
                                                                     })
         end
       end
+
+      context "with dns_reverse array" do
+        let :facts do
+          facts.merge(default_facts).merge({:ipaddress_eth0 => '127.0.1.1'})
+        end
+
+        let :pre_condition do
+          "class {'foreman_proxy':
+            dns_reverse => ['0.168.192.in-addr.arpa', '1.168.192.in-addr.arpa']
+          }"
+        end
+
+        it 'should include the reverse zone 0.168.192.in-addr.arpa' do
+          should contain_dns__zone('0.168.192.in-addr.arpa').with({
+              :soa     => 'foreman.example.org',
+              :reverse => true,
+              :soaip   => '127.0.1.1',
+          })
+        end
+
+        it 'should include the reverse zone 1.168.192.in-addr.arpa' do
+          should contain_dns__zone('1.168.192.in-addr.arpa').with({
+              :soa     => 'foreman.example.org',
+              :reverse => true,
+              :soaip   => '127.0.1.1',
+          })
+        end
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,14 @@ def exclude_test_os
   end
 end
 
+# Use the above environment variables to limit the platforms under test
+def on_os_under_test
+  on_supported_os.reject do |os, facts|
+    (only_test_os() && !only_test_os.include?(os)) ||
+      (exclude_test_os() && exclude_test_os.include?(os))
+  end
+end
+
 def get_content(subject, title)
   content = subject.resource('file', title).send(:parameters)[:content]
   content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }


### PR DESCRIPTION
By default the module assumes that we run Foreman in a small /24 network. BIND server expects reverse zones to be setup per /24 network chunks so this makes it impossible with current settings to create reverse zone for say /23 network.

This change is allowing us to either stick with the default string value for a small network or use an array to create necessary configuration. And the nature of it is making it backwards compatible with existing modules to setup Foreman.