### PR TITLE
Configure ansible for ansible proxy plugin

### DIFF
--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -31,6 +31,14 @@ class foreman_proxy::plugin::ansible (
     validate_absolute_path($working_dir)
   }
 
+  file {"${::foreman_proxy::dir}/.ansible.cfg":
+    ensure  => file,
+    content => template('foreman_proxy/plugin/ansible.cfg.erb'),
+    owner   => 'root',
+    group   => $::foreman_proxy::user,
+    mode    => '0640',
+  }
+
   include ::foreman_proxy::plugin::dynflow
 
   foreman_proxy::plugin { 'ansible':

--- a/manifests/plugin/ansible/params.pp
+++ b/manifests/plugin/ansible/params.pp
@@ -3,5 +3,5 @@ class foreman_proxy::plugin::ansible::params {
   $enabled     = true
   $listen_on   = 'https'
   $ansible_dir = '/etc/ansible'
-  $working_dir = undef
+  $working_dir = '/tmp'
 }

--- a/spec/classes/foreman_proxy__plugin__ansible_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__ansible_spec.rb
@@ -18,6 +18,13 @@ describe 'foreman_proxy::plugin::ansible' do
         with_content(/:enabled: https/).
         with_content(%r{:ansible_dir: /etc/ansible})
     end
+
+    it 'should configure ansible.cfg' do
+      should contain_file('/usr/share/foreman-proxy/.ansible.cfg').
+        with_content(%r{[default]}).
+        with_content(%r{callback_whitelist = foreman}).
+        with_content(%r{local_tmp = /tmp})
+    end
   end
 
   describe 'with override parameters' do
@@ -29,7 +36,7 @@ describe 'foreman_proxy::plugin::ansible' do
       {
         :enabled     => true,
         :ansible_dir => '/etc/ansible-test',
-        :working_dir => '/tmp'
+        :working_dir => '/tmp/ansible'
       }
     end
 
@@ -39,7 +46,14 @@ describe 'foreman_proxy::plugin::ansible' do
       should contain_file('/etc/foreman-proxy/settings.d/ansible.yml').
         with_content(/:enabled: https/).
         with_content(%r{:ansible_dir: /etc/ansible-test}).
-        with_content(%r{:working_dir: /tmp})
+        with_content(%r{:working_dir: /tmp/ansible})
+    end
+
+    it 'should configure ansible.cfg' do
+      should contain_file('/usr/share/foreman-proxy/.ansible.cfg').
+        with_content(%r{[default]}).
+        with_content(%r{callback_whitelist = foreman}).
+        with_content(%r{local_tmp = /tmp/ansible})
     end
   end
 end

--- a/templates/plugin/ansible.cfg.erb
+++ b/templates/plugin/ansible.cfg.erb
@@ -1,0 +1,3 @@
+[defaults]
+callback_whitelist = foreman
+local_tmp = <%= @working_dir %>


### PR DESCRIPTION
If the ansible proxy plugin is installed, this will make sure that
ansible is installed on the proxy and configured to use the foreman
callback plugin.