### PR TITLE
Allow $dns_reverse to be a string or an array

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -283,7 +283,7 @@
 #                               type:String
 #
 # $dns_reverse::                DNS reverse zone name
-#                               type:String
+#                               type:Variant[String, Array[String]]
 #
 # $dns_server::                 Address of DNS server to manage
 #                               type:String
@@ -525,8 +525,12 @@ class foreman_proxy (
 
   # Validate dns params
   validate_bool($dns)
-  validate_string($dns_interface, $dns_provider, $dns_reverse, $dns_server, $keyfile)
+  validate_string($dns_interface, $dns_provider, $dns_server, $keyfile)
   validate_array($dns_forwarders)
+  # $dns_reverse can be a string or an array of strings (to cover /23 networks for example)
+  if ! is_string($dns_reverse) and ! is_array($dns_reverse) {
+    fail('$dns_reverse must be a string or an array of strings')
+  }
 
   # Validate libvirt params
   validate_string($libvirt_network, $libvirt_connection)

--- a/spec/classes/foreman_proxy__proxydns__spec.rb
+++ b/spec/classes/foreman_proxy__proxydns__spec.rb
@@ -102,6 +102,30 @@ describe 'foreman_proxy::proxydns' do
           should contain_dns__zone('100.168.192.in-addr.arpa').with_soaip('127.0.1.1')
         end
       end
+
+      context "with dns_reverse array" do
+        let :facts do
+          facts.merge({:ipaddress_eth0 => '127.0.1.1'})
+        end
+
+        let :pre_condition do
+          "class {'foreman_proxy':
+            dns_reverse => ['0.168.192.in-addr.arpa', '1.168.192.in-addr.arpa']
+          }"
+        end
+
+        it 'should include the reverse zone 0.168.192.in-addr.arpa' do
+          should contain_dns__zone('0.168.192.in-addr.arpa').with_soa('foo.example.com')
+          should contain_dns__zone('0.168.192.in-addr.arpa').with_reverse(true)
+          should contain_dns__zone('0.168.192.in-addr.arpa').with_soaip('127.0.1.1')
+        end
+
+        it 'should include the reverse zone 1.168.192.in-addr.arpa' do
+          should contain_dns__zone('1.168.192.in-addr.arpa').with_soa('foo.example.com')
+          should contain_dns__zone('1.168.192.in-addr.arpa').with_reverse(true)
+          should contain_dns__zone('1.168.192.in-addr.arpa').with_soaip('127.0.1.1')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
By default the module assumes that we run Foreman in a small /24 network. BIND server expects reverse zones to be setup per /24 network chunks so this makes it impossible with current settings to create reverse zone for say /23 network.

This change is allowing us to either stick with the default string value for a small network or use an array to create necessary configuration. And the nature of it is making it backwards compatible with existing modules to setup Foreman.
