### PR TITLE
Set foreman_smartproxy features for built-in and plugin modules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,7 @@ fixtures:
   repositories:
     apt:      'git://github.com/puppetlabs/puppetlabs-apt'
     concat:   'git://github.com/puppetlabs/puppetlabs-concat'
+    datacat:  'git://github.com/richardc/puppet-datacat'
     dhcp:     'git://github.com/theforeman/puppet-dhcp'
     dns:      'git://github.com/theforeman/puppet-dns'
     extlib:   'git://github.com/voxpupuli/puppet-extlib'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,10 +44,12 @@ class foreman_proxy::config {
 
   foreman_proxy::settings_file { 'bmc':
     enabled   => $::foreman_proxy::bmc,
+    feature   => 'BMC',
     listen_on => $::foreman_proxy::bmc_listen_on,
   }
   foreman_proxy::settings_file { 'dhcp':
     enabled   => $::foreman_proxy::dhcp,
+    feature   => 'DHCP',
     listen_on => $::foreman_proxy::dhcp_listen_on,
   }
   foreman_proxy::settings_file { 'dhcp_isc':
@@ -55,6 +57,7 @@ class foreman_proxy::config {
   }
   foreman_proxy::settings_file { 'dns':
     enabled   => $::foreman_proxy::dns,
+    feature   => 'DNS',
     listen_on => $::foreman_proxy::dns_listen_on,
   }
   foreman_proxy::settings_file { ['dns_nsupdate', 'dns_nsupdate_gss']:
@@ -65,6 +68,7 @@ class foreman_proxy::config {
   }
   foreman_proxy::settings_file { 'puppet':
     enabled   => $::foreman_proxy::puppet,
+    feature   => 'Puppet',
     listen_on => $::foreman_proxy::puppet_listen_on,
   }
   foreman_proxy::settings_file { [
@@ -80,10 +84,12 @@ class foreman_proxy::config {
   }
   foreman_proxy::settings_file { 'puppetca':
     enabled   => $::foreman_proxy::puppetca,
+    feature   => 'Puppet CA',
     listen_on => $::foreman_proxy::puppetca_listen_on,
   }
   foreman_proxy::settings_file { 'realm':
     enabled   => $::foreman_proxy::realm,
+    feature   => 'Realm',
     listen_on => $::foreman_proxy::realm_listen_on,
   }
   if $::foreman_proxy::realm_split_config_files {
@@ -93,14 +99,17 @@ class foreman_proxy::config {
   }
   foreman_proxy::settings_file { 'tftp':
     enabled   => $::foreman_proxy::tftp,
+    feature   => 'TFTP',
     listen_on => $::foreman_proxy::tftp_listen_on,
   }
   foreman_proxy::settings_file { 'templates':
     enabled   => $::foreman_proxy::templates,
+    feature   => 'Templates',
     listen_on => $::foreman_proxy::templates_listen_on,
   }
   foreman_proxy::settings_file { 'logs':
     enabled   => $::foreman_proxy::logs,
+    feature   => 'Logs',
     listen_on => $::foreman_proxy::logs_listen_on,
   }
 

--- a/manifests/feature.pp
+++ b/manifests/feature.pp
@@ -1,0 +1,11 @@
+# Declares that a smart proxy feature should be present and enabled
+#
+# Used by foreman_proxy::register to specify that all of the expected features
+# should be present and enabled. Uses datacat to merge an array of features.
+#
+define foreman_proxy::feature {
+  datacat_fragment { "foreman_proxy::enabled_features::${name}":
+    target => 'foreman_proxy::enabled_features',
+    data   => { 'features' => [$name] },
+  }
+}

--- a/manifests/plugin/abrt.pp
+++ b/manifests/plugin/abrt.pp
@@ -51,6 +51,7 @@ class foreman_proxy::plugin::abrt (
   }
   -> foreman_proxy::settings_file { 'abrt':
     template_path => 'foreman_proxy/plugin/abrt.yml.erb',
+    feature       => 'Abrt',
     group         => $group,
     listen_on     => $listen_on,
     enabled       => $enabled,

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -33,6 +33,7 @@ class foreman_proxy::plugin::ansible (
   }
   -> foreman_proxy::settings_file { 'ansible':
     enabled       => $enabled,
+    feature       => 'Ansible',
     listen_on     => $listen_on,
     template_path => 'foreman_proxy/plugin/ansible.yml.erb',
   }

--- a/manifests/plugin/chef.pp
+++ b/manifests/plugin/chef.pp
@@ -45,6 +45,7 @@ class foreman_proxy::plugin::chef (
   -> foreman_proxy::settings_file { 'chef':
     listen_on     => $listen_on,
     enabled       => $enabled,
+    feature       => 'Chef',
     group         => $group,
     template_path => 'foreman_proxy/plugin/chef.yml.erb',
   }

--- a/manifests/plugin/discovery.pp
+++ b/manifests/plugin/discovery.pp
@@ -21,6 +21,8 @@ class foreman_proxy::plugin::discovery (
   foreman_proxy::plugin {'discovery':
   }
 
+  foreman_proxy::feature { 'Discovery': }
+
   if $install_images {
     $tftp_root_clean = regsubst($tftp_root, '/$', '')
 

--- a/manifests/plugin/dynflow.pp
+++ b/manifests/plugin/dynflow.pp
@@ -36,6 +36,7 @@ class foreman_proxy::plugin::dynflow (
   }
   -> foreman_proxy::settings_file { 'dynflow':
     enabled       => $enabled,
+    feature       => 'Dynflow',
     listen_on     => $listen_on,
     template_path => 'foreman_proxy/plugin/dynflow.yml.erb',
   }

--- a/manifests/plugin/monitoring.pp
+++ b/manifests/plugin/monitoring.pp
@@ -34,6 +34,7 @@ class foreman_proxy::plugin::monitoring (
     template_path => 'foreman_proxy/plugin/monitoring.yml.erb',
     group         => $group,
     enabled       => $enabled,
+    feature       => 'Monitoring',
     listen_on     => $listen_on,
   }
 }

--- a/manifests/plugin/omaha.pp
+++ b/manifests/plugin/omaha.pp
@@ -37,6 +37,7 @@ class foreman_proxy::plugin::omaha (
     template_path => 'foreman_proxy/plugin/omaha.yml.erb',
     group         => $group,
     enabled       => $enabled,
+    feature       => 'Omaha',
     listen_on     => $listen_on,
   }
 

--- a/manifests/plugin/openscap.pp
+++ b/manifests/plugin/openscap.pp
@@ -69,5 +69,6 @@ class foreman_proxy::plugin::openscap (
     template_path => 'foreman_proxy/plugin/openscap.yml.erb',
     listen_on     => $listen_on,
     enabled       => $enabled,
+    feature       => 'Openscap',
   }
 }

--- a/manifests/plugin/salt.pp
+++ b/manifests/plugin/salt.pp
@@ -45,5 +45,6 @@ class foreman_proxy::plugin::salt (
     listen_on     => $listen_on,
     template_path => 'foreman_proxy/plugin/salt.yml.erb',
     group         => $group,
+    feature       => 'Salt',
   }
 }

--- a/manifests/register.pp
+++ b/manifests/register.pp
@@ -1,6 +1,5 @@
 # Register the foreman proxy
 class foreman_proxy::register {
-
   if $foreman_proxy::register_in_foreman {
     foreman_smartproxy { $foreman_proxy::registered_name:
       ensure          => present,
@@ -11,6 +10,15 @@ class foreman_proxy::register {
       ssl_ca          => pick($foreman_proxy::foreman_ssl_ca, $foreman_proxy::ssl_ca),
       url             => $foreman_proxy::real_registered_proxy_url,
     }
-  }
 
+    # Assign the 'features' array from the enabled_features datacat resources to
+    # the above foreman_smartproxy's 'features' parameter, collecting all
+    # expected features from built-in and plugin modules.
+    datacat_collector { 'foreman_proxy::enabled_features':
+      before          => Foreman_smartproxy[$foreman_proxy::registered_name],
+      source_key      => 'features',
+      target_resource => Foreman_smartproxy[$foreman_proxy::registered_name],
+      target_field    => 'features',
+    }
+  }
 }

--- a/manifests/settings_file.pp
+++ b/manifests/settings_file.pp
@@ -22,6 +22,9 @@
 #
 # $mode:           Settings file's mode
 #
+# $feature::       Feature name advertised by proxy module
+#                  If set, foreman_proxy::register will validate the feature name is loaded and advertised.
+#
 define foreman_proxy::settings_file (
   Boolean $module = true,
   Boolean $enabled = true,
@@ -31,6 +34,7 @@ define foreman_proxy::settings_file (
   String $group = $::foreman_proxy::user,
   String $mode = '0640',
   String $template_path = "foreman_proxy/${title}.yml.erb",
+  Optional[String] $feature = undef,
 ) {
   # If the config file is for a proxy module, then we need to know
   # whether it's enabled, and if so, where to listen (https, http, or both).
@@ -43,6 +47,10 @@ define foreman_proxy::settings_file (
         'https' => 'https',
         'http'  => 'http',
         default => false,
+      }
+
+      if $feature {
+        foreman_proxy::feature { $feature: }
       }
     } else {
       $module_enabled = false

--- a/metadata.json
+++ b/metadata.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "theforeman/foreman",
-      "version_requirement": ">= 5.2.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     },
     {
       "name": "theforeman/puppet",
@@ -45,6 +45,10 @@
     {
       "name": "puppet/extlib",
       "version_requirement": ">= 0.10.4 < 2.0.0"
+    },
+    {
+      "name": "richardc/datacat",
+      "version_requirement": ">= 0.6.0 < 1.0.0"
     }
   ],
   "requirements": [

--- a/spec/classes/foreman_proxy__plugin__discovery_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__discovery_spec.rb
@@ -19,6 +19,7 @@ describe 'foreman_proxy::plugin::discovery' do
       end
 
       it { should contain_foreman_proxy__plugin('discovery') }
+      it { should contain_foreman_proxy__feature('Discovery') }
 
       describe 'without paramaters' do
         it { should_not contain_foreman__remote_file("#{tftproot}/boot/fdi-image-latest.tar") }

--- a/spec/defines/foreman_proxy_feature_spec.rb
+++ b/spec/defines/foreman_proxy_feature_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'foreman_proxy::feature' do
+  on_os_under_test.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+      let(:title) { 'Test' }
+
+      it 'should register feature' do
+        is_expected.to contain_datacat_fragment('foreman_proxy::enabled_features::Test').with(
+          data: { 'features' => ['Test'] },
+          target: 'foreman_proxy::enabled_features',
+        )
+      end
+    end
+  end
+end

--- a/spec/defines/foreman_proxy_settings_file_spec.rb
+++ b/spec/defines/foreman_proxy_settings_file_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+describe 'foreman_proxy::settings_file' do
+  on_os_under_test.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      let(:title) { 'test' }
+
+      let(:config_path) do
+        File.join(
+          ['FreeBSD', 'DragonFly'].include?(facts[:osfamily]) ? '/usr/local/etc' : '/etc',
+          'foreman-proxy', 'settings.d', "#{title}.yml"
+        )
+      end
+
+      let :pre_condition do
+        'include foreman_proxy'
+      end
+
+      context 'defaults, module enabled' do
+        it do
+          is_expected.to contain_file(config_path).with(
+            ensure: 'file',
+            owner: 'root',
+            group: ['FreeBSD', 'DragonFly'].include?(facts[:osfamily]) ? 'foreman_proxy' : 'foreman-proxy',
+            mode: '0640',
+          )
+        end
+        it { is_expected.to contain_file(config_path).that_requires('Class[foreman_proxy::install]') }
+        it { is_expected.to contain_file(config_path).that_notifies('Class[foreman_proxy::service]') }
+
+        it 'should set :enabled in config' do
+          verify_exact_contents(catalogue, config_path, ['---', ':enabled: https'])
+        end
+
+        it { is_expected.not_to contain_foreman_proxy__feature('Test') }
+      end
+
+      context 'with feature' do
+        let(:params) { { feature: 'Test' } }
+        it { is_expected.to contain_foreman_proxy__feature('Test') }
+      end
+
+      context 'with listen_on => both' do
+        let(:params) { { listen_on: 'both' } }
+
+        it 'should set :enabled to true in config' do
+          verify_exact_contents(catalogue, config_path, ['---', ':enabled: true'])
+        end
+      end
+
+      context 'with listen_on => http' do
+        let(:params) { { listen_on: 'http' } }
+
+        it 'should set :enabled to http in config' do
+          verify_exact_contents(catalogue, config_path, ['---', ':enabled: http'])
+        end
+      end
+
+      context 'with enabled => false' do
+        let(:params) { { enabled: false } }
+
+        it 'should set :enabled to false in config' do
+          verify_exact_contents(catalogue, config_path, ['---', ':enabled: false'])
+        end
+
+        context 'with feature' do
+          let(:params) { { enabled: false, feature: 'Test' } }
+          it { is_expected.not_to contain_foreman_proxy__feature('Test') }
+        end
+      end
+    end
+  end
+end

--- a/templates/test.yml.erb
+++ b/templates/test.yml.erb
@@ -1,0 +1,4 @@
+---
+# Test file only
+# Can be true, false, or http/https to enable just one of the protocols
+:enabled: <%= @module_enabled %>


### PR DESCRIPTION
Uses datacat to generate an array of enabled features across built-in
and plugin modules by passing the feature name to settings_file, or
using the foreman_proxy::feature type.