### PR TITLE
Adding $use_sudoers bool

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -114,7 +114,7 @@ class foreman_proxy::config {
         mode    => '0440',
         content => template('foreman_proxy/sudo.erb'),
       }
-    } else {
+    } elsif $foreman_proxy::use_sudoers {
       augeas { 'sudo-foreman-proxy':
         context => "/files${::foreman_proxy::sudoers}",
         changes => template('foreman_proxy/sudo_augeas.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,7 +93,7 @@
 # $use_sudoersd::               Add a file to /etc/sudoers.d (true).
 #                               type:Boolean
 #
-# $use_sudoers::                Add contents to /etc/sudoers (true).
+# $use_sudoers::                Add contents to /etc/sudoers (true). This is ignored if $use_sudoersd is true.
 #                               type:Boolean
 #
 # $puppetca::                   Enable Puppet CA feature

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,7 +90,10 @@
 #                               disabled to let a dedicated sudo module manage it instead.
 #                               type:Boolean
 #
-# $use_sudoersd::               Add a file to /etc/sudoers.d (true) or uses augeas (false)
+# $use_sudoersd::               Add a file to /etc/sudoers.d (true).
+#                               type:Boolean
+#
+# $use_sudoers::                Add contents to /etc/sudoers (true).
 #                               type:Boolean
 #
 # $puppetca::                   Enable Puppet CA feature
@@ -392,6 +395,7 @@ class foreman_proxy (
   $ssl_disabled_ciphers       = $foreman_proxy::params::ssl_disabled_ciphers,
   $manage_sudoersd            = $foreman_proxy::params::manage_sudoersd,
   $use_sudoersd               = $foreman_proxy::params::use_sudoersd,
+  $use_sudoers                = $foreman_proxy::params::use_sudoers,
   $puppetca                   = $foreman_proxy::params::puppetca,
   $puppetca_listen_on         = $foreman_proxy::params::puppetca_listen_on,
   $ssldir                     = $foreman_proxy::params::ssldir,
@@ -485,7 +489,7 @@ class foreman_proxy (
 
   # Validate misc params
   validate_string($bind_host)
-  validate_bool($ssl, $manage_sudoersd, $use_sudoersd, $register_in_foreman, $manage_puppet_group)
+  validate_bool($ssl, $manage_sudoersd, $use_sudoers, $use_sudoersd, $register_in_foreman, $manage_puppet_group)
   validate_array($trusted_hosts, $ssl_disabled_ciphers, $groups)
   validate_re($log_level, '^(UNKNOWN|FATAL|ERROR|WARN|INFO|DEBUG)$')
   validate_re($plugin_version, '^(installed|present|latest|absent)$')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -199,10 +199,6 @@ class foreman_proxy::params {
 
   $sudoers = "${etc}/sudoers"
 
-  # Whether to manage File["$etc/sudoers"] or not.  When reusing this module,
-  # this may be disabled to let a dedicated sudo module manage it instead.
-  $manage_sudoers = true
-
   # Whether to manage File["$etc/sudoers.d"] or not.  When reusing this module,
   # this may be disabled to let a dedicated sudo module manage it instead.
   $manage_sudoersd = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -199,12 +199,22 @@ class foreman_proxy::params {
 
   $sudoers = "${etc}/sudoers"
 
+  # Whether to manage File["$etc/sudoers"] or not.  When reusing this module,
+  # this may be disabled to let a dedicated sudo module manage it instead.
+  $manage_sudoers = true
+
   # Whether to manage File["$etc/sudoers.d"] or not.  When reusing this module,
   # this may be disabled to let a dedicated sudo module manage it instead.
   $manage_sudoersd = true
 
-  # Add a file to /etc/sudoers.d (true) or uses augeas (false)
+  # Setting both $use_sudoersd and $use_sudoers to false means this module will not
+  # touch any sudoers entries. Setting both to true will result in sudoersd winning.
+  # Add a file to /etc/sudoers.d (true).
   $use_sudoersd = true
+
+  # Add contents to /etc/sudoers (true). Defaults to false.
+  $use_sudoers = false
+
 
   # puppet settings
   $puppet_url                 = "https://${::fqdn}:8140"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -208,9 +208,8 @@ class foreman_proxy::params {
   # Add a file to /etc/sudoers.d (true).
   $use_sudoersd = true
 
-  # Add contents to /etc/sudoers (true). Defaults to false.
-  $use_sudoers = false
-
+  # Add contents to /etc/sudoers (true, only if $use_sudoers is false).
+  $use_sudoers = true
 
   # puppet settings
   $puppet_url                 = "https://${::fqdn}:8140"

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -962,6 +962,7 @@ describe 'foreman_proxy::config' do
             let :pre_condition do
               'class {"foreman_proxy":
                 use_sudoers  => true,
+                use_sudoersd => false,
                 puppetca     => false,
               }'
             end
@@ -980,6 +981,7 @@ describe 'foreman_proxy::config' do
             let :pre_condition do
               'class {"foreman_proxy":
                 use_sudoers        => true,
+                use_sudoersd       => false,
                 puppetrun_provider => "puppetrun",
               }'
             end

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -927,7 +927,7 @@ describe 'foreman_proxy::config' do
           end
 
           it "should not modify #{etc_dir}/sudoers" do
-            should_not contain_file("#{{etc_dir}/sudoers}")
+            should_not contain_file("#{etc_dir}/sudoers")
           end
         end
 

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -946,7 +946,7 @@ describe 'foreman_proxy::config' do
           end
 
           it "should not modify #{etc_dir}/sudoers" do
-            should_not contain_file("#{etc_dir}/sudoers")
+            should_not contain_augeas('sudo-foreman-proxy')
           end
         end
 

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -927,7 +927,7 @@ describe 'foreman_proxy::config' do
           end
 
           it "should not modify #{etc_dir}/sudoers" do
-            should_not contain_fail("#{{etc_dir}/sudoers}")
+            should_not contain_file("#{{etc_dir}/sudoers}")
           end
         end
 

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -918,6 +918,25 @@ describe 'foreman_proxy::config' do
           should_not contain_file("#{etc_dir}/sudoers.d/foreman-proxy")
         end
 
+        it "should modify #{etc_dir}/sudoers" do
+          should contain_augeas('sudo-foreman-proxy').with({
+            :context  => "/files#{etc_dir}/sudoers",
+          })
+
+          changes = catalogue.resource('augeas', 'sudo-foreman-proxy').send(:parameters)[:changes]
+          changes.split("\n").should == [
+            "set spec[user = '#{proxy_user_name}'][1]/user #{proxy_user_name}",
+            "set spec[user = '#{proxy_user_name}'][1]/host_group/host ALL",
+            "set spec[user = '#{proxy_user_name}'][1]/host_group/command '#{puppetca_command}'",
+            "set spec[user = '#{proxy_user_name}'][1]/host_group/command/runas_user root",
+            "set spec[user = '#{proxy_user_name}'][1]/host_group/command/tag NOPASSWD",
+            "rm spec[user = '#{proxy_user_name}'][1]/host_group/command[position() > 1]",
+            "rm spec[user = '#{proxy_user_name}'][position() > 1]",
+            "set Defaults[type = ':#{proxy_user_name}']/type :#{proxy_user_name}",
+            "set Defaults[type = ':#{proxy_user_name}']/requiretty/negate ''",
+          ]
+        end
+
         context 'when use_sudoers => false' do
           let :pre_condition do
             'class {"foreman_proxy":
@@ -931,19 +950,33 @@ describe 'foreman_proxy::config' do
           end
         end
 
-        context 'when use_sudoers => true' do
+        context 'when puppetca => false' do
           let :pre_condition do
             'class {"foreman_proxy":
-              use_sudoers  => true,
               use_sudoersd => false,
+              puppetca     => false,
             }'
           end
 
-          it "should modify #{etc_dir}/sudoers" do
-            should contain_augeas('sudo-foreman-proxy').with({
-              :context  => "/files#{etc_dir}/sudoers",
-            })
+          it "should remove all rules from #{etc_dir}/sudoers" do
+            changes = catalogue.resource('augeas', 'sudo-foreman-proxy').send(:parameters)[:changes]
+            changes.split("\n").should == [
+              "rm spec[user = '#{proxy_user_name}'][position() > 0]",
+              "set Defaults[type = ':#{proxy_user_name}']/type :#{proxy_user_name}",
+              "set Defaults[type = ':#{proxy_user_name}']/requiretty/negate ''",
+            ]
+          end
+        end
 
+        context 'when puppetrun_provider == puppetrun' do
+          let :pre_condition do
+            'class {"foreman_proxy":
+              use_sudoersd       => false,
+              puppetrun_provider => "puppetrun",
+            }'
+          end
+
+          it "should modify #{etc_dir}/sudoers for puppetca and puppetrun" do
             changes = catalogue.resource('augeas', 'sudo-foreman-proxy').send(:parameters)[:changes]
             changes.split("\n").should == [
               "set spec[user = '#{proxy_user_name}'][1]/user #{proxy_user_name}",
@@ -952,60 +985,16 @@ describe 'foreman_proxy::config' do
               "set spec[user = '#{proxy_user_name}'][1]/host_group/command/runas_user root",
               "set spec[user = '#{proxy_user_name}'][1]/host_group/command/tag NOPASSWD",
               "rm spec[user = '#{proxy_user_name}'][1]/host_group/command[position() > 1]",
-              "rm spec[user = '#{proxy_user_name}'][position() > 1]",
+              "set spec[user = '#{proxy_user_name}'][2]/user #{proxy_user_name}",
+              "set spec[user = '#{proxy_user_name}'][2]/host_group/host ALL",
+              "set spec[user = '#{proxy_user_name}'][2]/host_group/command '#{puppetrun_command}'",
+              "set spec[user = '#{proxy_user_name}'][2]/host_group/command/runas_user root",
+              "set spec[user = '#{proxy_user_name}'][2]/host_group/command/tag NOPASSWD",
+              "rm spec[user = '#{proxy_user_name}'][2]/host_group/command[position() > 1]",
+              "rm spec[user = '#{proxy_user_name}'][position() > 2]",
               "set Defaults[type = ':#{proxy_user_name}']/type :#{proxy_user_name}",
               "set Defaults[type = ':#{proxy_user_name}']/requiretty/negate ''",
             ]
-          end
-
-          context 'when puppetca => false' do
-            let :pre_condition do
-              'class {"foreman_proxy":
-                use_sudoers  => true,
-                use_sudoersd => false,
-                puppetca     => false,
-              }'
-            end
-
-            it "should remove all rules from #{etc_dir}/sudoers" do
-              changes = catalogue.resource('augeas', 'sudo-foreman-proxy').send(:parameters)[:changes]
-              changes.split("\n").should == [
-                "rm spec[user = '#{proxy_user_name}'][position() > 0]",
-                "set Defaults[type = ':#{proxy_user_name}']/type :#{proxy_user_name}",
-                "set Defaults[type = ':#{proxy_user_name}']/requiretty/negate ''",
-              ]
-            end
-          end
-
-          context 'when puppetrun_provider == puppetrun' do
-            let :pre_condition do
-              'class {"foreman_proxy":
-                use_sudoers        => true,
-                use_sudoersd       => false,
-                puppetrun_provider => "puppetrun",
-              }'
-            end
-
-            it "should modify #{etc_dir}/sudoers for puppetca and puppetrun" do
-              changes = catalogue.resource('augeas', 'sudo-foreman-proxy').send(:parameters)[:changes]
-              changes.split("\n").should == [
-                "set spec[user = '#{proxy_user_name}'][1]/user #{proxy_user_name}",
-                "set spec[user = '#{proxy_user_name}'][1]/host_group/host ALL",
-                "set spec[user = '#{proxy_user_name}'][1]/host_group/command '#{puppetca_command}'",
-                "set spec[user = '#{proxy_user_name}'][1]/host_group/command/runas_user root",
-                "set spec[user = '#{proxy_user_name}'][1]/host_group/command/tag NOPASSWD",
-                "rm spec[user = '#{proxy_user_name}'][1]/host_group/command[position() > 1]",
-                "set spec[user = '#{proxy_user_name}'][2]/user #{proxy_user_name}",
-                "set spec[user = '#{proxy_user_name}'][2]/host_group/host ALL",
-                "set spec[user = '#{proxy_user_name}'][2]/host_group/command '#{puppetrun_command}'",
-                "set spec[user = '#{proxy_user_name}'][2]/host_group/command/runas_user root",
-                "set spec[user = '#{proxy_user_name}'][2]/host_group/command/tag NOPASSWD",
-                "rm spec[user = '#{proxy_user_name}'][2]/host_group/command[position() > 1]",
-                "rm spec[user = '#{proxy_user_name}'][position() > 2]",
-                "set Defaults[type = ':#{proxy_user_name}']/type :#{proxy_user_name}",
-                "set Defaults[type = ':#{proxy_user_name}']/requiretty/negate ''",
-              ]
-            end
           end
         end
       end


### PR DESCRIPTION
This change is because the "puppet" bool is used to control two different actions (configure puppet module in the smart proxy and add content to sudoers or sudoers.d) and should be separated in certain circumstances:

* Company policy may not allow for non-hostsec people to modify sudoers or sudoers.d (or, another process already controls those contents).
* Augeas in Puppet 3 cannot handle the "!$Cmnd_Alias" option in sudoers. (Note: This is solved in Puppet 4)

I created $use_sudoers (which is **very** similar to $use_sudoers**d**) to tell the module whether or not it can touch /etc/sudoers. If you set both $use_sudoersd and $use_sudoers to true, then the module should touch sudoers.d (due to the if/else statement's order). If you set them both to false, the module will leave sudoers and sudoers.d alone.

Opened a feature request about this: http://projects.theforeman.org/issues/18142