### PR TITLE
Change existing Kafo type definitions to Puppet 4 types

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -17,3 +17,4 @@ fixtures:
 
   symlinks:
     foreman_proxy: "#{source_dir}"
+    test: "#{source_dir}/spec/static_fixtures/test_module"

--- a/Gemfile
+++ b/Gemfile
@@ -26,5 +26,6 @@ gem 'puppet-blacksmith', '>= 3.1.0', {"groups"=>["development"]}
 gem 'json', '~> 1.0', {"platforms"=>["ruby_19"], "groups"=>["test"]}
 gem 'json_pure', '~> 1.0', {"platforms"=>["ruby_19"], "groups"=>["test"]}
 gem 'metadata-json-lint'
+gem 'kafo_module_lint'
 
 # vim:ft=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,9 @@ end
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp", "vendor/**/*.pp"]
 PuppetLint.configuration.log_format = '%{path}:%{linenumber}:%{KIND}: %{message}'
 
+# Used for type alias tests
+PuppetSyntax.exclude_paths << 'spec/static_fixtures/test_module/**/*.pp' if Puppet.version.to_f < 4.0
+
 require 'puppet-lint-param-docs/tasks'
 PuppetLintParamDocs.define_selective do |config|
   config.pattern = ["manifests/init.pp", "manifests/plugin/**/*.pp"]

--- a/Rakefile
+++ b/Rakefile
@@ -27,4 +27,9 @@ PuppetLintParamDocs.define_selective do |config|
   config.pattern = ["manifests/init.pp", "manifests/plugin/**/*.pp"]
 end
 
+require 'kafo_module_lint/tasks'
+KafoModuleLint::RakeTask.new do |config|
+  config.pattern = ["manifests/init.pp", "manifests/plugin/**/*.pp"]
+end
+
 task :default => [:validate, :lint, :spec]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,288 +3,362 @@
 # === Parameters:
 #
 # $repo::                       This can be stable, rc, or nightly
+#                               type:String
 #
 # $gpgcheck::                   Turn on/off gpg check in repo files (effective only on RedHat family systems)
-#                               type:boolean
+#                               type:Boolean
 #
 # $custom_repo::                No need to change anything here by default
 #                               if set to true, no repo will be added by this module, letting you to
 #                               set it to some custom location.
-#                               type:boolean
+#                               type:Boolean
 #
 # $version::                    foreman package version, it's passed to ensure parameter of package resource
 #                               can be set to specific version number, 'latest', 'present' etc.
+#                               type:String
 #
 # $ensure_packages_version::    control extra packages version, it's passed to ensure parameter of package resource
-#                               can be set to 'installed', 'present', 'latest', 'absent'
+#                               type:Enum['latest', 'present', 'installed', 'absent']
 #
 # $plugin_version::             foreman plugins version, it's passed to ensure parameter of plugins package resource
-#                               can be set to 'latest', 'present',  'installed', 'absent'.
+#                               type:Enum['latest', 'present', 'installed', 'absent']
 #
 # $bind_host::                  Host to bind ports to, e.g. *, localhost, 0.0.0.0
+#                               type:String
 #
 # $http::                       Enable HTTP
-#                               type:boolean
+#                               type:Boolean
 #
 # $http_port::                  HTTP port to listen on (if http is enabled)
-#                               type:integer
+#                               type:Integer[0, 65535]
 #
 # $ssl::                        Enable SSL, ensure feature is added with "https://" protocol if true
-#                               type:boolean
+#                               type:Boolean
 #
 # $ssl_port::                   HTTPS port to listen on (if ssl is enabled)
-#                               type:integer
+#                               type:Integer[0, 65535]
 #
 # $dir::                        Foreman proxy install directory
+#                               type:Stdlib::Absolutepath
 #
 # $user::                       User under which foreman proxy will run
+#                               type:String
 #
 # $groups::                     Array of additional groups for the foreman proxy user
-#                               type:array
+#                               type:Array[String]
 #
 # $log::                        Foreman proxy log file, 'STDOUT' or 'SYSLOG'
+#                               type:Variant[Enum['STDOUT', 'SYSLOG'], Stdlib::Absolutepath]
 #
