### PR TITLE
Use puppetdir from params

### DIFF
--- a/manifests/plugin/pulp/params.pp
+++ b/manifests/plugin/pulp/params.pp
@@ -10,6 +10,6 @@ class foreman_proxy::plugin::pulp::params {
   $pulp_url           = "https://${::fqdn}/pulp"
   $pulp_dir           = '/var/lib/pulp'
   $pulp_content_dir   = '/var/lib/pulp/content'
-  $puppet_content_dir = pick($::puppet_environmentpath, "${::foreman_proxy::puppetdir}/environments")
+  $puppet_content_dir = pick($::puppet_environmentpath, "${::foreman_proxy::params::puppetdir}/environments")
   $mongodb_dir        = '/var/lib/mongodb'
 }


### PR DESCRIPTION
The foreman_proxy class doesn't always seem to be available and loaded in the installer, so this ends up being just "/environments" on a real install in Puppet 3.