### PR TITLE
Use versioncmp to check Puppet version for 4.10.x compatibility

### DIFF
--- a/spec/aliases/listen_on_spec.rb
+++ b/spec/aliases/listen_on_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   describe 'test::listen_on', type: :class do
     describe 'valid handling' do
       %w{


### PR DESCRIPTION
`Puppet.version.to_f` on Puppet 4.10.0 will evaluate to `4.1`, causing
test and behavioural changes when conditionals check that the version is
equal or greater than versions such as `4.3`.

Version comparisons that are vulnerable to this have been changed to use
Puppet's versioncmp implementation, while most others only check for
for major version boundaries which is safe.