-# $log_level::                  Foreman proxy log level: WARN, DEBUG, ERROR, FATAL, INFO, UNKNOWN
+# $log_level::                  Foreman proxy log level
+#                               type:Enum['WARN', 'DEBUG', 'ERROR', 'FATAL', 'INFO', 'UNKNOWN']
 #
 # $log_buffer::                 Log buffer size
-#                               type:integer
+#                               type:Integer[0]
 #
 # $log_buffer_errors::          Additional log buffer size for errors
-#                               type:integer
+#                               type:Integer[0]
 #
 # $ssl_ca::                     SSL CA to validate the client certificates used to access the proxy
+#                               type:Stdlib::Absolutepath
 #
 # $ssl_cert::                   SSL certificate to be used to run the foreman proxy via https.
+#                               type:Stdlib::Absolutepath
 #
 # $ssl_key::                    Corresponding key to a ssl_cert certificate
+#                               type:Stdlib::Absolutepath
 #
 # $foreman_ssl_ca::             SSL CA used to verify connections when accessing the Foreman API.
 #                               When not specified, the ssl_ca is used instead.
+#                               type:Optional[Stdlib::Absolutepath]
 #
 # $foreman_ssl_cert::           SSL client certificate used when accessing the Foreman API
 #                               When not specified, the ssl_cert is used instead.
+#                               type:Optional[Stdlib::Absolutepath]
 #
 # $foreman_ssl_key::            Corresponding key to a foreman_ssl_cert certificate
 #                               When not specified, the ssl_key is used instead.
+#                               type:Optional[Stdlib::Absolutepath]
 #
 # $ssl_disabled_ciphers::       List of OpenSSL cipher suite names that will be disabled from the default
-#                               type:array
+#                               type:Array[String]
 #
 # $trusted_hosts::              Only hosts listed will be permitted, empty array to disable authorization
-#                               type:array
+#                               type:Array[String]
 #
 # $manage_sudoersd::            Whether to manage File['/etc/sudoers.d'] or not.  When reusing this module, this may be
 #                               disabled to let a dedicated sudo module manage it instead.
-#                               type:boolean
+#                               type:Boolean
 #
 # $use_sudoersd::               Add a file to /etc/sudoers.d (true) or uses augeas (false)
-#                               type:boolean
+#                               type:Boolean
 #
 # $puppetca::                   Enable Puppet CA feature
-#                               type:boolean
+#                               type:Boolean
 #
-# $puppetca_listen_on::         Puppet CA feature to listen on https, http, or both
+# $puppetca_listen_on::         Protocols for the Puppet CA feature to listen on
+#                               type:Foreman_proxy::ListenOn
 #
-# $ssldir::                     Puppet CA ssl directory
+# $ssldir::                     Puppet CA SSL directory
+#                               type:Stdlib::Absolutepath
 #
 # $puppetdir::                  Puppet var directory
+#                               type:Stdlib::Absolutepath
 #
 # $puppetca_cmd::               Puppet CA command to be allowed in sudoers
+#                               type:String
 #
 # $puppet_group::               Groups of Foreman proxy user
+#                               type:String
 #
 # $manage_puppet_group::        Whether to ensure the $puppet_group exists.  Also ensures group owner of ssl keys and certs is $puppet_group
 #                               Not applicable when ssl is false.
-#                               type:boolean
+#                               type:Boolean
 #
 # $puppet::                     Enable Puppet module for environment imports and Puppet runs
-#                               type:boolean
+#                               type:Boolean
 #
-# $puppet_listen_on::           Puppet feature to listen on https, http, or both
+# $puppet_listen_on::           Protocols for the Puppet feature to listen on
+#                               type:Foreman_proxy::ListenOn
 #
 # $puppetrun_provider::         Provider for running/kicking Puppet agents
+#                               type:Optional[String]
 #
 # $puppetrun_cmd::              Puppet run/kick command to be allowed in sudoers
+#                               type:String
 #
 # $customrun_cmd::              Puppet customrun command
+#                               type:String
 #
 # $customrun_args::             Puppet customrun command arguments
+#                               type:String
 #
 # $mcollective_user::           The user for puppetrun_provider mcollective
+#                               type:String
 #
 # $puppetssh_sudo::             Whether to use sudo before commands when using puppetrun_provider puppetssh
