### PR TITLE
Improve proxydns

### DIFF
--- a/manifests/proxydns.pp
+++ b/manifests/proxydns.pp
@@ -1,42 +1,67 @@
 # Configure the DNS component
-class foreman_proxy::proxydns {
+#
+# $nsupdate:: The nsupdate package name
+#
+# $ensure_packages_version:: The ensure to use on the nsupdate package
+#
+# $forwarders:: The DNS forwarders to use
+#
+# $interface:: The interface to use for fact determination. By default the IP
+#              is used to create an A record in the forward zone and determine
+#              the reverse DNS zone(s).
+#
+# $forward_zone:: The forward DNS zone name
+#
+# $reverse_zone:: The reverse DNS zone name
+#
+# $soa:: The hostname to use in the SOA record. Also used to create a forward
+#        DNS entry.
+#
+class foreman_proxy::proxydns(
+  $nsupdate = $::foreman_proxy::nsupdate,
+  $ensure_packages_version = $::foreman_proxy::ensure_packages_version,
+  $forwarders = $::foreman_proxy::dns_forwarders,
+  $interface = $::foreman_proxy::dns_interface,
+  $forward_zone = $::foreman_proxy::dns_zone,
+  $reverse_zone = $::foreman_proxy::dns_reverse,
+  String $soa = $::fqdn,
+) {
   class { '::dns':
-    forwarders => $foreman_proxy::dns_forwarders,
+    forwarders => $forwarders,
   }
 
-  ensure_packages([$foreman_proxy::params::nsupdate], { ensure => $foreman_proxy::ensure_packages_version, })
+  ensure_packages([$nsupdate], { ensure => $ensure_packages_version, })
 
   # puppet fact names are converted from ethX.X and ethX:X to ethX_X
   # so for alias and vlan interfaces we have to modify the name accordingly
-  $interface_fact_name = regsubst($foreman_proxy::dns_interface, '[.:]', '_')
+  $interface_fact_name = regsubst($interface, '[.:]', '_')
   $ip = getvar("::ipaddress_${interface_fact_name}")
 
-  if ! is_ip_address($ip) {
+  unless is_ip_address($ip) {
     fail("Could not get the ip address from fact ipaddress_${interface_fact_name}")
   }
 
-  if $::foreman_proxy::dns_reverse {
-    $reverse = $::foreman_proxy::dns_reverse
+  if $reverse_zone {
+    $reverse = $reverse_zone
   } else {
     $netmask = getvar("::netmask_${interface_fact_name}")
     unless is_ip_address($netmask) {
       fail("Could not get the netmask from fact netmask_${interface_fact_name}")
     }
     $reverse = get_network_in_addr($ip, $netmask)
-    if ! is_string($reverse) or $reverse == '' {
+    assert_type(String[1], $reverse) |$expected, $actual| {
       fail("Could not determine reverse for ${ip}/${netmask}")
     }
   }
 
-  dns::zone { $::foreman_proxy::dns_zone:
-    soa     => $::fqdn,
+  dns::zone { $forward_zone:
+    soa     => $soa,
     reverse => false,
     soaip   => $ip,
   }
 
   dns::zone { $reverse:
-    soa     => $::fqdn,
+    soa     => $soa,
     reverse => true,
-    soaip   => $ip,
   }
 }

--- a/spec/classes/foreman_proxy__proxydns__spec.rb
+++ b/spec/classes/foreman_proxy__proxydns__spec.rb
@@ -3,167 +3,234 @@ require 'spec_helper'
 describe 'foreman_proxy::proxydns' do
   on_os_under_test.each do |os, facts|
     context "on #{os}" do
-      context 'without parameters' do
-        let(:facts) do
-          facts.merge({
-            :ipaddress_eth0 => '192.168.100.1',
-            :netmask_eth0   => '255.255.255.0',
-          })
-        end
-
-        let :pre_condition do
-          "class {'foreman_proxy':}"
-        end
-
-        it 'should include the dns class' do
-          should contain_class('dns').with_forwarders([])
-        end
-
-        it 'should install nsupdate' do
-          nsupdate_pkg = case facts[:osfamily]
-                         when 'RedHat'
-                           'bind-utils'
-                         when 'FreeBSD', 'DragonFly'
-                           'bind910'
-                         when 'Archlinux'
-                           'bind-tools'
-                         else
-                           'dnsutils'
-                         end
-          should contain_package(nsupdate_pkg).with_ensure('present')
-        end
-
-        it 'should include the forward zone' do
-          should contain_dns__zone('example.com').with_soa('foo.example.com')
-          should contain_dns__zone('example.com').with_reverse(false)
-          should contain_dns__zone('example.com').with_soaip('192.168.100.1')
-        end
-
-        it 'should include the reverse zone' do
-          should contain_dns__zone('100.168.192.in-addr.arpa').with_soa('foo.example.com')
-          should contain_dns__zone('100.168.192.in-addr.arpa').with_reverse(true)
-          should contain_dns__zone('100.168.192.in-addr.arpa').with_soaip('192.168.100.1')
-        end
-      end
-
-      context 'with dns_zone overridden' do
-        let(:facts) do
-          facts.merge({
-            :ipaddress_eth0 => '192.168.100.1',
-            :netmask_eth0   => '255.255.255.0',
-          })
-        end
-
-        let :pre_condition do
-          "class {'foreman_proxy': dns_zone => 'something.example.com' }"
-        end
-
-        it 'should include the forward zone' do
-          should contain_dns__zone('something.example.com').with_soa('foo.example.com')
-          should contain_dns__zone('something.example.com').with_reverse(false)
-          should contain_dns__zone('something.example.com').with_soaip('192.168.100.1')
-        end
-      end
-
-      context "with vlan interface" do
+      context 'with inherited parameters' do
         let :facts do
-          facts.merge({
-            :ipaddress_eth0_0 => '192.168.100.1',
-            :netmask_eth0_0   => '255.255.255.0',
-          })
-        end
-
-        let :pre_condition do
-          "class {'foreman_proxy':
-            dns_interface => 'eth0.0'
-          }"
-        end
-
-        it 'should include the forward zone' do
-          should contain_dns__zone('example.com').with_soa('foo.example.com')
-          should contain_dns__zone('example.com').with_reverse(false)
-          should contain_dns__zone('example.com').with_soaip('192.168.100.1')
-        end
-
-        it 'should include the reverse zone' do
-          should contain_dns__zone('100.168.192.in-addr.arpa').with_soa('foo.example.com')
-          should contain_dns__zone('100.168.192.in-addr.arpa').with_reverse(true)
-          should contain_dns__zone('100.168.192.in-addr.arpa').with_soaip('192.168.100.1')
-        end
-      end
-
-      context "with alias interface" do
-        let(:facts) do
-          facts.merge({
-            :ipaddress_eth0_0 => '192.168.100.1',
-            :netmask_eth0_0   => '255.255.255.0',
-          })
-        end
-
-        let :pre_condition do
-          "class {'foreman_proxy':
-            dns_interface => 'eth0:0'
-          }"
-        end
-
-        it 'should include the forward zone' do
-          should contain_dns__zone('example.com').with_soa('foo.example.com')
-          should contain_dns__zone('example.com').with_reverse(false)
-          should contain_dns__zone('example.com').with_soaip('192.168.100.1')
-        end
-
-        it 'should include the reverse zone' do
-          should contain_dns__zone('100.168.192.in-addr.arpa').with_soa('foo.example.com')
-          should contain_dns__zone('100.168.192.in-addr.arpa').with_reverse(true)
-          should contain_dns__zone('100.168.192.in-addr.arpa').with_soaip('192.168.100.1')
-        end
-      end
-
-      context "with dns_reverse value" do
-        let(:facts) do
-          facts.merge({
+          facts.merge(
             :ipaddress_eth0 => '192.168.100.1',
             :netmask_eth0   => '255.255.255.0',
-          })
+          )
         end
 
         let :pre_condition do
-          "class {'foreman_proxy':
-            dns_reverse => ['168.192.in-addr.arpa']
-          }"
+          'include ::foreman_proxy'
         end
 
-        it 'should include the reverse zone 168.192.in-addr.arpa' do
-          should contain_dns__zone('168.192.in-addr.arpa').with_soa('foo.example.com')
-          should contain_dns__zone('168.192.in-addr.arpa').with_reverse(true)
-          should contain_dns__zone('168.192.in-addr.arpa').with_soaip('192.168.100.1')
+        nsupdate_pkg = case facts[:osfamily]
+                       when 'RedHat'
+                         'bind-utils'
+                       when 'FreeBSD', 'DragonFly'
+                         'bind910'
+                       when 'Archlinux'
+                         'bind-tools'
+                       else
+                         'dnsutils'
+                       end
+
+        it { should compile.with_all_deps }
+
+        it 'should inherit the correct parameters' do
+          should contain_class('foreman_proxy::proxydns')
+            .with_nsupdate(nsupdate_pkg)
+            .with_ensure_packages_version('present')
+            .with_forwarders([])
+            .with_interface('eth0')
+            .with_forward_zone('example.com')
+            .with_reverse_zone(nil)
+            .with_soa('foo.example.com')
         end
       end
 
-      context "with dns_reverse array" do
-        let(:facts) do
-          facts.merge({
-            :ipaddress_eth0 => '192.168.100.1',
-            :netmask_eth0   => '255.255.255.0',
-          })
+      context 'with explicit parameters' do
+        let :base_params do
+          {
+            :nsupdate                => 'nsupdate',
+            :ensure_packages_version => 'installed',
+            :forwarders              => [],
+            :interface               => 'eth0',
+            :forward_zone            => 'example.com',
+            :reverse_zone            => false,
+          }
         end
 
-        let :pre_condition do
-          "class {'foreman_proxy':
-            dns_reverse => ['0.168.192.in-addr.arpa', '1.168.192.in-addr.arpa']
-          }"
+        context 'with base parameters' do
+          let :facts do
+            facts.merge(
+              :ipaddress_eth0 => '192.168.100.1',
+              :netmask_eth0   => '255.255.255.0',
+            )
+          end
+
+          let :params do
+            base_params
+          end
+
+          it { should compile.with_all_deps }
+
+          it 'should include the dns class' do
+            should contain_class('dns').with_forwarders([])
+          end
+
+          it 'should install nsupdate' do
+            should contain_package('nsupdate').with_ensure('present')
+          end
+
+          it 'should include the forward zone' do
+            should contain_dns__zone('example.com')
+              .with_soa('foo.example.com')
+              .with_reverse(false)
+              .with_soaip('192.168.100.1')
+          end
+
+          it 'should include the reverse zone' do
+            should contain_dns__zone('100.168.192.in-addr.arpa')
+              .with_soa('foo.example.com')
+              .with_reverse(true)
+          end
         end
 
-        it 'should include the reverse zone 0.168.192.in-addr.arpa' do
-          should contain_dns__zone('0.168.192.in-addr.arpa').with_soa('foo.example.com')
-          should contain_dns__zone('0.168.192.in-addr.arpa').with_reverse(true)
-          should contain_dns__zone('0.168.192.in-addr.arpa').with_soaip('192.168.100.1')
+        context 'with dns_zone overridden' do
+          let :facts do
+            facts.merge(
+              :ipaddress_eth0 => '192.168.100.1',
+              :netmask_eth0   => '255.255.255.0',
+            )
+          end
+
+          let :params do
+            base_params.merge(:forward_zone => 'something.example.com')
+          end
+
+          it 'should include the forward zone' do
+            should contain_dns__zone('something.example.com')
+              .with_soa('foo.example.com')
+              .with_reverse(false)
+              .with_soaip('192.168.100.1')
+          end
         end
 
-        it 'should include the reverse zone 1.168.192.in-addr.arpa' do
-          should contain_dns__zone('1.168.192.in-addr.arpa').with_soa('foo.example.com')
-          should contain_dns__zone('1.168.192.in-addr.arpa').with_reverse(true)
-          should contain_dns__zone('1.168.192.in-addr.arpa').with_soaip('192.168.100.1')
+        context "with vlan interface" do
+          let :facts do
+            facts.merge(
+              :ipaddress_eth0_0 => '192.168.100.1',
+              :netmask_eth0_0   => '255.255.255.0',
+            )
+          end
+
+          let :params do
+            base_params.merge(:interface => 'eth0:0')
+          end
+
+          it 'should include the forward zone' do
+            should contain_dns__zone('example.com')
+              .with_soa('foo.example.com')
+              .with_reverse(false)
+              .with_soaip('192.168.100.1')
+          end
+
+          it 'should include the reverse zone' do
+            should contain_dns__zone('100.168.192.in-addr.arpa')
+              .with_soa('foo.example.com')
+              .with_reverse(true)
+          end
+        end
+
+        context "with alias interface" do
+          let :facts do
+            facts.merge(
+              :ipaddress_eth0_0 => '192.168.100.1',
+              :netmask_eth0_0   => '255.255.255.0',
+            )
+          end
+
+          let :params do
+            base_params.merge(:interface => 'eth0:0')
+          end
+
+          it 'should include the forward zone' do
+            should contain_dns__zone('example.com')
+              .with_soa('foo.example.com')
+              .with_reverse(false)
+              .with_soaip('192.168.100.1')
+          end
+
+          it 'should include the reverse zone' do
+            should contain_dns__zone('100.168.192.in-addr.arpa')
+              .with_soa('foo.example.com')
+              .with_reverse(true)
+          end
+        end
+
+        context "with dns_reverse value" do
+          let :facts do
+            facts.merge(
+              :ipaddress_eth0 => '192.168.100.1',
+              :netmask_eth0   => '255.255.255.0',
+            )
+          end
+
+          let :params do
+            base_params.merge(:reverse_zone => ['168.192.in-addr.arpa'])
+          end
+
+          it 'should include the reverse zone 168.192.in-addr.arpa' do
+            should contain_dns__zone('168.192.in-addr.arpa')
+              .with_soa('foo.example.com')
+              .with_reverse(true)
+          end
+        end
+
+        context "with dns_reverse array" do
+          let :facts do
+            facts.merge(
+              :ipaddress_eth0 => '192.168.100.1',
+              :netmask_eth0   => '255.255.255.0',
+            )
+          end
+
+          let :params do
+            base_params.merge(:reverse_zone => ['0.168.192.in-addr.arpa', '1.168.192.in-addr.arpa'])
+          end
+
+          it 'should include the reverse zone 0.168.192.in-addr.arpa' do
+            should contain_dns__zone('0.168.192.in-addr.arpa')
+              .with_soa('foo.example.com')
+              .with_reverse(true)
+          end
+
+          it 'should include the reverse zone 1.168.192.in-addr.arpa' do
+            should contain_dns__zone('1.168.192.in-addr.arpa')
+              .with_soa('foo.example.com')
+              .with_reverse(true)
+          end
+        end
+
+        context 'with an invalid reverse' do
+          context 'missing netmask fact' do
+            let :facts do
+              facts
+            end
+
+            let :params do
+              base_params.merge(:interface => 'invalid')
+            end
+
+            it { should raise_error(Puppet::Error, /Could not get the /) }
+          end
+
+          context 'invalid netmask fact' do
+            let :facts do
+              facts.merge(
+                :ipaddress_eth0 => '192.168.100.1',
+                :netmask_eth0   => '0.0.0.0',
+              )
+            end
+
+            let :params do
+              base_params.merge(:interface => 'eth0')
+            end
+
+            it { should raise_error(Puppet::Error) }
+          end
         end
       end
     end


### PR DESCRIPTION
This uses local variables and drops the (ignored) soaip parameter for reverse zones. The tests are rewritten to use the local variables which results in faster tests. A testcase for inherited parameters still exists to ensure that continues working.