### PR TITLE
[WIP] Migrate to Puppet 4 datatypes to get rid of validate_* functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    # Only Ubuntu 14.04 uses Ruby 1.9.3 to run Puppet 3.x
-    - rvm: 1.9.3
-      env: PUPPET_VERSION=3.5 ONLY_OS="ubuntu-14-x86_64,ubuntu-14.04-x86_64"
-    # Only EL7 uses Ruby 2.0.0 to run Puppet 3.x
-    - rvm: 2.0.0
-      env: PUPPET_VERSION=3.5 ONLY_OS="centos-7-x86_64,redhat-7-x86_64"
     # Only Puppet 4.x supports Ruby 2.2. Also limit the OS set we test Ruby 2.2 with.
     - rvm: 2.2.6
       env: PUPPET_VERSION=4.0 ONLY_OS="debian-8-x86_64,centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,freebsd-10-amd64,windows-2012 R2-x64"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -376,203 +376,128 @@
 #                               type:Optional[Boolean]
 #
 class foreman_proxy (
-  $repo                       = $foreman_proxy::params::repo,
-  $gpgcheck                   = $foreman_proxy::params::gpgcheck,
-  $custom_repo                = $foreman_proxy::params::custom_repo,
-  $version                    = $foreman_proxy::params::version,
-  $ensure_packages_version    = $foreman_proxy::params::ensure_packages_version,
-  $plugin_version             = $foreman_proxy::params::plugin_version,
-  $bind_host                  = $foreman_proxy::params::bind_host,
-  $http_port                  = $foreman_proxy::params::http_port,
-  $ssl_port                   = $foreman_proxy::params::ssl_port,
-  $dir                        = $foreman_proxy::params::dir,
-  $user                       = $foreman_proxy::params::user,
-  $groups                     = $foreman_proxy::params::groups,
-  $log                        = $foreman_proxy::params::log,
-  $log_level                  = $foreman_proxy::params::log_level,
-  $log_buffer                 = $foreman_proxy::params::log_buffer,
-  $log_buffer_errors          = $foreman_proxy::params::log_buffer_errors,
-  $http                       = $foreman_proxy::params::http,
-  $ssl                        = $foreman_proxy::params::ssl,
-  $ssl_ca                     = $foreman_proxy::params::ssl_ca,
-  $ssl_cert                   = $foreman_proxy::params::ssl_cert,
-  $ssl_key                    = $foreman_proxy::params::ssl_key,
-  $foreman_ssl_ca             = $foreman_proxy::params::foreman_ssl_ca,
-  $foreman_ssl_cert           = $foreman_proxy::params::foreman_ssl_cert,
-  $foreman_ssl_key            = $foreman_proxy::params::foreman_ssl_key,
-  $trusted_hosts              = $foreman_proxy::params::trusted_hosts,
-  $ssl_disabled_ciphers       = $foreman_proxy::params::ssl_disabled_ciphers,
-  $manage_sudoersd            = $foreman_proxy::params::manage_sudoersd,
-  $use_sudoersd               = $foreman_proxy::params::use_sudoersd,
-  $use_sudoers                = $foreman_proxy::params::use_sudoers,
-  $puppetca                   = $foreman_proxy::params::puppetca,
-  $puppetca_listen_on         = $foreman_proxy::params::puppetca_listen_on,
-  $ssldir                     = $foreman_proxy::params::ssldir,
-  $puppetdir                  = $foreman_proxy::params::puppetdir,
-  $puppetca_cmd               = $foreman_proxy::params::puppetca_cmd,
-  $puppet_group               = $foreman_proxy::params::puppet_group,
-  $manage_puppet_group        = $foreman_proxy::params::manage_puppet_group,
-  $puppet                     = $foreman_proxy::params::puppet,
-  $puppet_listen_on           = $foreman_proxy::params::puppet_listen_on,
-  $puppetrun_cmd              = $foreman_proxy::params::puppetrun_cmd,
-  $puppetrun_provider         = $foreman_proxy::params::puppetrun_provider,
-  $customrun_cmd              = $foreman_proxy::params::customrun_cmd,
-  $customrun_args             = $foreman_proxy::params::customrun_args,
-  $mcollective_user           = $foreman_proxy::params::mcollective_user,
-  $puppetssh_sudo             = $foreman_proxy::params::puppetssh_sudo,
-  $puppetssh_command          = $foreman_proxy::params::puppetssh_command,
-  $puppetssh_user             = $foreman_proxy::params::puppetssh_user,
-  $puppetssh_keyfile          = $foreman_proxy::params::puppetssh_keyfile,
-  $puppetssh_wait             = $foreman_proxy::params::puppetssh_wait,
-  $salt_puppetrun_cmd         = $foreman_proxy::params::salt_puppetrun_cmd,
-  $puppet_user                = $foreman_proxy::params::puppet_user,
-  $puppet_url                 = $foreman_proxy::params::puppet_url,
-  $puppet_ssl_ca              = $foreman_proxy::params::ssl_ca,
-  $puppet_ssl_cert            = $foreman_proxy::params::ssl_cert,
-  $puppet_ssl_key             = $foreman_proxy::params::ssl_key,
-  $puppet_use_environment_api = $foreman_proxy::params::puppet_use_environment_api,
-  $puppet_api_timeout         = $foreman_proxy::params::puppet_api_timeout,
-  $templates                  = $foreman_proxy::params::templates,
-  $templates_listen_on        = $foreman_proxy::params::templates_listen_on,
-  $template_url               = $foreman_proxy::params::template_url,
-  $logs                       = $foreman_proxy::params::logs,
-  $logs_listen_on             = $foreman_proxy::params::logs_listen_on,
-  $tftp                       = $foreman_proxy::params::tftp,
-  $tftp_listen_on             = $foreman_proxy::params::tftp_listen_on,
-  $tftp_managed               = $foreman_proxy::params::tftp_managed,
-  $tftp_manage_wget           = $foreman_proxy::params::tftp_manage_wget,
-  $tftp_syslinux_filenames    = $foreman_proxy::params::tftp_syslinux_filenames,
-  $tftp_root                  = $foreman_proxy::params::tftp_root,
-  $tftp_dirs                  = $foreman_proxy::params::tftp_dirs,
-  $tftp_servername            = $foreman_proxy::params::tftp_servername,
-  $dhcp                       = $foreman_proxy::params::dhcp,
-  $dhcp_listen_on             = $foreman_proxy::params::dhcp_listen_on,
-  $dhcp_managed               = $foreman_proxy::params::dhcp_managed,
-  $dhcp_provider              = $foreman_proxy::params::dhcp_provider,
-  $dhcp_subnets               = $foreman_proxy::params::dhcp_subnets,
-  $dhcp_option_domain         = $foreman_proxy::params::dhcp_option_domain,
-  $dhcp_search_domains        = $foreman_proxy::params::dhcp_search_domains,
-  $dhcp_interface             = $foreman_proxy::params::dhcp_interface,
-  $dhcp_gateway               = $foreman_proxy::params::dhcp_gateway,
-  $dhcp_range                 = $foreman_proxy::params::dhcp_range,
-  $dhcp_pxeserver             = $foreman_proxy::params::dhcp_pxeserver,
-  $dhcp_nameservers           = $foreman_proxy::params::dhcp_nameservers,
-  $dhcp_server                = $foreman_proxy::params::dhcp_server,
-  $dhcp_config                = $foreman_proxy::params::dhcp_config,
-  $dhcp_leases                = $foreman_proxy::params::dhcp_leases,
-  $dhcp_key_name              = $foreman_proxy::params::dhcp_key_name,
-  $dhcp_key_secret            = $foreman_proxy::params::dhcp_key_secret,
-  $dhcp_omapi_port            = $foreman_proxy::params::dhcp_omapi_port,
-  $dns                        = $foreman_proxy::params::dns,
-  $dns_listen_on              = $foreman_proxy::params::dns_listen_on,
-  $dns_managed                = $foreman_proxy::params::dns_managed,
-  $dns_provider               = $foreman_proxy::params::dns_provider,
-  $dns_interface              = $foreman_proxy::params::dns_interface,
-  $dns_zone                   = $foreman_proxy::params::dns_zone,
-  $dns_reverse                = $foreman_proxy::params::dns_reverse,
-  $dns_server                 = $foreman_proxy::params::dns_server,
-  $dns_ttl                    = $foreman_proxy::params::dns_ttl,
-  $dns_tsig_keytab            = $foreman_proxy::params::dns_tsig_keytab,
-  $dns_tsig_principal         = $foreman_proxy::params::dns_tsig_principal,
-  $dns_forwarders             = $foreman_proxy::params::dns_forwarders,
-  $libvirt_network            = $foreman_proxy::params::libvirt_network,
-  $libvirt_connection         = $foreman_proxy::params::libvirt_connection,
-  $bmc                        = $foreman_proxy::params::bmc,
-  $bmc_listen_on              = $foreman_proxy::params::bmc_listen_on,
-  $bmc_default_provider       = $foreman_proxy::params::bmc_default_provider,
-  $realm                      = $foreman_proxy::params::realm,
-  $realm_split_config_files   = $foreman_proxy::params::realm_split_config_files,
-  $realm_listen_on            = $foreman_proxy::params::realm_listen_on,
-  $realm_provider             = $foreman_proxy::params::realm_provider,
-  $realm_keytab               = $foreman_proxy::params::realm_keytab,
-  $realm_principal            = $foreman_proxy::params::realm_principal,
-  $freeipa_config             = $foreman_proxy::params::freeipa_config,
-  $freeipa_remove_dns         = $foreman_proxy::params::freeipa_remove_dns,
-  $keyfile                    = $foreman_proxy::params::keyfile,
-  $register_in_foreman        = $foreman_proxy::params::register_in_foreman,
-  $foreman_base_url           = $foreman_proxy::params::foreman_base_url,
-  $registered_name            = $foreman_proxy::params::registered_name,
-  $registered_proxy_url       = $foreman_proxy::params::registered_proxy_url,
-  $oauth_effective_user       = $foreman_proxy::params::oauth_effective_user,
-  $oauth_consumer_key         = $foreman_proxy::params::oauth_consumer_key,
-  $oauth_consumer_secret      = $foreman_proxy::params::oauth_consumer_secret,
-  $puppet_use_cache           = $foreman_proxy::params::puppet_use_cache,
+  String $repo                                                                                = $foreman_proxy::params::repo,
+  Boolean $gpgcheck                                                                           = $foreman_proxy::params::gpgcheck,
+  Boolean $custom_repo                                                                        = $foreman_proxy::params::custom_repo,
+  String $version                                                                             = $foreman_proxy::params::version,
+  Enum['latest', 'present', 'installed', 'absent'] $ensure_packages_version                   = $foreman_proxy::params::ensure_packages_version,
+  Enum['latest', 'present', 'installed', 'absent'] $plugin_version                            = $foreman_proxy::params::plugin_version,
+  Variant[Array[String], String] $bind_host                                                   = $foreman_proxy::params::bind_host,
+  Integer[0, 65535] $http_port                                                                = $foreman_proxy::params::http_port,
+  Integer[0, 65535] $ssl_port                                                                 = $foreman_proxy::params::ssl_port,
+  Stdlib::Absolutepath $dir                                                                   = $foreman_proxy::params::dir,
+  String $user                                                                                = $foreman_proxy::params::user,
+  Array[String] $groups                                                                       = $foreman_proxy::params::groups,
+  Variant[Enum['STDOUT', 'SYSLOG'], Stdlib::Absolutepath] $log                                = $foreman_proxy::params::log,
+  Enum['WARN', 'DEBUG', 'ERROR', 'FATAL', 'INFO', 'UNKNOWN'] $log_level                       = $foreman_proxy::params::log_level,
+  Integer[0] $log_buffer                                                                      = $foreman_proxy::params::log_buffer,
+  Integer[0] $log_buffer_errors                                                               = $foreman_proxy::params::log_buffer_errors,
+  Boolean $http                                                                               = $foreman_proxy::params::http,
+  Boolean $ssl                                                                                = $foreman_proxy::params::ssl,
+  Stdlib::Absolutepath $ssl_ca                                                                = $foreman_proxy::params::ssl_ca,
+  Stdlib::Absolutepath $ssl_cert                                                              = $foreman_proxy::params::ssl_cert,
+  Stdlib::Absolutepath $ssl_key                                                               = $foreman_proxy::params::ssl_key,
+  Optional[Stdlib::Absolutepath] $foreman_ssl_ca                                              = $foreman_proxy::params::foreman_ssl_ca,
+  Optional[Stdlib::Absolutepath] $foreman_ssl_cert                                            = $foreman_proxy::params::foreman_ssl_cert,
+  Optional[Stdlib::Absolutepath] $foreman_ssl_key                                             = $foreman_proxy::params::foreman_ssl_key,
+  Array[String] $trusted_hosts                                                                = $foreman_proxy::params::trusted_hosts,
+  Array[String] $ssl_disabled_ciphers                                                         = $foreman_proxy::params::ssl_disabled_ciphers,
+  Boolean $manage_sudoersd                                                                    = $foreman_proxy::params::manage_sudoersd,
+  Boolean $use_sudoersd                                                                       = $foreman_proxy::params::use_sudoersd,
+  Boolean $use_sudoers                                                                        = $foreman_proxy::params::use_sudoers,
+  Boolean $puppetca                                                                           = $foreman_proxy::params::puppetca,
+  Foreman_proxy::ListenOn $puppetca_listen_on                                                 = $foreman_proxy::params::puppetca_listen_on,
+  Stdlib::Absolutepath $ssldir                                                                = $foreman_proxy::params::ssldir,
+  Stdlib::Absolutepath $puppetdir                                                             = $foreman_proxy::params::puppetdir,
+  String $puppetca_cmd                                                                        = $foreman_proxy::params::puppetca_cmd,
+  String $puppet_group                                                                        = $foreman_proxy::params::puppet_group,
+  Boolean $manage_puppet_group                                                                = $foreman_proxy::params::manage_puppet_group,
+  Boolean $puppet                                                                             = $foreman_proxy::params::puppet,
+  Foreman_proxy::ListenOn $puppet_listen_on                                                   = $foreman_proxy::params::puppet_listen_on,
+  $puppetrun_cmd                                                                              = $foreman_proxy::params::puppetrun_cmd,
+  Optional[Enum['puppetrun', 'mcollective', 'ssh', 'salt', 'customrun']] $puppetrun_provider  = $foreman_proxy::params::puppetrun_provider,
+  String $customrun_cmd                                                                       = $foreman_proxy::params::customrun_cmd,
+  String $customrun_args                                                                      = $foreman_proxy::params::customrun_args,
+  String $mcollective_user                                                                    = $foreman_proxy::params::mcollective_user,
+  Boolean $puppetssh_sudo                                                                     = $foreman_proxy::params::puppetssh_sudo,
+  String $puppetssh_command                                                                   = $foreman_proxy::params::puppetssh_command,
+  String $puppetssh_user                                                                      = $foreman_proxy::params::puppetssh_user,
+  Stdlib::Absolutepath $puppetssh_keyfile                                                     = $foreman_proxy::params::puppetssh_keyfile,
+  Boolean $puppetssh_wait                                                                     = $foreman_proxy::params::puppetssh_wait,
+  String $salt_puppetrun_cmd                                                                  = $foreman_proxy::params::salt_puppetrun_cmd,
+  String $puppet_user                                                                         = $foreman_proxy::params::puppet_user,
+  Stdlib::HTTPUrl $puppet_url                                                                 = $foreman_proxy::params::puppet_url,
+  Stdlib::Absolutepath $puppet_ssl_ca                                                         = $foreman_proxy::params::ssl_ca,
+  Stdlib::Absolutepath $puppet_ssl_cert                                                       = $foreman_proxy::params::ssl_cert,
+  Stdlib::Absolutepath $puppet_ssl_key                                                        = $foreman_proxy::params::ssl_key,
+  Optional[Boolean] $puppet_use_environment_api                                               = $foreman_proxy::params::puppet_use_environment_api,
+  Integer[0] $puppet_api_timeout                                                              = $foreman_proxy::params::puppet_api_timeout,
+  Boolean $templates                                                                          = $foreman_proxy::params::templates,
+  Foreman_proxy::ListenOn $templates_listen_on                                                = $foreman_proxy::params::templates_listen_on,
+  Stdlib::HTTPUrl $template_url                                                               = $foreman_proxy::params::template_url,
+  Boolean $logs                                                                               = $foreman_proxy::params::logs,
+  Foreman_proxy::ListenOn $logs_listen_on                                                     = $foreman_proxy::params::logs_listen_on,
+  Boolean $tftp                                                                               = $foreman_proxy::params::tftp,
+  Foreman_proxy::ListenOn $tftp_listen_on                                                     = $foreman_proxy::params::tftp_listen_on,
+  Boolean $tftp_managed                                                                       = $foreman_proxy::params::tftp_managed,
+  Boolean $tftp_manage_wget                                                                   = $foreman_proxy::params::tftp_manage_wget,
+  Array[Stdlib::Absolutepath] $tftp_syslinux_filenames                                        = $foreman_proxy::params::tftp_syslinux_filenames,
+  Stdlib::Absolutepath $tftp_root                                                             = $foreman_proxy::params::tftp_root,
+  Array[Stdlib::Absolutepath] $tftp_dirs                                                      = $foreman_proxy::params::tftp_dirs,
+  Optional[String] $tftp_servername                                                           = $foreman_proxy::params::tftp_servername,
+  Boolean $dhcp                                                                               = $foreman_proxy::params::dhcp,
+  Foreman_proxy::ListenOn $dhcp_listen_on                                                     = $foreman_proxy::params::dhcp_listen_on,
+  Boolean $dhcp_managed                                                                       = $foreman_proxy::params::dhcp_managed,
+  String $dhcp_provider                                                                       = $foreman_proxy::params::dhcp_provider,
+  Array[String] $dhcp_subnets                                                                 = $foreman_proxy::params::dhcp_subnets,
+  Array[String] $dhcp_option_domain                                                           = $foreman_proxy::params::dhcp_option_domain,
+  Optional[Array[String]] $dhcp_search_domains                                                = $foreman_proxy::params::dhcp_search_domains,
+  String $dhcp_interface                                                                      = $foreman_proxy::params::dhcp_interface,
+  Optional[String] $dhcp_gateway                                                              = $foreman_proxy::params::dhcp_gateway,
+  Optional[String] $dhcp_range                                                                = $foreman_proxy::params::dhcp_range,
+  Optional[String] $dhcp_pxeserver                                                            = $foreman_proxy::params::dhcp_pxeserver,
+  String $dhcp_nameservers                                                                    = $foreman_proxy::params::dhcp_nameservers,
+  String $dhcp_server                                                                         = $foreman_proxy::params::dhcp_server,
+  Stdlib::Absolutepath $dhcp_config                                                           = $foreman_proxy::params::dhcp_config,
+  Stdlib::Absolutepath $dhcp_leases                                                           = $foreman_proxy::params::dhcp_leases,
+  Optional[String] $dhcp_key_name                                                             = $foreman_proxy::params::dhcp_key_name,
+  Optional[String] $dhcp_key_secret                                                           = $foreman_proxy::params::dhcp_key_secret,
+  Integer[0, 65535] $dhcp_omapi_port                                                          = $foreman_proxy::params::dhcp_omapi_port,
+  Boolean $dns                                                                                = $foreman_proxy::params::dns,
+  Foreman_proxy::ListenOn $dns_listen_on                                                      = $foreman_proxy::params::dns_listen_on,
+  Boolean $dns_managed                                                                        = $foreman_proxy::params::dns_managed,
+  String $dns_provider                                                                        = $foreman_proxy::params::dns_provider,
+  String $dns_interface                                                                       = $foreman_proxy::params::dns_interface,
+  String $dns_zone                                                                            = $foreman_proxy::params::dns_zone,
+  Optional[Variant[String, Array[String]]] $dns_reverse                                       = $foreman_proxy::params::dns_reverse,
+  String $dns_server                                                                          = $foreman_proxy::params::dns_server,
+  Integer[0] $dns_ttl                                                                         = $foreman_proxy::params::dns_ttl,
+  String $dns_tsig_keytab                                                                     = $foreman_proxy::params::dns_tsig_keytab,
+  String $dns_tsig_principal                                                                  = $foreman_proxy::params::dns_tsig_principal,
+  Array[String] $dns_forwarders                                                               = $foreman_proxy::params::dns_forwarders,
+  String $libvirt_network                                                                     = $foreman_proxy::params::libvirt_network,
+  String $libvirt_connection                                                                  = $foreman_proxy::params::libvirt_connection,
+  Boolean $bmc                                                                                = $foreman_proxy::params::bmc,
+  Foreman_proxy::ListenOn $bmc_listen_on                                                      = $foreman_proxy::params::bmc_listen_on,
+  Enum['ipmitool', 'freeipmi', 'shell'] $bmc_default_provider                                 = $foreman_proxy::params::bmc_default_provider,
+  Boolean $realm                                                                              = $foreman_proxy::params::realm,
+  Boolean $realm_split_config_files                                                           = $foreman_proxy::params::realm_split_config_files,
+  Foreman_proxy::ListenOn $realm_listen_on                                                    = $foreman_proxy::params::realm_listen_on,
+  String $realm_provider                                                                      = $foreman_proxy::params::realm_provider,
+  Stdlib::Absolutepath $realm_keytab                                                          = $foreman_proxy::params::realm_keytab,
+  String $realm_principal                                                                     = $foreman_proxy::params::realm_principal,
+  Stdlib::Absolutepath $freeipa_config                                                        = $foreman_proxy::params::freeipa_config,
+  Boolean $freeipa_remove_dns                                                                 = $foreman_proxy::params::freeipa_remove_dns,
+  Stdlib::Absolutepath $keyfile                                                               = $foreman_proxy::params::keyfile,
+  Boolean $register_in_foreman                                                                = $foreman_proxy::params::register_in_foreman,
+  Stdlib::HTTPUrl $foreman_base_url                                                           = $foreman_proxy::params::foreman_base_url,
+  String $registered_name                                                                     = $foreman_proxy::params::registered_name,
+  Optional[Stdlib::HTTPUrl] $registered_proxy_url                                             = $foreman_proxy::params::registered_proxy_url,
+  String $oauth_effective_user                                                                = $foreman_proxy::params::oauth_effective_user,
+  String $oauth_consumer_key                                                                  = $foreman_proxy::params::oauth_consumer_key,
+  String $oauth_consumer_secret                                                               = $foreman_proxy::params::oauth_consumer_secret,
+  Optional[Boolean] $puppet_use_cache                                                         = $foreman_proxy::params::puppet_use_cache,
 ) inherits foreman_proxy::params {
-
-  # Validate misc params
-  unless is_array($bind_host) {
-    validate_string($bind_host)
-    warning('foreman_proxy::bind_host should be changed to an array, support for string only is deprecated')
-  }
-  validate_bool($ssl, $manage_sudoersd, $use_sudoers, $use_sudoersd, $register_in_foreman, $manage_puppet_group)
-  validate_array($trusted_hosts, $ssl_disabled_ciphers, $groups)
-  validate_re($log_level, '^(UNKNOWN|FATAL|ERROR|WARN|INFO|DEBUG)$')
-  validate_re($plugin_version, '^(installed|present|latest|absent)$')
-  validate_re($ensure_packages_version, '^(installed|present|latest|absent)$')
-  # lint:ignore:undef_in_function
-  validate_integer($log_buffer, undef, 0)
-  validate_integer($log_buffer_errors, undef, 0)
-  # lint:endignore
-
-  # Validate puppet params
-  validate_bool($puppet, $puppetssh_wait)
-  validate_string($ssldir, $puppetdir, $puppetca_cmd, $puppetrun_cmd)
-  validate_string($puppet_url, $puppet_ssl_ca, $puppet_ssl_cert, $puppet_ssl_key)
-  validate_string($mcollective_user, $salt_puppetrun_cmd)
-  validate_integer($puppet_api_timeout)
-  if $puppet_use_cache != undef {
-    validate_bool($puppet_use_cache)
-  }
-  if $puppetrun_provider {
-    validate_string($puppetrun_provider)
-    validate_re($puppetrun_provider, '^puppetrun|mcollective|ssh|salt|customrun$', 'Invalid provider: choose puppetrun, mcollective, ssh, salt or customrun')
-  }
-
-  # Validate template params
-  validate_string($template_url)
-
-  # Validate logs params
-  validate_bool($logs)
-  validate_listen_on($logs_listen_on)
-
-  # Validate tftp params
-  validate_bool($tftp_managed, $tftp_manage_wget)
-  if $tftp_servername {
-    validate_string($tftp_servername)
-  }
-
-  # Validate dhcp params
-  validate_bool($dhcp_managed)
-  validate_array($dhcp_option_domain)
-  validate_integer($dhcp_omapi_port)
-  validate_string($dhcp_provider, $dhcp_server)
-  validate_array($dhcp_subnets)
-  if $dhcp_pxeserver {
-    validate_string($dhcp_pxeserver)
-  }
-
-  # Validate dns params
-  validate_bool($dns)
-  validate_string($dns_interface, $dns_provider, $dns_server, $keyfile)
-  validate_array($dns_forwarders)
-  # $dns_reverse can be a string or an array of strings (to cover /23 networks for example)
-  if ! is_string($dns_reverse) and ! is_array($dns_reverse) {
-    fail('$dns_reverse must be a string or an array of strings')
-  }
-
-  # Validate libvirt params
-  validate_string($libvirt_network, $libvirt_connection)
-
-  # Validate bmc params
-  validate_re($bmc_default_provider, '^(freeipmi|ipmitool|shell)$')
-
-  # Validate realm params
-  validate_bool($freeipa_remove_dns, $realm_split_config_files)
-  validate_string($realm_provider, $realm_principal, $freeipa_config)
-  unless $realm_split_config_files {
-    validate_re($realm_provider, '^freeipa$', 'Invalid provider: choose freeipa')
-  }
-  validate_absolute_path($realm_keytab)
 
   $real_registered_proxy_url = pick($registered_proxy_url, "https://${::fqdn}:${ssl_port}")
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -172,7 +172,7 @@ class foreman_proxy::params {
   # Enable listening on http
   $bind_host = ['*']
   $http      = false
-  $http_port = '8000'
+  $http_port = 8000
 
   # Logging settings
   $log               = '/var/log/foreman-proxy/proxy.log'
@@ -182,7 +182,7 @@ class foreman_proxy::params {
 
   # Enable SSL, ensure proxy is added with "https://" protocol if true
   $ssl      = true
-  $ssl_port = '8443'
+  $ssl_port = 8443
   # If CA is specified, remote Foreman host will be verified
   $ssl_ca = "${ssldir}/certs/ca.pem"
   # Used to communicate to Foreman
@@ -293,7 +293,7 @@ class foreman_proxy::params {
   $dns_reverse            = undef
   # localhost can resolve to ipv6 which ruby doesn't handle well
   $dns_server             = '127.0.0.1'
-  $dns_ttl                = '86400'
+  $dns_ttl                = 86400
   $dns_tsig_keytab        = "${etc}/foreman-proxy/dns.keytab"
   $dns_tsig_principal     = "foremanproxy/${::fqdn}@${dns_realm}"
 

--- a/manifests/plugin/abrt.pp
+++ b/manifests/plugin/abrt.pp
@@ -45,26 +45,19 @@
 #                               type:Optional[String]
 #
 class foreman_proxy::plugin::abrt (
-  $enabled                 = $::foreman_proxy::plugin::abrt::params::enabled,
-  $listen_on               = $::foreman_proxy::plugin::abrt::params::listen_on,
-  $version                 = $::foreman_proxy::plugin::abrt::params::version,
-  $group                   = $::foreman_proxy::plugin::abrt::params::group,
-  $abrt_send_log_file      = $::foreman_proxy::plugin::abrt::params::abrt_send_log_file,
-  $spooldir                = $::foreman_proxy::plugin::abrt::params::spooldir,
-  $aggregate_reports       = $::foreman_proxy::plugin::abrt::params::aggregate_reports,
-  $send_period             = $::foreman_proxy::plugin::abrt::params::send_period,
-  $faf_server_url          = $::foreman_proxy::plugin::abrt::params::faf_server_url,
-  $faf_server_ssl_noverify = $::foreman_proxy::plugin::abrt::params::faf_server_ssl_noverify,
-  $faf_server_ssl_cert     = $::foreman_proxy::plugin::abrt::params::faf_server_ssl_cert,
-  $faf_server_ssl_key      = $::foreman_proxy::plugin::abrt::params::faf_server_ssl_key,
+  Boolean $enabled                                    = $::foreman_proxy::plugin::abrt::params::enabled,
+  Foreman_proxy::ListenOn $listen_on                  = $::foreman_proxy::plugin::abrt::params::listen_on,
+  Optional[String] $version                           = $::foreman_proxy::plugin::abrt::params::version,
+  Optional[String] $group                             = $::foreman_proxy::plugin::abrt::params::group,
+  Stdlib::Absolutepath $abrt_send_log_file            = $::foreman_proxy::plugin::abrt::params::abrt_send_log_file,
+  Stdlib::Absolutepath $spooldir                      = $::foreman_proxy::plugin::abrt::params::spooldir,
+  Boolean $aggregate_reports                          = $::foreman_proxy::plugin::abrt::params::aggregate_reports,
+  Integer[0] $send_period                             = $::foreman_proxy::plugin::abrt::params::send_period,
+  Optional[String] $faf_server_url                    = $::foreman_proxy::plugin::abrt::params::faf_server_url,
+  Boolean $faf_server_ssl_noverify                    = $::foreman_proxy::plugin::abrt::params::faf_server_ssl_noverify,
+  Optional[Stdlib::Absolutepath] $faf_server_ssl_cert = $::foreman_proxy::plugin::abrt::params::faf_server_ssl_cert,
+  Optional[Stdlib::Absolutepath] $faf_server_ssl_key  = $::foreman_proxy::plugin::abrt::params::faf_server_ssl_key,
 ) inherits foreman_proxy::plugin::abrt::params {
-
-  validate_bool($enabled)
-  validate_listen_on($listen_on)
-  validate_absolute_path($abrt_send_log_file)
-  validate_absolute_path($spooldir)
-  validate_bool($aggregate_reports)
-  validate_bool($faf_server_ssl_noverify)
 
   foreman_proxy::plugin { 'abrt':
     version => $version,

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -18,18 +18,11 @@
 #                type:Foreman_proxy::ListenOn
 #
 class foreman_proxy::plugin::ansible (
-  $enabled     = $::foreman_proxy::plugin::ansible::params::enabled,
-  $listen_on   = $::foreman_proxy::plugin::ansible::params::listen_on,
-  $ansible_dir = $::foreman_proxy::plugin::ansible::params::ansible_dir,
-  $working_dir = $::foreman_proxy::plugin::ansible::params::working_dir,
+  Boolean $enabled                            = $::foreman_proxy::plugin::ansible::params::enabled,
+  Foreman_proxy::ListenOn $listen_on          = $::foreman_proxy::plugin::ansible::params::listen_on,
+  Stdlib::Absolutepath $ansible_dir           = $::foreman_proxy::plugin::ansible::params::ansible_dir,
+  Optional[Stdlib::Absolutepath] $working_dir = $::foreman_proxy::plugin::ansible::params::working_dir,
 ) inherits foreman_proxy::plugin::ansible::params {
-
-  validate_bool($enabled)
-  validate_listen_on($listen_on)
-  validate_absolute_path($ansible_dir)
-  if $working_dir {
-    validate_absolute_path($working_dir)
-  }
 
   file {"${::foreman_proxy::dir}/.ansible.cfg":
     ensure  => file,

--- a/manifests/plugin/chef.pp
+++ b/manifests/plugin/chef.pp
@@ -38,19 +38,16 @@
 #                 type:Optional[String]
 #
 class foreman_proxy::plugin::chef (
-  $enabled      = $::foreman_proxy::plugin::chef::params::enabled,
-  $listen_on    = $::foreman_proxy::plugin::chef::params::listen_on,
-  $version      = $::foreman_proxy::plugin::chef::params::version,
-  $group        = $::foreman_proxy::plugin::chef::params::group,
-  $server_url   = $::foreman_proxy::plugin::chef::params::server_url,
-  $client_name  = $::foreman_proxy::plugin::chef::params::client_name,
-  $private_key  = $::foreman_proxy::plugin::chef::params::private_key,
-  $ssl_verify   = $::foreman_proxy::plugin::chef::params::ssl_verify,
-  $ssl_pem_file = $::foreman_proxy::plugin::chef::params::ssl_pem_file,
+  Boolean $enabled                              = $::foreman_proxy::plugin::chef::params::enabled,
+  Foreman_proxy::ListenOn $listen_on            = $::foreman_proxy::plugin::chef::params::listen_on,
+  Optional[String] $version                     = $::foreman_proxy::plugin::chef::params::version,
+  Optional[String] $group                       = $::foreman_proxy::plugin::chef::params::group,
+  Stdlib::HTTPUrl $server_url                   = $::foreman_proxy::plugin::chef::params::server_url,
+  String $client_name                           = $::foreman_proxy::plugin::chef::params::client_name,
+  Stdlib::Absolutepath $private_key             = $::foreman_proxy::plugin::chef::params::private_key,
+  Boolean $ssl_verify                           = $::foreman_proxy::plugin::chef::params::ssl_verify,
+  Optional[Stdlib::Absolutepath] $ssl_pem_file  = $::foreman_proxy::plugin::chef::params::ssl_pem_file,
 ) inherits foreman_proxy::plugin::chef::params {
-
-  validate_bool($enabled)
-  validate_listen_on($listen_on)
 
   foreman_proxy::plugin {'chef':
     version => $version,

--- a/manifests/plugin/dhcp/infoblox.pp
+++ b/manifests/plugin/dhcp/infoblox.pp
@@ -17,14 +17,11 @@
 #                type:Boolean
 #
 class foreman_proxy::plugin::dhcp::infoblox (
-  $username    = $::foreman_proxy::plugin::dhcp::infoblox::params::username,
-  $password    = $::foreman_proxy::plugin::dhcp::infoblox::params::password,
-  $record_type = $::foreman_proxy::plugin::dhcp::infoblox::params::record_type,
-  $use_ranges  = $::foreman_proxy::plugin::dhcp::infoblox::params::use_ranges,
+  String $username                          = $::foreman_proxy::plugin::dhcp::infoblox::params::username,
+  String $password                          = $::foreman_proxy::plugin::dhcp::infoblox::params::password,
+  Enum['host', 'fixedaddress'] $record_type = $::foreman_proxy::plugin::dhcp::infoblox::params::record_type,
+  Boolean $use_ranges                       = $::foreman_proxy::plugin::dhcp::infoblox::params::use_ranges,
 ) inherits foreman_proxy::plugin::dhcp::infoblox::params {
-  validate_string($username, $password)
-  validate_re($record_type, '^host|fixedaddress$', 'Invalid record type: choose host or fixedaddress')
-  validate_bool($use_ranges)
 
   foreman_proxy::plugin { 'dhcp_infoblox':
   } ->

--- a/manifests/plugin/discovery.pp
+++ b/manifests/plugin/discovery.pp
@@ -17,22 +17,18 @@
 #                    type:String
 #
 class foreman_proxy::plugin::discovery (
-  $install_images = $::foreman_proxy::plugin::discovery::params::install_images,
-  $tftp_root      = $::foreman_proxy::plugin::discovery::params::tftp_root,
-  $source_url     = $::foreman_proxy::plugin::discovery::params::source_url,
-  $image_name     = $::foreman_proxy::plugin::discovery::params::image_name,
+  Boolean $install_images         = $::foreman_proxy::plugin::discovery::params::install_images,
+  Stdlib::Absolutepath $tftp_root = $::foreman_proxy::plugin::discovery::params::tftp_root,
+  Stdlib::HTTPUrl $source_url     = $::foreman_proxy::plugin::discovery::params::source_url,
+  String $image_name              = $::foreman_proxy::plugin::discovery::params::image_name,
 ) inherits foreman_proxy::plugin::discovery::params {
 
-  validate_bool($install_images)
 
   foreman_proxy::plugin {'discovery':
   }
 
   if $install_images {
     $tftp_root_clean = regsubst($tftp_root, '/$', '')
-    validate_absolute_path($tftp_root_clean)
-    validate_string($source_url)
-    validate_string($image_name)
 
     foreman::remote_file {"${tftp_root_clean}/boot/${image_name}":
       remote_location => "${source_url}${image_name}",

--- a/manifests/plugin/dns/infoblox.pp
+++ b/manifests/plugin/dns/infoblox.pp
@@ -14,11 +14,10 @@
 #               type:String
 #
 class foreman_proxy::plugin::dns::infoblox (
-  $dns_server = $::foreman_proxy::plugin::dns::infoblox::params::dns_server,
-  $username   = $::foreman_proxy::plugin::dns::infoblox::params::username,
-  $password   = $::foreman_proxy::plugin::dns::infoblox::params::password,
+  String $dns_server  = $::foreman_proxy::plugin::dns::infoblox::params::dns_server,
+  String $username    = $::foreman_proxy::plugin::dns::infoblox::params::username,
+  String $password    = $::foreman_proxy::plugin::dns::infoblox::params::password,
 ) inherits foreman_proxy::plugin::dns::infoblox::params {
-  validate_string($dns_server, $username, $password)
 
   foreman_proxy::plugin { 'dns_infoblox':
   } ->

--- a/manifests/plugin/dns/powerdns.pp
+++ b/manifests/plugin/dns/powerdns.pp
@@ -37,20 +37,17 @@
 #                          type:String
 #
 class foreman_proxy::plugin::dns::powerdns (
-  $backend               = $::foreman_proxy::plugin::dns::powerdns::params::backend,
-  $mysql_hostname        = $::foreman_proxy::plugin::dns::powerdns::params::mysql_hostname,
-  $mysql_username        = $::foreman_proxy::plugin::dns::powerdns::params::mysql_username,
-  $mysql_password        = $::foreman_proxy::plugin::dns::powerdns::params::mysql_password,
-  $mysql_database        = $::foreman_proxy::plugin::dns::powerdns::params::mysql_database,
-  $postgresql_connection = $::foreman_proxy::plugin::dns::powerdns::params::postgresql_connection,
-  $rest_url              = $::foreman_proxy::plugin::dns::powerdns::params::rest_url,
-  $rest_api_key          = $::foreman_proxy::plugin::dns::powerdns::params::rest_api_key,
-  $manage_database       = $::foreman_proxy::plugin::dns::powerdns::params::manage_database,
-  $pdnssec               = $::foreman_proxy::plugin::dns::powerdns::params::pdnssec,
+  Enum['rest', 'mysql', 'postgresql'] $backend  = $::foreman_proxy::plugin::dns::powerdns::params::backend,
+  String $mysql_hostname                        = $::foreman_proxy::plugin::dns::powerdns::params::mysql_hostname,
+  String $mysql_username                        = $::foreman_proxy::plugin::dns::powerdns::params::mysql_username,
+  String $mysql_password                        = $::foreman_proxy::plugin::dns::powerdns::params::mysql_password,
+  String $mysql_database                        = $::foreman_proxy::plugin::dns::powerdns::params::mysql_database,
+  String $postgresql_connection                 = $::foreman_proxy::plugin::dns::powerdns::params::postgresql_connection,
+  Stdlib::HTTPUrl $rest_url                     = $::foreman_proxy::plugin::dns::powerdns::params::rest_url,
+  String $rest_api_key                          = $::foreman_proxy::plugin::dns::powerdns::params::rest_api_key,
+  Boolean $manage_database                      = $::foreman_proxy::plugin::dns::powerdns::params::manage_database,
+  String $pdnssec                               = $::foreman_proxy::plugin::dns::powerdns::params::pdnssec,
 ) inherits foreman_proxy::plugin::dns::powerdns::params {
-  validate_bool($manage_database)
-  validate_re($backend, '^rest|mysql|postgresql$', 'Invalid backend: choose rest, mysql or postgresql')
-  validate_string($mysql_hostname, $mysql_username, $mysql_password, $mysql_database, $postgresql_connection, $rest_url, $rest_api_key, $pdnssec)
 
   if $manage_database and $backend == 'mysql' {
     include ::mysql::server

--- a/manifests/plugin/dynflow.pp
+++ b/manifests/plugin/dynflow.pp
@@ -25,18 +25,14 @@
 #                    type:Integer[0, 65535]
 #
 class foreman_proxy::plugin::dynflow (
-  $enabled           = $::foreman_proxy::plugin::dynflow::params::enabled,
-  $listen_on         = $::foreman_proxy::plugin::dynflow::params::listen_on,
-  $database_path     = $::foreman_proxy::plugin::dynflow::params::database_path,
-  $console_auth      = $::foreman_proxy::plugin::dynflow::params::console_auth,
-  $core_listen       = $::foreman_proxy::plugin::dynflow::params::core_listen,
-  $core_port         = $::foreman_proxy::plugin::dynflow::params::core_port,
+  Boolean $enabled                    = $::foreman_proxy::plugin::dynflow::params::enabled,
+  Foreman_proxy::ListenOn $listen_on  = $::foreman_proxy::plugin::dynflow::params::listen_on,
+  Stdlib::Absolutepath $database_path = $::foreman_proxy::plugin::dynflow::params::database_path,
+  Boolean $console_auth               = $::foreman_proxy::plugin::dynflow::params::console_auth,
+  String $core_listen                 = $::foreman_proxy::plugin::dynflow::params::core_listen,
+  Integer $core_port                  = $::foreman_proxy::plugin::dynflow::params::core_port,
 ) inherits foreman_proxy::plugin::dynflow::params {
 
-  validate_integer($core_port)
-  validate_bool($enabled, $console_auth)
-  validate_listen_on($listen_on)
-  validate_absolute_path($database_path)
 
   if $::foreman_proxy::ssl {
     $core_url = "https://${::fqdn}:${core_port}"

--- a/manifests/plugin/monitoring.pp
+++ b/manifests/plugin/monitoring.pp
@@ -23,15 +23,12 @@
 #                       type:Optional[String]
 #
 class foreman_proxy::plugin::monitoring (
-  $enabled            = $::foreman_proxy::plugin::monitoring::params::enabled,
-  $group              = $::foreman_proxy::plugin::monitoring::params::group,
-  $listen_on          = $::foreman_proxy::plugin::monitoring::params::listen_on,
-  $provider           = $::foreman_proxy::plugin::monitoring::params::provider,
-  $version            = $::foreman_proxy::plugin::monitoring::params::version,
+  Boolean $enabled                    = $::foreman_proxy::plugin::monitoring::params::enabled,
+  Optional[String] $group             = $::foreman_proxy::plugin::monitoring::params::group,
+  Foreman_proxy::ListenOn $listen_on  = $::foreman_proxy::plugin::monitoring::params::listen_on,
+  String $provider                    = $::foreman_proxy::plugin::monitoring::params::provider,
+  Optional[String] $version           = $::foreman_proxy::plugin::monitoring::params::version,
 ) inherits foreman_proxy::plugin::monitoring::params {
-  validate_bool($enabled)
-  validate_listen_on($listen_on)
-  validate_string($provider)
 
   foreman_proxy::plugin { 'monitoring':
     version => $version,

--- a/manifests/plugin/monitoring/icinga2.pp
+++ b/manifests/plugin/monitoring/icinga2.pp
@@ -27,22 +27,15 @@
 # $enabled::               Enable this plugin.
 #
 class foreman_proxy::plugin::monitoring::icinga2 (
-  $enabled = $::foreman_proxy::plugin::monitoring::icinga2::params::enabled,
-  $server = $::foreman_proxy::plugin::monitoring::icinga2::params::server,
-  $api_cacert = $::foreman_proxy::plugin::monitoring::icinga2::params::api_cacert,
-  $api_user = $::foreman_proxy::plugin::monitoring::icinga2::params::api_user,
-  $api_usercert = $::foreman_proxy::plugin::monitoring::icinga2::params::api_usercert,
-  $api_userkey = $::foreman_proxy::plugin::monitoring::icinga2::params::api_userkey,
-  $api_password = $::foreman_proxy::plugin::monitoring::icinga2::params::api_password,
-  $verify_ssl = $::foreman_proxy::plugin::monitoring::icinga2::params::verify_ssl,
+  Boolean $enabled                  = $::foreman_proxy::plugin::monitoring::icinga2::params::enabled,
+  String $server                    = $::foreman_proxy::plugin::monitoring::icinga2::params::server,
+  Stdlib::Absolutepath $api_cacert  = $::foreman_proxy::plugin::monitoring::icinga2::params::api_cacert,
+  String $api_user                  = $::foreman_proxy::plugin::monitoring::icinga2::params::api_user,
+  String $api_usercert              = $::foreman_proxy::plugin::monitoring::icinga2::params::api_usercert,
+  String $api_userkey               = $::foreman_proxy::plugin::monitoring::icinga2::params::api_userkey,
+  Optional[String] $api_password    = $::foreman_proxy::plugin::monitoring::icinga2::params::api_password,
+  Boolean $verify_ssl               = $::foreman_proxy::plugin::monitoring::icinga2::params::verify_ssl,
 ) inherits foreman_proxy::plugin::monitoring::icinga2::params {
-  validate_bool($enabled)
-  validate_string($server, $api_user, $api_usercert, $api_userkey)
-
-  validate_bool($verify_ssl)
-  if $api_password {
-    validate_string($api_password)
-  }
 
   include ::foreman_proxy::plugin::monitoring
 

--- a/manifests/plugin/monitoring/icinga2.pp
+++ b/manifests/plugin/monitoring/icinga2.pp
@@ -16,11 +16,11 @@
 #
 # $api_password::          Icinga2 API password. If set to undef (default) API
 #                          connection is made via certificate and key.
-#                          type:password
+#                          type:String
 #
 # $verify_ssl::            Whether smart-proxy should verify the ssl connection
 #                          to Icinga2.
-#                          type:boolean
+#                          type:Boolean
 #
 # === Advanced parameters:
 #

--- a/manifests/plugin/omaha.pp
+++ b/manifests/plugin/omaha.pp
@@ -29,22 +29,14 @@
 #                       type:Optional[String]
 #
 class foreman_proxy::plugin::omaha (
-  $enabled            = $::foreman_proxy::plugin::omaha::params::enabled,
-  $group              = $::foreman_proxy::plugin::omaha::params::group,
-  $listen_on          = $::foreman_proxy::plugin::omaha::params::listen_on,
-  $contentpath        = $::foreman_proxy::plugin::omaha::params::contentpath,
-  $sync_releases      = $::foreman_proxy::plugin::omaha::params::sync_releases,
-  $http_proxy         = $::foreman_proxy::plugin::omaha::params::http_proxy,
-  $version            = $::foreman_proxy::plugin::omaha::params::version,
+  Boolean $enabled                      = $::foreman_proxy::plugin::omaha::params::enabled,
+  Optional[String] $group               = $::foreman_proxy::plugin::omaha::params::group,
+  Foreman_proxy::ListenOn $listen_on    = $::foreman_proxy::plugin::omaha::params::listen_on,
+  Stdlib::Absolutepath $contentpath     = $::foreman_proxy::plugin::omaha::params::contentpath,
+  Integer[0] $sync_releases             = $::foreman_proxy::plugin::omaha::params::sync_releases,
+  Optional[Stdlib::HTTPUrl] $http_proxy = $::foreman_proxy::plugin::omaha::params::http_proxy,
+  Optional[String] $version             = $::foreman_proxy::plugin::omaha::params::version,
 ) inherits foreman_proxy::plugin::omaha::params {
-  validate_bool($enabled)
-  validate_listen_on($listen_on)
-  validate_absolute_path($contentpath)
-  validate_integer($sync_releases)
-
-  if $http_proxy {
-    validate_string($http_proxy)
-  }
 
   foreman_proxy::plugin { 'omaha':
     version => $version,

--- a/manifests/plugin/openscap.pp
+++ b/manifests/plugin/openscap.pp
@@ -39,24 +39,16 @@
 #                               type:Optional[String]
 #
 class foreman_proxy::plugin::openscap (
-  $configure_openscap_repo = $::foreman_proxy::plugin::openscap::params::configure_openscap_repo,
-  $enabled                 = $::foreman_proxy::plugin::openscap::params::enabled,
-  $version                 = $::foreman_proxy::plugin::openscap::params::version,
-  $listen_on               = $::foreman_proxy::plugin::openscap::params::listen_on,
-  $openscap_send_log_file  = $::foreman_proxy::plugin::openscap::params::openscap_send_log_file,
-  $spooldir                = $::foreman_proxy::plugin::openscap::params::spooldir,
-  $contentdir              = $::foreman_proxy::plugin::openscap::params::contentdir,
-  $reportsdir              = $::foreman_proxy::plugin::openscap::params::reportsdir,
-  $failed_dir              = $::foreman_proxy::plugin::openscap::params::failed_dir,
+  Boolean $configure_openscap_repo              = $::foreman_proxy::plugin::openscap::params::configure_openscap_repo,
+  Boolean $enabled                              = $::foreman_proxy::plugin::openscap::params::enabled,
+  Optional[String] $version                     = $::foreman_proxy::plugin::openscap::params::version,
+  Foreman_proxy::ListenOn $listen_on            = $::foreman_proxy::plugin::openscap::params::listen_on,
+  Stdlib::Absolutepath $openscap_send_log_file  = $::foreman_proxy::plugin::openscap::params::openscap_send_log_file,
+  Stdlib::Absolutepath $spooldir                = $::foreman_proxy::plugin::openscap::params::spooldir,
+  Stdlib::Absolutepath $contentdir              = $::foreman_proxy::plugin::openscap::params::contentdir,
+  Stdlib::Absolutepath $reportsdir              = $::foreman_proxy::plugin::openscap::params::reportsdir,
+  Stdlib::Absolutepath $failed_dir              = $::foreman_proxy::plugin::openscap::params::failed_dir,
 ) inherits foreman_proxy::plugin::openscap::params {
-  validate_bool($configure_openscap_repo)
-  validate_bool($enabled)
-  validate_listen_on($listen_on)
-  validate_absolute_path($spooldir)
-  validate_absolute_path($openscap_send_log_file)
-  validate_absolute_path($contentdir)
-  validate_absolute_path($reportsdir)
-  validate_absolute_path($failed_dir)
 
   if $configure_openscap_repo {
     case $::osfamily {

--- a/manifests/plugin/pulp.pp
+++ b/manifests/plugin/pulp.pp
@@ -36,24 +36,17 @@
 #                       type:Stdlib::Absolutepath
 #
 class foreman_proxy::plugin::pulp (
-  $enabled            = $::foreman_proxy::plugin::pulp::params::enabled,
-  $listen_on          = $::foreman_proxy::plugin::pulp::params::listen_on,
-  $pulpnode_enabled   = $::foreman_proxy::plugin::pulp::params::pulpnode_enabled,
-  $version            = $::foreman_proxy::plugin::pulp::params::version,
-  $group              = $::foreman_proxy::plugin::pulp::params::group,
-  $pulp_url           = $::foreman_proxy::plugin::pulp::params::pulp_url,
-  $pulp_dir           = $::foreman_proxy::plugin::pulp::params::pulp_dir,
-  $pulp_content_dir   = $::foreman_proxy::plugin::pulp::params::pulp_content_dir,
-  $puppet_content_dir = $::foreman_proxy::plugin::pulp::params::puppet_content_dir,
-  $mongodb_dir        = $::foreman_proxy::plugin::pulp::params::mongodb_dir
+  Boolean $enabled                          = $::foreman_proxy::plugin::pulp::params::enabled,
+  Foreman_proxy::ListenOn $listen_on        = $::foreman_proxy::plugin::pulp::params::listen_on,
+  Boolean $pulpnode_enabled                 = $::foreman_proxy::plugin::pulp::params::pulpnode_enabled,
+  Optional[String] $version                 = $::foreman_proxy::plugin::pulp::params::version,
+  Optional[String] $group                   = $::foreman_proxy::plugin::pulp::params::group,
+  Stdlib::HTTPUrl $pulp_url                 = $::foreman_proxy::plugin::pulp::params::pulp_url,
+  Stdlib::Absolutepath $pulp_dir            = $::foreman_proxy::plugin::pulp::params::pulp_dir,
+  Stdlib::Absolutepath $pulp_content_dir    = $::foreman_proxy::plugin::pulp::params::pulp_content_dir,
+  Stdlib::Absolutepath $puppet_content_dir  = $::foreman_proxy::plugin::pulp::params::puppet_content_dir,
+  Stdlib::Absolutepath $mongodb_dir         = $::foreman_proxy::plugin::pulp::params::mongodb_dir
 ) inherits foreman_proxy::plugin::pulp::params {
-
-  validate_bool($enabled)
-  validate_bool($pulpnode_enabled)
-  validate_absolute_path($pulp_dir)
-  validate_absolute_path($pulp_content_dir)
-  validate_absolute_path($puppet_content_dir)
-  validate_absolute_path($mongodb_dir)
 
   foreman_proxy::plugin {'pulp':
     version => $version,

--- a/manifests/plugin/remote_execution/ssh.pp
+++ b/manifests/plugin/remote_execution/ssh.pp
@@ -29,22 +29,18 @@
 # $listen_on::          Proxy feature listens on https, http, or both
 #
 class foreman_proxy::plugin::remote_execution::ssh (
-  $enabled            = $::foreman_proxy::plugin::remote_execution::ssh::params::enabled,
-  $listen_on          = $::foreman_proxy::plugin::remote_execution::ssh::params::listen_on,
-  $generate_keys      = $::foreman_proxy::plugin::remote_execution::ssh::params::generate_keys,
-  $install_key        = $::foreman_proxy::plugin::remote_execution::ssh::params::install_key,
-  $ssh_identity_dir   = $::foreman_proxy::plugin::remote_execution::ssh::params::ssh_identity_dir,
-  $ssh_identity_file  = $::foreman_proxy::plugin::remote_execution::ssh::params::ssh_identity_file,
-  $ssh_keygen         = $::foreman_proxy::plugin::remote_execution::ssh::params::ssh_keygen,
-  $local_working_dir  = $::foreman_proxy::plugin::remote_execution::ssh::params::local_working_dir,
-  $remote_working_dir = $::foreman_proxy::plugin::remote_execution::ssh::params::remote_working_dir,
+  Boolean $enabled                          = $::foreman_proxy::plugin::remote_execution::ssh::params::enabled,
+  Foreman_proxy::ListenOn $listen_on        = $::foreman_proxy::plugin::remote_execution::ssh::params::listen_on,
+  Boolean $generate_keys                    = $::foreman_proxy::plugin::remote_execution::ssh::params::generate_keys,
+  Boolean $install_key                      = $::foreman_proxy::plugin::remote_execution::ssh::params::install_key,
+  Stdlib::Absolutepath $ssh_identity_dir    = $::foreman_proxy::plugin::remote_execution::ssh::params::ssh_identity_dir,
+  String $ssh_identity_file                 = $::foreman_proxy::plugin::remote_execution::ssh::params::ssh_identity_file,
+  String $ssh_keygen                        = $::foreman_proxy::plugin::remote_execution::ssh::params::ssh_keygen,
+  Stdlib::Absolutepath $local_working_dir   = $::foreman_proxy::plugin::remote_execution::ssh::params::local_working_dir,
+  Stdlib::Absolutepath $remote_working_dir  = $::foreman_proxy::plugin::remote_execution::ssh::params::remote_working_dir,
 ) inherits foreman_proxy::plugin::remote_execution::ssh::params {
 
   $ssh_identity_path = "${ssh_identity_dir}/${ssh_identity_file}"
-
-  validate_absolute_path($ssh_identity_path, $local_working_dir, $remote_working_dir)
-  validate_bool($enabled, $generate_keys, $install_key)
-  validate_listen_on($listen_on)
 
   include ::foreman_proxy::plugin::dynflow
 

--- a/manifests/plugin/salt.pp
+++ b/manifests/plugin/salt.pp
@@ -37,30 +37,17 @@
 #                    type:Foreman_proxy::ListenOn
 #
 class foreman_proxy::plugin::salt (
-  $autosign_file     = $::foreman_proxy::plugin::salt::params::autosign_file,
-  $enabled           = $::foreman_proxy::plugin::salt::params::enabled,
-  $listen_on         = $::foreman_proxy::plugin::salt::params::listen_on,
-  $user              = $::foreman_proxy::plugin::salt::params::user,
-  $group             = $::foreman_proxy::plugin::salt::params::group,
-  $api               = $::foreman_proxy::plugin::salt::params::api,
-  $api_url           = $::foreman_proxy::plugin::salt::params::api_url,
-  $api_auth          = $::foreman_proxy::plugin::salt::params::api_auth,
-  $api_username      = $::foreman_proxy::plugin::salt::params::api_username,
-  $api_password      = $::foreman_proxy::plugin::salt::params::api_password,
+  Stdlib::Absolutepath $autosign_file = $::foreman_proxy::plugin::salt::params::autosign_file,
+  Boolean $enabled                    = $::foreman_proxy::plugin::salt::params::enabled,
+  Foreman_proxy::ListenOn $listen_on  = $::foreman_proxy::plugin::salt::params::listen_on,
+  String $user                        = $::foreman_proxy::plugin::salt::params::user,
+  Optional[String] $group             = $::foreman_proxy::plugin::salt::params::group,
+  Boolean $api                        = $::foreman_proxy::plugin::salt::params::api,
+  Stdlib::HTTPUrl $api_url            = $::foreman_proxy::plugin::salt::params::api_url,
+  String $api_auth                    = $::foreman_proxy::plugin::salt::params::api_auth,
+  String $api_username                = $::foreman_proxy::plugin::salt::params::api_username,
+  String $api_password                = $::foreman_proxy::plugin::salt::params::api_password,
 ) inherits foreman_proxy::plugin::salt::params {
-
-  validate_bool($enabled, $api)
-  validate_listen_on($listen_on)
-  validate_absolute_path($autosign_file)
-  validate_string($user)
-
-  if $api {
-    validate_string($api_url, $api_auth, $api_username, $api_password)
-  }
-
-  if $group {
-    validate_string($group)
-  }
 
   foreman_proxy::plugin { 'salt':
   } ->

--- a/manifests/settings_file.pp
+++ b/manifests/settings_file.pp
@@ -25,17 +25,15 @@
 # $mode:           Settings file's mode
 #
 define foreman_proxy::settings_file (
-  $module        = true,
-  $enabled       = true,
-  $listen_on     = 'https',
-  $path          = "${::foreman_proxy::etc}/foreman-proxy/settings.d/${title}.yml",
-  $owner         = 'root',
-  $group         = $::foreman_proxy::user,
-  $mode          = '0640',
-  $template_path = "foreman_proxy/${title}.yml.erb",
+  Boolean $module                     = true,
+  Boolean $enabled                    = true,
+  Foreman_proxy::ListenOn $listen_on  = 'https',
+  Stdlib::Absolutepath $path          = "${::foreman_proxy::etc}/foreman-proxy/settings.d/${title}.yml",
+  String $owner                       = 'root',
+  String $group                       = $::foreman_proxy::user,
+  String $mode                        = '0640',
+  String $template_path               = "foreman_proxy/${title}.yml.erb",
 ) {
-  validate_bool($module, $enabled)
-  validate_listen_on($listen_on)
 
   # If the config file is for a proxy module, then we need to know
   # whether it's enabled, and if so, where to listen (https, http, or both).

--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.0 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 5.0.0"
     },
     {
       "name": "puppet/extlib",

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -519,18 +519,6 @@ describe 'foreman_proxy::config' do
         end
       end
 
-      context 'with invalid realm provider' do
-        let :pre_condition do
-          'class {"foreman_proxy":
-            realm => true,
-            realm_provider => "invalid",
-            realm_split_config_files => false,
-          }'
-        end
-
-        it { expect { subject.call } .to raise_error(/Invalid provider: choose freeipa/) }
-      end
-
       context 'with realm_split_config_files => true' do
         let :pre_condition do
           'class {"foreman_proxy":
@@ -840,16 +828,6 @@ describe 'foreman_proxy::config' do
             ':api_timeout: 600',
           ])
         end
-      end
-
-      context 'when puppetrun_provider => invalid' do
-        let :pre_condition do
-          'class {"foreman_proxy":
-            puppetrun_provider => "invalid",
-          }'
-        end
-
-        it { expect { subject.call } .to raise_error(/Invalid provider: choose puppetrun, mcollective, ssh, salt or customrun/) }
       end
 
       context 'with puppet use_cache enabled' do


### PR DESCRIPTION
The goal of this is to get rid of all the validate_* calls because they are deprecated.