-#                               type:boolean
+#                               type:Boolean
 #
 # $puppetssh_command::          The command used by puppetrun_provider puppetssh
+#                               type:String
 #
 # $puppetssh_user::             The user for puppetrun_provider puppetssh
+#                               type:String
 #
 # $puppetssh_keyfile::          The keyfile for puppetrun_provider puppetssh commands
+#                               type:Stdlib::Absolutepath
 #
 # $puppetssh_wait::             Whether to wait for completion of the Puppet command over SSH and return
 #                               the exit code
-#                               type:boolean
+#                               type:Boolean
 #
 # $salt_puppetrun_cmd::         Salt command to trigger Puppet run
+#                               type:String
 #
 # $puppet_user::                Which user to invoke sudo as to run puppet commands
+#                               type:String
 #
 # $puppet_url::                 URL of the Puppet master itself for API requests
+#                               type:Stdlib::HTTPUrl
 #
 # $puppet_ssl_ca::              SSL CA used to verify connections when accessing the Puppet master API
+#                               type:Stdlib::Absolutepath
 #
 # $puppet_ssl_cert::            SSL certificate used when accessing the Puppet master API
+#                               type:Stdlib::Absolutepath
 #
 # $puppet_ssl_key::             SSL private key used when accessing the Puppet master API
+#                               type:Stdlib::Absolutepath
 #
 # $puppet_use_environment_api:: Override use of Puppet's API to list environments.  When unset, the proxy will
 #                               try to determine this automatically.
-#                               type:boolean
+#                               type:Optional[Boolean]
 #
 # $templates::                  Enable templates feature
-#                               type:boolean
+#                               type:Boolean
 #
 # $templates_listen_on::        Templates proxy to listen on https, http, or both
+#                               type:Foreman_proxy::ListenOn
 #
 # $template_url::               URL a client should use for provisioning templates
+#                               type:Stdlib::HTTPUrl
 #
 # $logs::                       Enable Logs (log buffer) feature
-#                               type:boolean
+#                               type:Boolean
 #
 # $logs_listen_on::             Logs proxy to listen on https, http, or both
+#                               type:Foreman_proxy::ListenOn
 #
 # $tftp::                       Enable TFTP feature
-#                               type:boolean
+#                               type:Boolean
 #
 # $tftp_listen_on::             TFTP proxy to listen on https, http, or both
+#                               type:Foreman_proxy::ListenOn
 #
 # $tftp_managed::               TFTP is managed by Foreman proxy
-#                               type:boolean
+#                               type:Boolean
 #
 # $tftp_manage_wget::           If enabled will install the wget package
-#                               type:boolean
+#                               type:Boolean
 #
 # $tftp_syslinux_filenames::    Syslinux files to install on TFTP (full paths)
-#                               type:array
+#                               type:Array[Stdlib::Absolutepath]
 #
 # $tftp_root::                  TFTP root directory
+#                               type:Stdlib::Absolutepath
 #
 # $tftp_dirs::                  Directories to be create in $tftp_root
-#                               type:array
+#                               type:Array[Stdlib::Absolutepath]
 #
 # $tftp_servername::            Defines the TFTP Servername to use, overrides the name in the subnet declaration
+#                               type:Optional[String]
 #
 # $dhcp::                       Enable DHCP feature
-#                               type:boolean
+#                               type:Boolean
 #
 # $dhcp_listen_on::             DHCP proxy to listen on https, http, or both
+#                               type:Foreman_proxy::ListenOn
 #
 # $dhcp_managed::               DHCP is managed by Foreman proxy
-#                               type:boolean
+#                               type:Boolean
 #
 # $dhcp_provider::              DHCP provider
+#                               type:String
 #
 # $dhcp_subnets::               Subnets list to restrict DHCP management to
-#                               type:array
+#                               type:Array[String]
 #
 # $dhcp_option_domain::         DHCP use the dhcpd config option domain-name
-#                               type:array
+#                               type:Array[String]
 #
 # $dhcp_search_domains::        DHCP search domains option
-#                               type:array
+#                               type:Optional[Array[String]]
 #
 # $dhcp_interface::             DHCP listen interface
+#                               type:String
 #
 # $dhcp_gateway::               DHCP pool gateway
