### PR TITLE
Pin xinetd, fix puppet-lint 2.2 warnings

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,7 +10,9 @@ fixtures:
     puppet:   'git://github.com/theforeman/puppet-puppet'
     stdlib:   'git://github.com/puppetlabs/puppetlabs-stdlib.git'
     tftp:     'git://github.com/theforeman/puppet-tftp'
-    xinetd:   'git://github.com/puppetlabs/puppetlabs-xinetd.git'
+    xinetd:
+      repo:   'git://github.com/puppetlabs/puppetlabs-xinetd.git'
+      ref:    'e84f34f'
 
 
   symlinks:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -577,11 +577,11 @@ class foreman_proxy (
   $real_registered_proxy_url = pick($registered_proxy_url, "https://${::fqdn}:${ssl_port}")
 
   # lint:ignore:spaceship_operator_without_tag
-  class { '::foreman_proxy::install': } ~>
-  class { '::foreman_proxy::config': } ~>
-  Foreman_proxy::Plugin <| |> ~>
-  class { '::foreman_proxy::service': } ~>
-  class { '::foreman_proxy::register': } ->
-  Class['foreman_proxy']
+  class { '::foreman_proxy::install': }
+  ~> class { '::foreman_proxy::config': }
+  ~> Foreman_proxy::Plugin <| |>
+  ~> class { '::foreman_proxy::service': }
+  ~> class { '::foreman_proxy::register': }
+  -> Class['foreman_proxy']
   # lint:endignore
 }

