### PR TITLE
Fixes #16705 - copy signed grubx64.efi from /boot

### DIFF
--- a/manifests/tftp.pp
+++ b/manifests/tftp.pp
@@ -29,8 +29,6 @@ class foreman_proxy::tftp {
       } else {
         $grub_type = 'redhat'
       }
-      # taken from http://pkgs.fedoraproject.org/cgit/rpms/grub2.git/tree/grub2.spec
-      $grub_modules = 'all_video boot btrfs cat chain configfile echo efifwsetup efinet ext2 fat font gfxmenu gfxterm gzio halt hfsplus iso9660 jpeg loadenv loopback lvm mdraid09 mdraid1x minicmd normal part_apple part_msdos part_gpt password_pbkdf2 png reboot search search_fs_uuid search_fs_file search_label serial sleep syslinuxcfg test tftp video xfs linux backtrace usb usbserial_common usbserial_pl2303 usbserial_ftdi usbserial_usbdebug linuxefi'
     }
     'Debian': {
       $grub_type = 'debian'
@@ -67,14 +65,9 @@ class foreman_proxy::tftp {
     'redhat': {
       ensure_packages(['grub2-efi','grub2-efi-modules','grub2-tools','shim'], { ensure => 'installed', })
 
-      exec {'build-grub2-efi-image':
-        command => "/usr/bin/grub2-mkimage -O x86_64-efi -d ${efi_dir} -o ${foreman_proxy::tftp_root}/grub2/grubx64.efi -p '' ${grub_modules}",
-        creates => "${foreman_proxy::tftp_root}/grub2/grubx64.efi",
-        require => [File[$foreman_proxy::tftp_dirs], Package['grub2-tools']],
-      } ->
-      file {"${foreman_proxy::tftp_root}/grub2/grubx64.efi":
-        mode  => '0644',
-        owner => 'root',
+      foreman_proxy::tftp::copy_file{"/boot/efi/EFI/${grub_efi_path}/grubx64.efi":
+        target_path => "${foreman_proxy::tftp_root}/grub2",
+        require     => File[$foreman_proxy::tftp_dirs],
       }
 
       foreman_proxy::tftp::copy_file{"/boot/efi/EFI/${grub_efi_path}/shim.efi":

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -324,24 +324,25 @@ describe 'foreman_proxy::config' do
             it { should contain_package('grub2-efi-modules').with_ensure('installed') }
             it { should contain_package('grub2-tools').with_ensure('installed') }
             it { should contain_package('shim').with_ensure('installed') }
-            it 'should generate efi image from grub2 modules' do
-              should contain_exec('build-grub2-efi-image').
-                with_creates("#{tftp_root}/grub2/grubx64.efi")
-              should contain_file("#{tftp_root}/grub2/grubx64.efi").
-                with_mode('0644').
-                with_owner('root').
-                that_requires('Exec[build-grub2-efi-image]')
-            end
             case facts[:operatingsystem]
               when /^(RedHat|Scientific|OracleLinux)$/
+                it 'should copy the grubx64.efi for Red Hat and clones' do
+                  should contain_foreman_proxy__tftp__copy_file('/boot/efi/EFI/redhat/grubx64.efi')
+                end
                 it 'should copy the shim.efi for Red Hat and clones' do
                   should contain_foreman_proxy__tftp__copy_file('/boot/efi/EFI/redhat/shim.efi')
                 end
               when 'Fedora'
+                it 'should copy the grubx64.efi for Red Hat and clones' do
+                  should contain_foreman_proxy__tftp__copy_file('/boot/efi/EFI/fedora/grubx64.efi')
+                end
                 it 'should copy the shim.efi for Fedora' do
                   should contain_foreman_proxy__tftp__copy_file('/boot/efi/EFI/fedora/shim.efi')
                 end
               when 'CentOS'
+                it 'should copy the grubx64.efi for Red Hat and clones' do
+                  should contain_foreman_proxy__tftp__copy_file('/boot/efi/EFI/centos/grubx64.efi')
+                end
                 it 'should copy the shim.efi for CentOS' do
                   should contain_foreman_proxy__tftp__copy_file('/boot/efi/EFI/centos/shim.efi')
                 end


### PR DESCRIPTION
Building from scratch creates unsigned file which does not load with
SecureBoot. This change rather copies it from /boot folder.