### PR TITLE
Fixes #16148 - unify plugins description

### DIFF
--- a/manifests/plugin/abrt.pp
+++ b/manifests/plugin/abrt.pp
@@ -31,7 +31,7 @@
 #
 # === Advanced parameters:
 #
-# $enabled::                    Enables/disables the plugin
+# $enabled::                    Enables/disables the abrt plugin
 #                               type:Boolean
 #
 # $group::                      group owner of the configuration file

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -11,7 +11,7 @@
 #                A tmp directory will be created when left blank
 #                type:Optional[Stdlib::Absolutepath]
 #
-# $enabled::     Enables/disables the plugin
+# $enabled::     Enables/disables the ansible plugin
 #                type:Boolean
 #
 # $listen_on::   Proxy feature listens on https, http, or both

--- a/manifests/plugin/chef.pp
+++ b/manifests/plugin/chef.pp
@@ -24,7 +24,7 @@
 #
 # === Advanced parameters:
 #
-# $enabled::      enables/disables the plugin
+# $enabled::      enables/disables the chef plugin
 #                 type:Boolean
 #
 # $group::        group owner of the configuration file

--- a/manifests/plugin/dynflow.pp
+++ b/manifests/plugin/dynflow.pp
@@ -12,7 +12,7 @@
 #
 # === Advanced parameters:
 #
-# $enabled::         Enables/disables the plugin
+# $enabled::         Enables/disables the dynflow plugin
 #                    type:Boolean
 #
 # $listen_on::       Proxy feature listens on https, http, or both

--- a/manifests/plugin/openscap.pp
+++ b/manifests/plugin/openscap.pp
@@ -28,7 +28,7 @@
 #
 # === Advanced parameters:
 #
-# $enabled::                    enables/disables the plugin
+# $enabled::                    enables/disables the openscap plugin
 #                               type:Boolean
 #
 # $listen_on::                  Proxy feature listens on http, https, or both

--- a/manifests/plugin/salt.pp
+++ b/manifests/plugin/salt.pp
@@ -27,7 +27,7 @@
 #
 # === Advanced parameters:
 #
-# $enabled::         Enables/disables the plugin
+# $enabled::         Enables/disables the salt plugin
 #                    type:Boolean
 #
 # $group::           Owner of plugin configuration


### PR DESCRIPTION
During the discussion with the reporter of the issue we discovered that some plugins mention the name which makes the description clearer so I'm sending a PR that unifies the enable parameter description. The ticket is now in kafo project but very likely will be moved or closed. Feel free to wait with merging until it's in right project.