--- a/manifests/plugin/abrt.pp
+++ b/manifests/plugin/abrt.pp
@@ -68,8 +68,8 @@ class foreman_proxy::plugin::abrt (
 
   foreman_proxy::plugin { 'abrt':
     version => $version,
-  } ->
-  foreman_proxy::settings_file { 'abrt':
+  }
+  -> foreman_proxy::settings_file { 'abrt':
     template_path => 'foreman_proxy/plugin/abrt.yml.erb',
     group         => $group,
     listen_on     => $listen_on,

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -42,8 +42,8 @@ class foreman_proxy::plugin::ansible (
   include ::foreman_proxy::plugin::dynflow
 
   foreman_proxy::plugin { 'ansible':
-  } ->
-  foreman_proxy::settings_file { 'ansible':
+  }
+  -> foreman_proxy::settings_file { 'ansible':
     enabled       => $enabled,
     listen_on     => $listen_on,
     template_path => 'foreman_proxy/plugin/ansible.yml.erb',

--- a/manifests/plugin/chef.pp
+++ b/manifests/plugin/chef.pp
@@ -54,8 +54,8 @@ class foreman_proxy::plugin::chef (
 
   foreman_proxy::plugin {'chef':
     version => $version,
-  } ->
-  foreman_proxy::settings_file { 'chef':
+  }
+  -> foreman_proxy::settings_file { 'chef':
     listen_on     => $listen_on,
     enabled       => $enabled,
     group         => $group,

--- a/manifests/plugin/dhcp/infoblox.pp
+++ b/manifests/plugin/dhcp/infoblox.pp
@@ -27,8 +27,8 @@ class foreman_proxy::plugin::dhcp::infoblox (
   validate_bool($use_ranges)
 
   foreman_proxy::plugin { 'dhcp_infoblox':
-  } ->
-  foreman_proxy::settings_file { 'dhcp_infoblox':
+  }
+  -> foreman_proxy::settings_file { 'dhcp_infoblox':
     module        => false,
     template_path => 'foreman_proxy/plugin/dhcp_infoblox.yml.erb',
   }

--- a/manifests/plugin/dns/infoblox.pp
+++ b/manifests/plugin/dns/infoblox.pp
@@ -21,8 +21,8 @@ class foreman_proxy::plugin::dns::infoblox (
   validate_string($dns_server, $username, $password)
 
   foreman_proxy::plugin { 'dns_infoblox':
-  } ->
-  foreman_proxy::settings_file { 'dns_infoblox':
+  }
+  -> foreman_proxy::settings_file { 'dns_infoblox':
     module        => false,
     template_path => 'foreman_proxy/plugin/dns_infoblox.yml.erb',
   }

--- a/manifests/plugin/dns/powerdns.pp
+++ b/manifests/plugin/dns/powerdns.pp
@@ -63,8 +63,8 @@ class foreman_proxy::plugin::dns::powerdns (
   }
 
   foreman_proxy::plugin { 'dns_powerdns':
-  } ->
-  foreman_proxy::settings_file { 'dns_powerdns':
+  }
+  -> foreman_proxy::settings_file { 'dns_powerdns':
     module        => false,
     template_path => 'foreman_proxy/plugin/dns_powerdns.yml.erb',
   }

--- a/manifests/plugin/dynflow.pp
+++ b/manifests/plugin/dynflow.pp
@@ -45,8 +45,8 @@ class foreman_proxy::plugin::dynflow (
   }
 
   foreman_proxy::plugin { 'dynflow':
-  } ->
-  foreman_proxy::settings_file { 'dynflow':
+  }
+  -> foreman_proxy::settings_file { 'dynflow':
     enabled       => $enabled,
     listen_on     => $listen_on,
     template_path => 'foreman_proxy/plugin/dynflow.yml.erb',
@@ -62,16 +62,16 @@ class foreman_proxy::plugin::dynflow (
   if $scl_prefix != '' {
     foreman_proxy::plugin { 'dynflow_core':
       package => "${scl_prefix}${::foreman_proxy::plugin_prefix}dynflow_core",
-    } ~>
-    file { '/etc/smart_proxy_dynflow_core/settings.yml':
+    }
+    ~> file { '/etc/smart_proxy_dynflow_core/settings.yml':
       ensure  => file,
       content => template('foreman_proxy/plugin/dynflow_core.yml.erb'),
-    } ~>
-    file { '/etc/smart_proxy_dynflow_core/settings.d':
+    }
+    ~> file { '/etc/smart_proxy_dynflow_core/settings.d':
       ensure => link,
       target => '/etc/foreman-proxy/settings.d',
-    } ~>
-    service { 'smart_proxy_dynflow_core':
+    }
+    ~> service { 'smart_proxy_dynflow_core':
       ensure => running,
       enable => true,
     }

--- a/manifests/plugin/monitoring.pp
+++ b/manifests/plugin/monitoring.pp
@@ -35,8 +35,8 @@ class foreman_proxy::plugin::monitoring (
 
   foreman_proxy::plugin { 'monitoring':
     version => $version,
-  } ->
-  foreman_proxy::settings_file { 'monitoring':
+  }
+  -> foreman_proxy::settings_file { 'monitoring':
     template_path => 'foreman_proxy/plugin/monitoring.yml.erb',
     group         => $group,
     enabled       => $enabled,

--- a/manifests/plugin/omaha.pp
+++ b/manifests/plugin/omaha.pp
@@ -48,8 +48,8 @@ class foreman_proxy::plugin::omaha (
 
   foreman_proxy::plugin { 'omaha':
     version => $version,
-  } ->
-  foreman_proxy::settings_file { 'omaha':
+  }
+  -> foreman_proxy::settings_file { 'omaha':
     template_path => 'foreman_proxy/plugin/omaha.yml.erb',
     group         => $group,
     enabled       => $enabled,
@@ -60,8 +60,8 @@ class foreman_proxy::plugin::omaha (
     command => "mkdir -p ${contentpath}",
     creates => $contentpath,
     path    => '/bin:/usr/bin',
-  } ->
-  file { $contentpath:
+  }
+  -> file { $contentpath:
     ensure  => directory,
   }
 }

--- a/manifests/plugin/openscap.pp
+++ b/manifests/plugin/openscap.pp
@@ -82,8 +82,8 @@ class foreman_proxy::plugin::openscap (
 
   foreman_proxy::plugin { 'openscap':
     version => $version,
-  } ->
-  foreman_proxy::settings_file { 'openscap':
+  }
+  -> foreman_proxy::settings_file { 'openscap':
     template_path => 'foreman_proxy/plugin/openscap.yml.erb',
     listen_on     => $listen_on,
     enabled       => $enabled,

--- a/manifests/plugin/pulp.pp
+++ b/manifests/plugin/pulp.pp
@@ -57,14 +57,14 @@ class foreman_proxy::plugin::pulp (
 
   foreman_proxy::plugin {'pulp':
     version => $version,
-  } ->
-  foreman_proxy::settings_file { 'pulp':
+  }
+  -> foreman_proxy::settings_file { 'pulp':
     template_path => 'foreman_proxy/plugin/pulp.yml.erb',
     group         => $group,
     enabled       => $enabled,
     listen_on     => $listen_on,
-  } ->
-  foreman_proxy::settings_file { 'pulpnode':
+  }
+  -> foreman_proxy::settings_file { 'pulpnode':
     template_path => 'foreman_proxy/plugin/pulpnode.yml.erb',
     group         => $group,
     enabled       => $pulpnode_enabled,

--- a/manifests/plugin/remote_execution/ssh.pp
+++ b/manifests/plugin/remote_execution/ssh.pp
@@ -49,8 +49,8 @@ class foreman_proxy::plugin::remote_execution::ssh (
   include ::foreman_proxy::plugin::dynflow
 
   foreman_proxy::plugin { 'remote_execution_ssh':
-  } ->
-  foreman_proxy::settings_file { 'remote_execution_ssh':
+  }
+  -> foreman_proxy::settings_file { 'remote_execution_ssh':
     enabled       => $enabled,
     listen_on     => $listen_on,
     template_path => 'foreman_proxy/plugin/remote_execution_ssh.yml.erb',
@@ -62,8 +62,8 @@ class foreman_proxy::plugin::remote_execution::ssh (
       owner  => $::foreman_proxy::user,
       group  => $::foreman_proxy::user,
       mode   => '0700',
-    } ->
-    exec { 'generate_ssh_key':
+    }
+    -> exec { 'generate_ssh_key':
       command => "${ssh_keygen} -f ${ssh_identity_path} -N ''",
       user    => $::foreman_proxy::user,
       cwd     => $ssh_identity_dir,
@@ -76,8 +76,8 @@ class foreman_proxy::plugin::remote_execution::ssh (
         owner  => 'root',
         group  => 'root',
         mode   => '0700',
-      } ->
-      exec { 'install_ssh_key':
+      }
+      -> exec { 'install_ssh_key':
         path    => '/usr/bin:/usr/sbin:/bin',
         command => "cat ${ssh_identity_path}.pub >> /root/.ssh/authorized_keys",
         unless  => "grep -f ${ssh_identity_path}.pub /root/.ssh/authorized_keys",

--- a/manifests/plugin/salt.pp
+++ b/manifests/plugin/salt.pp
@@ -63,8 +63,8 @@ class foreman_proxy::plugin::salt (
   }
 
   foreman_proxy::plugin { 'salt':
-  } ->
-  foreman_proxy::settings_file { 'salt':
+  }
+  -> foreman_proxy::settings_file { 'salt':
     enabled       => $enabled,
     listen_on     => $listen_on,
     template_path => 'foreman_proxy/plugin/salt.yml.erb',

--- a/manifests/tftp.pp
+++ b/manifests/tftp.pp
@@ -106,8 +106,8 @@ class foreman_proxy::tftp {
         command => "/usr/bin/grub-mkimage -O x86_64-efi -d ${efi_dir} -o ${foreman_proxy::tftp_root}/grub2/grubx64.efi -p '' ${grub_modules}",
         unless  => "/bin/grep -q regexp '${foreman_proxy::tftp_root}/grub2/grubx64.efi'",
         require => [File[$foreman_proxy::tftp_dirs], Package['grub-common','grub-efi-amd64-bin']],
-      } ->
-      file {"${foreman_proxy::tftp_root}/grub2/grubx64.efi":
+      }
+      -> file {"${foreman_proxy::tftp_root}/grub2/grubx64.efi":
         mode  => '0644',
         owner => 'root',
       }


### PR DESCRIPTION
Two fixes to have the tests pass again. ~~~The linting will still fail with an exception and failures in the traiing_comma check until puppet-lint 2.2.1's released, due to https://github.com/rodjek/puppet-lint/issues/681.~~~