+#                               type:Optional[String]
 #
 # $dhcp_range::                 Space-separated DHCP pool range
+#                               type:Optional[String]
 #
-# $dhcp_nameservers::           DHCP nameservers
+# $dhcp_nameservers::           DHCP nameservers, comma-separated
+#                               type:String
 #
 # $dhcp_server::                Address of DHCP server to manage
+#                               type:String
 #
 # $dhcp_config::                DHCP config file path
+#                               type:Stdlib::Absolutepath
 #
 # $dhcp_leases::                DHCP leases file
+#                               type:Stdlib::Absolutepath
 #
 # $dhcp_key_name::              DHCP key name
+#                               type:Optional[String]
 #
 # $dhcp_key_secret::            DHCP password
+#                               type:Optional[String]
 #
 # $dhcp_omapi_port::            DHCP server OMAPI port
-#                               type:integer
+#                               type:Integer[0, 65535]
 #
 # $dns::                        Enable DNS feature
-#                               type:boolean
+#                               type:Boolean
 #
 # $dns_listen_on::              DNS proxy to listen on https, http, or both
+#                               type:Foreman_proxy::ListenOn
 #
 # $dns_managed::                DNS is managed by Foreman proxy
-#                               type:boolean
+#                               type:Boolean
 #
 # $dns_provider::               DNS provider
+#                               type:String
 #
 # $dns_interface::              DNS interface
+#                               type:String
 #
 # $dns_zone::                   DNS zone name
+#                               type:String
 #
 # $dns_reverse::                DNS reverse zone name
+#                               type:String
 #
 # $dns_server::                 Address of DNS server to manage
+#                               type:String
 #
 # $dns_ttl::                    DNS default TTL override
+#                               type:Integer[0]
 #
 # $dns_tsig_keytab::            Kerberos keytab for DNS updates using GSS-TSIG authentication
+#                               type:String
 #
 # $dns_tsig_principal::         Kerberos principal for DNS updates using GSS-TSIG authentication
+#                               type:String
 #
 # $dns_forwarders::             DNS forwarders
-#                               type:array
+#                               type:Array[String]
 #
 # $libvirt_connection::         Connection string of libvirt DNS/DHCP provider (e.g. "qemu:///system")
+#                               type:String
 #
 # $libvirt_network::            Network for libvirt DNS/DHCP provider
+#                               type:String
 #
 # $bmc::                        Enable BMC feature
-#                               type:boolean
+#                               type:Boolean
 #
 # $bmc_listen_on::              BMC proxy to listen on https, http, or both
+#                               type:Foreman_proxy::ListenOn
 #
 # $bmc_default_provider::       BMC default provider.
+#                               type:String
 #
 # $keyfile::                    DNS server keyfile path
+#                               type:Stdlib::Absolutepath
 #
 # $realm::                      Enable realm management feature
-#                               type:boolean
+#                               type:Boolean
 #
 # $realm_listen_on::            Realm proxy to listen on https, http, or both
+#                               type:Foreman_proxy::ListenOn
 #
 # $realm_provider::             Realm management provider
+#                               type:String
 #
 # $realm_keytab::               Kerberos keytab path to authenticate realm updates
+#                               type:Stdlib::Absolutepath
 #
 # $realm_principal::            Kerberos principal for realm updates
+#                               type:String
 #
 # $freeipa_remove_dns::         Remove DNS entries from FreeIPA when deleting hosts from realm
-#                               type:boolean
+#                               type:Boolean
 #
 # $register_in_foreman::        Register proxy back in Foreman
-#                               type:boolean
+#                               type:Boolean
 #
 # $registered_name::            Proxy name which is registered in Foreman
+#                               type:String
 #
 # $registered_proxy_url::       Proxy URL which is registered in Foreman
+#                               type:Optional[Stdlib::HTTPUrl]
 #
 # $foreman_base_url::           Base Foreman URL used for REST interaction
+#                               type:Stdlib::HTTPUrl
 #
 # $oauth_effective_user::       User to be used for REST interaction
+#                               type:String
 #
 # $oauth_consumer_key::         OAuth key to be used for REST interaction
+#                               type:String
 #
 # $oauth_consumer_secret::      OAuth secret to be used for REST interaction
+#                               type:String
 #
 # $puppet_use_cache::           Whether to enable caching of puppet classes
