### PR TITLE
Allow bind_hosts to be an array of interfaces

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,7 +24,7 @@
 #                               type:Enum['latest', 'present', 'installed', 'absent']
 #
 # $bind_host::                  Host to bind ports to, e.g. *, localhost, 0.0.0.0
-#                               type:String
+#                               type:Variant[Array[String], String]
 #
 # $http::                       Enable HTTP
 #                               type:Boolean
@@ -488,7 +488,10 @@ class foreman_proxy (
 ) inherits foreman_proxy::params {
 
   # Validate misc params
-  validate_string($bind_host)
+  unless is_array($bind_host) {
+    validate_string($bind_host)
+    warning('foreman_proxy::bind_host should be changed to an array, support for string only is deprecated')
+  }
   validate_bool($ssl, $manage_sudoersd, $use_sudoers, $use_sudoersd, $register_in_foreman, $manage_puppet_group)
   validate_array($trusted_hosts, $ssl_disabled_ciphers, $groups)
   validate_re($log_level, '^(UNKNOWN|FATAL|ERROR|WARN|INFO|DEBUG)$')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -170,7 +170,7 @@ class foreman_proxy::params {
   $plugin_version          = 'installed'
 
   # Enable listening on http
-  $bind_host = '*'
+  $bind_host = ['*']
   $http      = false
   $http_port = '8000'
 

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -586,6 +586,36 @@ describe 'foreman_proxy::config' do
         end
       end
 
+      context 'bind_host set to string' do
+        let :pre_condition do
+          'class {"foreman_proxy":
+            bind_host => "*",
+          }'
+        end
+
+        it 'should set bind_host to a string' do
+          verify_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.yml", [
+            ':bind_host: \'*\'',
+          ])
+        end
+      end
+
+      context 'bind_host set to array' do
+        let :pre_condition do
+          'class {"foreman_proxy":
+            bind_host => ["eth0", "192.168.0.1"],
+          }'
+        end
+
+        it 'should set bind_host to an array' do
+          verify_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.yml", [
+            ':bind_host:',
+            '  - "eth0"',
+            '  - "192.168.0.1"',
+          ])
+        end
+      end
+
       context 'when dns_provider => libvirt' do
         let :pre_condition do
           'class {"foreman_proxy":

--- a/templates/settings.yml.erb
+++ b/templates/settings.yml.erb
@@ -82,8 +82,20 @@
 #:daemon_pid: /var/run/foreman-proxy/foreman-proxy.pid
 
 # host and ports configuration
-# Host or IPs to bind on (e.g. *, localhost, 0.0.0.0, ::, 192.168.1.20)
+<%# Write bind_host as a string if given a single-element array for 1.14 compatibility -%>
+<% if scope.lookupvar("foreman_proxy::bind_host").is_a?(String) -%>
+# Host or IP to bind ports to (e.g. *, localhost, 0.0.0.0, ::, 192.168.1.20)
 :bind_host: '<%= scope.lookupvar("foreman_proxy::bind_host") %>'
+<% elsif scope.lookupvar("foreman_proxy::bind_host").length == 1 -%>
+# Host or IP to bind ports to (e.g. *, localhost, 0.0.0.0, ::, 192.168.1.20)
+:bind_host: '<%= scope.lookupvar("foreman_proxy::bind_host").first %>'
+<% else -%>
+# An array of hosts or IPs to bind ports to (e.g. *, localhost, 0.0.0.0, ::, 192.168.1.20)
+:bind_host:
+<% scope.lookupvar("foreman_proxy::bind_host").each do |h| -%>
+<%= "  - #{h.inspect}" %>
+<% end -%>
+<% end -%>
 # http is disabled by default. To enable, uncomment 'http_port' setting
 # https is enabled if certificate, CA certificate, and private key are present in locations specifed by
 # ssl_certificate, ssl_ca_file, and ssl_private_key correspondingly


### PR DESCRIPTION
Version 1.15 will have support for an array of interfaces, so begin
allowing these to be specified. For 1.14 compatibility, a single
interface in an array will be configured as a string (also the default
value and behaviour.)