### PR TITLE
Fixes - #19956 Set ssl_disabled_ciphers dynflow_core setting

### DIFF
--- a/manifests/plugin/dynflow.pp
+++ b/manifests/plugin/dynflow.pp
@@ -18,6 +18,8 @@
 #
 # $core_port::       Port to use for the local dynflow core service
 #
+# $ssl_disabled_ciphers:: Disable SSL ciphers
+#
 class foreman_proxy::plugin::dynflow (
   Boolean $enabled = $::foreman_proxy::plugin::dynflow::params::enabled,
   Foreman_proxy::ListenOn $listen_on = $::foreman_proxy::plugin::dynflow::params::listen_on,
@@ -25,6 +27,7 @@ class foreman_proxy::plugin::dynflow (
   Boolean $console_auth = $::foreman_proxy::plugin::dynflow::params::console_auth,
   String $core_listen = $::foreman_proxy::plugin::dynflow::params::core_listen,
   Integer[0, 65535] $core_port = $::foreman_proxy::plugin::dynflow::params::core_port,
+  Optional[Array[String]] $ssl_disabled_ciphers = $::foreman_proxy::plugin::dynflow::params::ssl_disabled_ciphers,
 ) inherits foreman_proxy::plugin::dynflow::params {
   if $::foreman_proxy::ssl {
     $core_url = "https://${::fqdn}:${core_port}"

--- a/manifests/plugin/dynflow/params.pp
+++ b/manifests/plugin/dynflow/params.pp
@@ -1,9 +1,10 @@
 # Default parameters for the Dynflow smart proxy plugin
 class foreman_proxy::plugin::dynflow::params {
-  $enabled           = true
-  $listen_on         = 'https'
-  $database_path     = '/var/lib/foreman-proxy/dynflow/dynflow.sqlite'
-  $console_auth      = true
-  $core_listen       = '0.0.0.0'
-  $core_port         = 8008
+  $enabled              = true
+  $listen_on            = 'https'
+  $database_path        = '/var/lib/foreman-proxy/dynflow/dynflow.sqlite'
+  $console_auth         = true
+  $core_listen          = '0.0.0.0'
+  $core_port            = 8008
+  $ssl_disabled_ciphers = undef
 }

--- a/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
@@ -41,4 +41,40 @@ describe 'foreman_proxy::plugin::dynflow' do
       ])
     end
   end
+
+  describe 'with custom settings' do
+    let :facts do
+      on_supported_os['redhat-7-x86_64']
+    end
+
+    let :pre_condition do
+      "include foreman_proxy"
+    end
+    let :params do {
+      :ssl_disabled_ciphers => ['NULL-MD5', 'NULL-SHA'],
+    } end
+
+    it { should contain_foreman_proxy__plugin('dynflow') }
+
+    it 'should create settings.d symlink' do
+      should contain_file("/etc/smart_proxy_dynflow_core/settings.d").
+        with_ensure('link').with_target('/etc/foreman-proxy/settings.d')
+    end
+
+    it 'should generate correct dynflow core settings.yml' do
+      verify_exact_contents(catalogue, "/etc/smart_proxy_dynflow_core/settings.yml", [
+          "---",
+          ":database: /var/lib/foreman-proxy/dynflow/dynflow.sqlite",
+          ":console_auth: true",
+          ":foreman_url: https://foo.example.com",
+          ":listen: 0.0.0.0",
+          ":port: 8008",
+          ":use_https: true",
+          ":ssl_ca_file: /var/lib/puppet/ssl/certs/ca.pem",
+          ":ssl_certificate: /var/lib/puppet/ssl/certs/foo.example.com.pem",
+          ":ssl_private_key: /var/lib/puppet/ssl/private_keys/foo.example.com.pem",
+          ':ssl_disabled_ciphers: ["NULL-MD5", "NULL-SHA"]'
+      ])
+    end
+  end
 end

--- a/templates/plugin/dynflow_core.yml.erb
+++ b/templates/plugin/dynflow_core.yml.erb
@@ -54,6 +54,12 @@
 # :ssl_private_key: ssl/localhost.pem
 # :ssl_certificate: ssl/certs/localhost.pem
 
+<% if ssl && ![nil, :undefined, :undef].include?(scope.lookupvar("foreman_proxy::plugin::dynflow::ssl_disabled_ciphers")) -%>
+:ssl_disabled_ciphers: <%= scope.lookupvar("foreman_proxy::plugin::dynflow::ssl_disabled_ciphers") %>
+<% else -%>
+#:ssl_disabled_ciphers: [CIPHER-SUITE-1, CIPHER-SUITE-2]
+<% end -%>
+
 # File to log to, leave empty for logging to STDOUT
 # :log_file: /var/log/foreman-proxy/smart_proxy_dynflow_core.log
 


### PR DESCRIPTION
This option was added in https://github.com/theforeman/smart_proxy_dynflow/commit/13f7dfe17de94b0bb1a0fecddec834e945eb468b 