### PR TITLE
Use a default if puppet_environmentpath fact not available

### DIFF
--- a/manifests/plugin/pulp/params.pp
+++ b/manifests/plugin/pulp/params.pp
@@ -10,6 +10,6 @@ class foreman_proxy::plugin::pulp::params {
   $pulp_url           = "https://${::fqdn}/pulp"
   $pulp_dir           = '/var/lib/pulp'
   $pulp_content_dir   = '/var/lib/pulp/content'
-  $puppet_content_dir = $::puppet_environmentpath
+  $puppet_content_dir = pick($::puppet_environmentpath, "${::foreman_proxy::puppetdir}/environments")
   $mongodb_dir        = '/var/lib/mongodb'
 }

--- a/spec/classes/foreman_proxy__plugin__pulp_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__pulp_spec.rb
@@ -2,8 +2,13 @@ require 'spec_helper'
 
 describe 'foreman_proxy::plugin::pulp' do
 
+  let :puppet_environmentpath do
+    # In Puppet 3, Puppet[:environmentpath] default is ""
+    Gem::Version.new(Puppet.version) >= Gem::Version.new('4.0') ? '/etc/puppetlabs/code/environments' : ""
+  end
+
   let :facts do
-    on_supported_os['redhat-6-x86_64'].merge(:puppet_environmentpath => '/etc/puppetlabs/code/environments')
+    on_supported_os['redhat-6-x86_64'].merge(:puppet_environmentpath => puppet_environmentpath)
   end
 
   let :etc_dir do
@@ -29,7 +34,7 @@ describe 'foreman_proxy::plugin::pulp' do
           ":pulp_url: https://#{facts[:fqdn]}/pulp",
           ':pulp_dir: /var/lib/pulp',
           ':pulp_content_dir: /var/lib/pulp/content',
-          ':puppet_content_dir: /etc/puppetlabs/code/environments',
+          ":puppet_content_dir: #{puppet_environmentpath.empty? ? '/etc/puppet/environments' : puppet_environmentpath}",
           ':mongodb_dir: /var/lib/mongodb',
         ])
     end


### PR DESCRIPTION
Unfortunately on Puppet 3, there is no default value:
  https://github.com/puppetlabs/puppet/blob/3.8.2/lib/puppet/defaults.rb#L253

And at install time, there's no puppet master yet configured - thus no environmentpath. :-\

