### PR TITLE
Fixes #17631 - Validate realms/puppetrun providers

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,7 +122,7 @@
 #                               type:Foreman_proxy::ListenOn
 #
 # $puppetrun_provider::         Provider for running/kicking Puppet agents
-#                               type:Optional[String]
+#                               type:Optional[Enum['puppetrun', 'mcollective', 'ssh', 'salt', 'customrun']]
 #
 # $puppetrun_cmd::              Puppet run/kick command to be allowed in sudoers
 #                               type:String
@@ -316,7 +316,7 @@
 #                               type:Foreman_proxy::ListenOn
 #
 # $bmc_default_provider::       BMC default provider.
-#                               type:String
+#                               type:Enum['ipmitool', 'freeipmi', 'shell']
 #
 # $keyfile::                    DNS server keyfile path
 #                               type:Stdlib::Absolutepath
@@ -328,7 +328,7 @@
 #                               type:Foreman_proxy::ListenOn
 #
 # $realm_provider::             Realm management provider
-#                               type:String
+#                               type:Enum['freeipa']
 #
 # $realm_keytab::               Kerberos keytab path to authenticate realm updates
 #                               type:Stdlib::Absolutepath
@@ -505,6 +505,7 @@ class foreman_proxy (
   }
   if $puppetrun_provider {
     validate_string($puppetrun_provider)
+    validate_re($puppetrun_provider, '^puppetrun|mcollective|ssh|salt|customrun$', 'Invalid provider: choose puppetrun, mcollective, ssh, salt or customrun')
   }
 
   # Validate template params
@@ -548,6 +549,7 @@ class foreman_proxy (
   # Validate realm params
   validate_bool($freeipa_remove_dns)
   validate_string($realm_provider, $realm_principal)
+  validate_re($realm_provider, '^freeipa$', 'Invalid provider: choose freeipa')
   validate_absolute_path($realm_keytab)
 
   $real_registered_proxy_url = pick($registered_proxy_url, "https://${::fqdn}:${ssl_port}")

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -512,6 +512,17 @@ describe 'foreman_proxy::config' do
         end
       end
 
+      context 'with invalid realm provider' do
+        let :pre_condition do
+          'class {"foreman_proxy":
+            realm => true,
+            realm_provider => "invalid",
+          }'
+        end
+
+        it { expect { subject.call } .to raise_error(/Invalid provider: choose freeipa/) }
+      end
+
       context 'with tftp_managed enabled and tftp_syslinux_filenames set' do
         let :pre_condition do
           'class {"foreman_proxy":
@@ -735,6 +746,16 @@ describe 'foreman_proxy::config' do
             ':use_environment_api: false',
           ])
         end
+      end
+
+      context 'when puppetrun_provider => invalid' do
+        let :pre_condition do
+          'class {"foreman_proxy":
+            puppetrun_provider => "invalid",
+          }'
+        end
+
+        it { expect { subject.call } .to raise_error(/Invalid provider: choose puppetrun, mcollective, ssh, salt or customrun/) }
       end
 
       context 'with puppet use_cache enabled' do


### PR DESCRIPTION
This commit adds checks for the dhcp/dns/realms providers so that they
have to be compliant with a certain regex in order to be accepted as
parameters.

---- 

I know the values can come from plugins, and we effectively have no way of validating that the value doesn't come from a plugin. My argument is that in that case, the providers that come from plugins should be added to this repo to add the validation. 

Otherwise if you install a new plugin that provides a provider you manage the configuration yourself. It's nothing new, we already do this with the BMC provider (it's validated prior to this PR)

I can see how people can get frustrated by having their entire installation (if the proxy fails, the installation fails) aborted for getting such a minor thing wrong.