### PR TITLE
Fixes #20721 - use in-memory sqlite in smart proxy dynflow

### DIFF
--- a/manifests/plugin/dynflow.pp
+++ b/manifests/plugin/dynflow.pp
@@ -4,7 +4,7 @@
 #
 # === Parameters:
 #
-# $database_path::   Path to the SQLite database file
+# $database_path::   Path to the SQLite database file, set empty for in-memory sqlite
 #
 # $console_auth::    Whether to enable trusted hosts and ssl for the dynflow console
 #
@@ -23,7 +23,7 @@
 class foreman_proxy::plugin::dynflow (
   Boolean $enabled = $::foreman_proxy::plugin::dynflow::params::enabled,
   Foreman_proxy::ListenOn $listen_on = $::foreman_proxy::plugin::dynflow::params::listen_on,
-  Stdlib::Absolutepath $database_path = $::foreman_proxy::plugin::dynflow::params::database_path,
+  Optional[Stdlib::Absolutepath] $database_path = $::foreman_proxy::plugin::dynflow::params::database_path,
   Boolean $console_auth = $::foreman_proxy::plugin::dynflow::params::console_auth,
   String $core_listen = $::foreman_proxy::plugin::dynflow::params::core_listen,
   Integer[0, 65535] $core_port = $::foreman_proxy::plugin::dynflow::params::core_port,

--- a/manifests/plugin/dynflow/params.pp
+++ b/manifests/plugin/dynflow/params.pp
@@ -2,7 +2,8 @@
 class foreman_proxy::plugin::dynflow::params {
   $enabled              = true
   $listen_on            = 'https'
-  $database_path        = '/var/lib/foreman-proxy/dynflow/dynflow.sqlite'
+  # use in-memory sqlite by default for performance reasons
+  $database_path        = undef
   $console_auth         = true
   $core_listen          = '0.0.0.0'
   $core_port            = 8008

--- a/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
@@ -16,7 +16,7 @@ describe 'foreman_proxy::plugin::dynflow' do
       verify_exact_contents(catalogue, "/etc/foreman-proxy/settings.d/dynflow.yml", [
           '---',
           ':enabled: https',
-          ':database: /var/lib/foreman-proxy/dynflow/dynflow.sqlite',
+          ':database: ',
           ':core_url: https://foo.example.com:8008',
       ])
     end
@@ -29,7 +29,7 @@ describe 'foreman_proxy::plugin::dynflow' do
     it 'should generate correct dynflow core settings.yml' do
       verify_exact_contents(catalogue, "/etc/smart_proxy_dynflow_core/settings.yml", [
           "---",
-          ":database: /var/lib/foreman-proxy/dynflow/dynflow.sqlite",
+          ":database: ",
           ":console_auth: true",
           ":foreman_url: https://foo.example.com",
           ":listen: 0.0.0.0",
@@ -51,6 +51,7 @@ describe 'foreman_proxy::plugin::dynflow' do
       "include foreman_proxy"
     end
     let :params do {
+      :database_path        => '/var/lib/foreman-proxy/dynflow/dynflow.sqlite',
       :ssl_disabled_ciphers => ['NULL-MD5', 'NULL-SHA'],
     } end
 


### PR DESCRIPTION
The persisted sqlite is not suitable for large scale that
is being used by remote execution.