-#                               type:boolean
+#                               type:Optional[Boolean]
 #
 class foreman_proxy (
   $repo                       = $foreman_proxy::params::repo,

--- a/manifests/plugin/abrt.pp
+++ b/manifests/plugin/abrt.pp
@@ -5,35 +5,44 @@
 # === Parameters:
 #
 # $abrt_send_log_file::         Log file for the forwarding script.
+#                               type:Stdlib::Absolutepath
 #
 # $spooldir::                   Directory where uReports are stored before they are sent
+#                               type:Stdlib::Absolutepath
 #
 # $aggregate_reports::          Merge duplicate reports before sending
+#                               type:Boolean
 #
 # $send_period::                Period (in seconds) after which collected reports are forwarded.
 #                               Meaningful only if smart-proxy-abrt-send is run as a daemon (not from cron).
-#                               type:integer
+#                               type:Integer[0]
 #
 # $faf_server_url::             FAF server instance the reports will be forwarded to
+#                               type:Optional[String]
 #
 # $faf_server_ssl_noverify::    Set to true if FAF server uses self-signed certificate
-#                               type:boolean
+#                               type:Boolean
 #
 # $faf_server_ssl_cert::        Enable client authentication to FAF server: set ssl certificate
+#                               type:Optional[Stdlib::Absolutepath]
 #
 # $faf_server_ssl_key::         Enable client authentication to FAF server: set ssl key
+#                               type:Optional[Stdlib::Absolutepath]
 #
 # === Advanced parameters:
 #
 # $enabled::                    Enables/disables the plugin
-#                               type:boolean
+#                               type:Boolean
 #
 # $group::                      group owner of the configuration file
+#                               type:Optional[String]
 #
 # $listen_on::                  Proxy feature listens on http, https, or both
+#                               type:Foreman_proxy::ListenOn
 #
 # $version::                    plugin package version, it's passed to ensure parameter of package resource
 #                               can be set to specific version number, 'latest', 'present' etc.
+#                               type:Optional[String]
 #
 class foreman_proxy::plugin::abrt (
   $enabled                 = $::foreman_proxy::plugin::abrt::params::enabled,

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -5,14 +5,17 @@
 # === Advanced parameters:
 #
 # $ansible_dir:: Ansible directory to search for available roles
+#                type:Stdlib::Absolutepath
 #
 # $working_dir:: A directory where the playbooks will be generated.
 #                A tmp directory will be created when left blank
+#                type:Optional[Stdlib::Absolutepath]
 #
 # $enabled::     Enables/disables the plugin
-#                type:boolean
+#                type:Boolean
 #
 # $listen_on::   Proxy feature listens on https, http, or both
+#                type:Foreman_proxy::ListenOn
 #
 class foreman_proxy::plugin::ansible (
   $enabled     = $::foreman_proxy::plugin::ansible::params::enabled,

--- a/manifests/plugin/chef.pp
+++ b/manifests/plugin/chef.pp
@@ -5,29 +5,37 @@
 # === Parameters:
 #
 # $server_url::   chef server url
+#                 type:Stdlib::HTTPUrl
 #
 # $client_name::  chef client name used for authentication of other client requests
+#                 type:String
 #
 # $private_key::  path to file containing private key for $client_name client
+#                 type:Stdlib::Absolutepath
 #
 # $ssl_verify::   should we perform chef server ssl cert verification? this requires
 #                 CA certificate installed and trusted
-#                 type:boolean
+#                 type:Boolean
 #
 # $ssl_pem_file:: if $ssl_verify is true you can specify a path to a file which
 #                 contains certificate and related private key if the certificate
 #                 is not globally trusted
+#                 type:Optional[Stdlib::Absolutepath]
 #
 # === Advanced parameters:
 #
 # $enabled::      enables/disables the plugin
+#                 type:Boolean
 #
 # $group::        group owner of the configuration file
+#                 type:Optional[String]
 #
 # $listen_on::    Proxy feature listens on http, https, or both
+#                 type:Foreman_proxy::ListenOn
 #
 # $version::      plugin package version, it's passed to ensure parameter of package resource
 #                 can be set to specific version number, 'latest', 'present' etc.
+#                 type:Optional[String]
 #
 class foreman_proxy::plugin::chef (
   $enabled      = $::foreman_proxy::plugin::chef::params::enabled,

--- a/manifests/plugin/dhcp/infoblox.pp
+++ b/manifests/plugin/dhcp/infoblox.pp
@@ -5,13 +5,16 @@
 # === Parameters:
 #
 # $username::    The username of the Infoblox user
+#                type:String
 #
 # $password::    The password of the Infoblox user
+#                type:String
 #
 # $record_type:: Record type to manage, can be "host" or "fixedaddress"
+#                type:Enum['host', 'fixedaddress']
 #
-# $use_ranges::  Use  pre-definded ranges in networks to find available IP's
-#                type:boolean
+# $use_ranges::  Use pre-definded ranges in networks to find available IP's
+#                type:Boolean
 #
 class foreman_proxy::plugin::dhcp::infoblox (
   $username    = $::foreman_proxy::plugin::dhcp::infoblox::params::username,

--- a/manifests/plugin/discovery.pp
+++ b/manifests/plugin/discovery.pp
@@ -5,13 +5,16 @@
 # === Parameters:
 #
 # $install_images::  should the discovery image be downloaded and extracted
-#                    type:boolean
+#                    type:Boolean
 #
 # $tftp_root::       tftp root to install image into
+#                    type:Stdlib::Absolutepath
 #
 # $source_url::      source URL to download from
+#                    type:Stdlib::HTTPUrl
 #
 # $image_name::      tarball with images
+#                    type:String
 #
 class foreman_proxy::plugin::discovery (
   $install_images = $::foreman_proxy::plugin::discovery::params::install_images,

--- a/manifests/plugin/dns/infoblox.pp
+++ b/manifests/plugin/dns/infoblox.pp
@@ -5,10 +5,13 @@
 # === Parameters:
 #
 # $dns_server:: The address of the Infoblox server
+#               type:String
 #
 # $username::   The username of the Infoblox user
+#               type:String
 #
 # $password::   The password of the Infoblox user
+#               type:String
 #
 class foreman_proxy::plugin::dns::infoblox (
   $dns_server = $::foreman_proxy::plugin::dns::infoblox::params::dns_server,

--- a/manifests/plugin/dns/powerdns.pp
+++ b/manifests/plugin/dns/powerdns.pp
@@ -5,23 +5,30 @@
 # === Parameters:
 #
 # $backend::               The backend to select, either mysql or postgresql.
+#                          type:Enum['mysql', 'postgresql']
 #
 # $mysql_hostname::        MySQL server hostname. Only used when the backend is mysql.
+#                          type:String
 #
 # $mysql_username::        MySQL server username. Only used when the backend is mysql.
+#                          type:String
 #
 # $mysql_password::        MySQL server password. Only used when the backend is mysql.
+#                          type:String
 #
 # $mysql_database::        MySQL server database. Only used when the backend is mysql.
+#                          type:String
 #
 # $postgresql_connection:: The postgresql connection string.
+#                          type:String
 #
 # $manage_database::       Whether to manage the database. Only works for
 #                          mysql. Includes the mysql server.
-#                          type:boolean
+#                          type:Boolean
 #
 # $pdnssec::               pdnssec command to run rectify-zone with. Can be an
 #                          empty string.
+#                          type:String
 #
 class foreman_proxy::plugin::dns::powerdns (
   $backend               = $::foreman_proxy::plugin::dns::powerdns::params::backend,

--- a/manifests/plugin/dynflow.pp
+++ b/manifests/plugin/dynflow.pp
@@ -5,21 +5,24 @@
 # === Parameters:
 #
 # $database_path::   Path to the SQLite database file
+#                    type:Stdlib::Absolutepath
 #
 # $console_auth::    Whether to enable trusted hosts and ssl for the dynflow console
-#                    type:boolean
+#                    type:Boolean
 #
 # === Advanced parameters:
 #
 # $enabled::         Enables/disables the plugin
-#                    type:boolean
+#                    type:Boolean
 #
 # $listen_on::       Proxy feature listens on https, http, or both
+#                    type:Foreman_proxy::ListenOn
 #
 # $core_listen::     Address to listen on for the dynflow core service
+#                    type:String
 #
 # $core_port::       Port to use for the local dynflow core service
-#                    type:integer
+#                    type:Integer[0, 65535]
 #
 class foreman_proxy::plugin::dynflow (
   $enabled           = $::foreman_proxy::plugin::dynflow::params::enabled,

--- a/manifests/plugin/monitoring.pp
+++ b/manifests/plugin/monitoring.pp
@@ -5,18 +5,22 @@
 # === Parameters:
 #
 # $provider::           monitoring provider
+#                       type:String
 #
 # === Advanced parameters:
 #
 # $enabled::            enables/disables the monitoring plugin
-#                       type:boolean
+#                       type:Boolean
 #
 # $group::              owner of plugin configuration
+#                       type:Optional[String]
 #
 # $listen_on::          proxy feature listens on http, https, or both
+#                       type:Foreman_proxy::ListenOn
 #
 # $version::            plugin package version, it's passed to ensure parameter of package resource
 #                       can be set to specific version number, 'latest', 'present' etc.
+#                       type:Optional[String]
 #
 class foreman_proxy::plugin::monitoring (
   $enabled            = $::foreman_proxy::plugin::monitoring::params::enabled,

--- a/manifests/plugin/omaha.pp
+++ b/manifests/plugin/omaha.pp
@@ -5,22 +5,28 @@
 # === Parameters:
 #
 # $contentpath::        Path where omaha content is stored
+#                       type:Stdlib::Absolutepath
 #
 # $sync_releases::      How many of the latest releases should be synced
+#                       type:Integer[0]
 #
 # $http_proxy::         URL to a proxy server that should be used to retrieve omaha content, e.g. 'http://proxy.example.com:3128/'
+#                       type:Optional[Stdlib::HTTPUrl]
 #
 # === Advanced parameters:
 #
 # $enabled::            enables/disables the omaha plugin
-#                       type:boolean
+#                       type:Boolean
 #
 # $group::              owner of plugin configuration
+#                       type:Optional[String]
 #
 # $listen_on::          proxy feature listens on http, https, or both
+#                       type:Foreman_proxy::ListenOn
 #
 # $version::            plugin package version, it's passed to ensure parameter of package resource
 #                       can be set to specific version number, 'latest', 'present' etc.
+#                       type:Optional[String]
 #
 class foreman_proxy::plugin::omaha (
   $enabled            = $::foreman_proxy::plugin::omaha::params::enabled,

--- a/manifests/plugin/openscap.pp
+++ b/manifests/plugin/openscap.pp
@@ -5,30 +5,38 @@
 # === Parameters:
 #
 # $configure_openscap_repo::    Enable custom yum repo with packages needed for smart_proxy_openscap,
-#                               type:boolean
+#                               type:Boolean
 #
 # $openscap_send_log_file::     Log file for the forwarding script
+#                               type:Stdlib::Absolutepath
 #
 # $spooldir::                   Directory where OpenSCAP audits are stored
 #                               before they are forwarded to Foreman
+#                               type:Stdlib::Absolutepath
 #
 # $contentdir::                 Directory where OpenSCAP content XML are stored
 #                               So we will not request the XML from Foreman each time
+#                               type:Stdlib::Absolutepath
 #
 # $reportsdir::                 Directory where OpenSCAP report XML are stored
 #                               So Foreman can request arf xml reports
+#                               type:Stdlib::Absolutepath
 #
 # $failed_dir::                 Directory where OpenSCAP report XML are stored
 #                               In case sending to Foreman succeeded, yet failed to save to reportsdir
+#                               type:Stdlib::Absolutepath
+#
 # === Advanced parameters:
 #
 # $enabled::                    enables/disables the plugin
-#                               type:boolean
+#                               type:Boolean
 #
 # $listen_on::                  Proxy feature listens on http, https, or both
+#                               type:Foreman_proxy::ListenOn
 #
 # $version::                    plugin package version, it's passed to ensure parameter of package resource
 #                               can be set to specific version number, 'latest', 'present' etc.
+#                               type:Optional[String]
 #
 class foreman_proxy::plugin::openscap (
   $configure_openscap_repo = $::foreman_proxy::plugin::openscap::params::configure_openscap_repo,

--- a/manifests/plugin/pulp.pp
+++ b/manifests/plugin/pulp.pp
@@ -5,27 +5,35 @@
 # === Advanced parameters:
 #
 # $enabled::            enables/disables the pulp plugin
-#                       type:boolean
+#                       type:Boolean
 #
 # $group::              group owner of the configuration file
+#                       type:Optional[String]
 #
 # $listen_on::          proxy feature listens on http, https, or both
+#                       type:Foreman_proxy::ListenOn
 #
 # $version::            plugin package version, it's passed to ensure parameter of package resource
 #                       can be set to specific version number, 'latest', 'present' etc.
+#                       type:Optional[String]
 #
 # $pulp_url::           pulp url to use
+#                       type:Stdlib::HTTPUrl
 #
 # $pulp_dir::           directory for pulp
+#                       type:Stdlib::Absolutepath
 #
 # $pulp_content_dir::   directory for pulp content
+#                       type:Stdlib::Absolutepath
 #
 # $pulpnode_enabled::   enables/disables the pulpnode plugin
-#                       type:boolean
+#                       type:Boolean
 #
 # $puppet_content_dir:: directory for puppet content
+#                       type:Stdlib::Absolutepath
 #
 # $mongodb_dir::        directory for Mongo DB
+#                       type:Stdlib::Absolutepath
 #
 class foreman_proxy::plugin::pulp (
   $enabled            = $::foreman_proxy::plugin::pulp::params::enabled,

--- a/manifests/plugin/salt.pp
+++ b/manifests/plugin/salt.pp
@@ -5,28 +5,36 @@
 # === Parameters:
 #
 # $autosign_file::   File to use for salt autosign
+#                    type:Stdlib::Absolutepath
 #
 # $user::            User to run salt commands under
+#                    type:String
 #
 # $api::             Use Salt API
-#                    type:boolean
+#                    type:Boolean
 #
 # $api_url::         Salt API URL
+#                    type:Stdlib::HTTPUrl
 #
 # $api_auth::        Salt API auth mechanism
+#                    type:String
 #
 # $api_username::    Salt API username
+#                    type:String
 #
 # $api_password::    Salt API password
+#                    type:String
 #
 # === Advanced parameters:
 #
 # $enabled::         Enables/disables the plugin
-#                    type:boolean
+#                    type:Boolean
 #
 # $group::           Owner of plugin configuration
+#                    type:Optional[String]
 #
 # $listen_on::       Proxy feature listens on https, http, or both
+#                    type:Foreman_proxy::ListenOn
 #
 class foreman_proxy::plugin::salt (
   $autosign_file     = $::foreman_proxy::plugin::salt::params::autosign_file,

--- a/spec/aliases/listen_on_spec.rb
+++ b/spec/aliases/listen_on_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+if Puppet.version.to_f >= 4.5
+  describe 'test::listen_on', type: :class do
+    describe 'valid handling' do
+      %w{
+        http
+        https
+        both
+      }.each do |value|
+        describe value.inspect do
+          let(:params) {{ value: value }}
+          it { is_expected.to compile }
+        end
+      end
+    end
+
+    describe 'invalid value handling' do
+      context 'garbage inputs' do
+        [
+          nil,
+          "all",
+          "htt",
+        ].each do |value|
+          describe value.inspect do
+            let(:params) {{ value: value }}
+            it { is_expected.to compile.and_raise_error(/parameter 'value' expects a match for Foreman_proxy::ListenOn/) }
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/spec/static_fixtures/test_module/manifests/listen_on.pp
+++ b/spec/static_fixtures/test_module/manifests/listen_on.pp
@@ -1,0 +1,6 @@
+# Class to test the Foreman_proxy::ListenOn type
+class test::listen_on(
+  Foreman_proxy::ListenOn $value,
+) {
+  notice("Success")
+}

--- a/types/listenon.pp
+++ b/types/listenon.pp
@@ -1,0 +1,1 @@
+type Foreman_proxy::ListenOn = Enum['http', 'https', 'both']


### PR DESCRIPTION
Supported since Kafo 1.0.0, it performs more precise validation of
parameter values and can later be moved to the parameter definitions
when the module is made Puppet 4-only.

---

The odd testing of the type alias matches how stdlib's doing it, but in future rspec-puppet versions will hopefully be possible directly.