### PR TITLE
Fix notification of the dynflow service on Debian

### DIFF
--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -47,6 +47,10 @@ class foreman_proxy::plugin::ansible (
     enabled       => $enabled,
     listen_on     => $listen_on,
     template_path => 'foreman_proxy/plugin/ansible.yml.erb',
-  } ~>
-  Service['smart_proxy_dynflow_core']
+  }
+
+  if $::osfamily == 'RedHat' and $::operatingsystem != 'Fedora' {
+    Foreman_proxy::Settings_file['ansible']
+      ~> Service['smart_proxy_dynflow_core']
+  }
 }

--- a/spec/classes/foreman_proxy__plugin__ansible_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__ansible_spec.rb
@@ -2,58 +2,62 @@ require 'spec_helper'
 
 describe 'foreman_proxy::plugin::ansible' do
 
-  let :facts do
-    on_supported_os['redhat-7-x86_64']
-  end
+  ['redhat-7-x86_64', 'debian-8-x86_64'].each do |os|
+    context "on #{os}" do
+      let :facts do
+        on_supported_os[os]
+      end
 
-  describe 'with default settings' do
-    let :pre_condition do
-      "include foreman_proxy"
-    end
+      describe 'with default settings' do
+        let :pre_condition do
+          "include foreman_proxy"
+        end
 
-    it { should contain_foreman_proxy__plugin('dynflow') }
+        it { should contain_foreman_proxy__plugin('dynflow') }
 
-    it 'should configure ansible.yml' do
-      should contain_file('/etc/foreman-proxy/settings.d/ansible.yml').
-        with_content(/:enabled: https/).
-        with_content(%r{:ansible_dir: /etc/ansible})
-    end
+        it 'should configure ansible.yml' do
+          should contain_file('/etc/foreman-proxy/settings.d/ansible.yml').
+            with_content(/:enabled: https/).
+            with_content(%r{:ansible_dir: /etc/ansible})
+        end
 
-    it 'should configure ansible.cfg' do
-      should contain_file('/usr/share/foreman-proxy/.ansible.cfg').
-        with_content(%r{[default]}).
-        with_content(%r{callback_whitelist = foreman}).
-        with_content(%r{local_tmp = /tmp})
-    end
-  end
+        it 'should configure ansible.cfg' do
+          should contain_file('/usr/share/foreman-proxy/.ansible.cfg').
+            with_content(%r{[default]}).
+            with_content(%r{callback_whitelist = foreman}).
+            with_content(%r{local_tmp = /tmp})
+        end
+      end
 
-  describe 'with override parameters' do
-    let :pre_condition do
-      "include foreman_proxy"
-    end
+      describe 'with override parameters' do
+        let :pre_condition do
+          "include foreman_proxy"
+        end
 
-    let :params do
-      {
-        :enabled     => true,
-        :ansible_dir => '/etc/ansible-test',
-        :working_dir => '/tmp/ansible'
-      }
-    end
+        let :params do
+          {
+            :enabled     => true,
+            :ansible_dir => '/etc/ansible-test',
+            :working_dir => '/tmp/ansible'
+          }
+        end
 
-    it { should contain_foreman_proxy__plugin('dynflow') }
+        it { should contain_foreman_proxy__plugin('dynflow') }
 
-    it 'should configure ansible.yml' do
-      should contain_file('/etc/foreman-proxy/settings.d/ansible.yml').
-        with_content(/:enabled: https/).
-        with_content(%r{:ansible_dir: /etc/ansible-test}).
-        with_content(%r{:working_dir: /tmp/ansible})
-    end
+        it 'should configure ansible.yml' do
+          should contain_file('/etc/foreman-proxy/settings.d/ansible.yml').
+            with_content(/:enabled: https/).
+            with_content(%r{:ansible_dir: /etc/ansible-test}).
+            with_content(%r{:working_dir: /tmp/ansible})
+        end
 
-    it 'should configure ansible.cfg' do
-      should contain_file('/usr/share/foreman-proxy/.ansible.cfg').
-        with_content(%r{[default]}).
-        with_content(%r{callback_whitelist = foreman}).
-        with_content(%r{local_tmp = /tmp/ansible})
+        it 'should configure ansible.cfg' do
+          should contain_file('/usr/share/foreman-proxy/.ansible.cfg').
+            with_content(%r{[default]}).
+            with_content(%r{callback_whitelist = foreman}).
+            with_content(%r{local_tmp = /tmp/ansible})
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This implements the same logic for Ansible that's already in the REX SSH
plugin.

Closes GH-286