### PR TITLE
Fix TFTP grub_packages for RHEL 7.4+

### DIFF
--- a/manifests/tftp.pp
+++ b/manifests/tftp.pp
@@ -44,6 +44,9 @@ class foreman_proxy::tftp (
       if versioncmp($::operatingsystemmajrelease, '6') <= 0 {
         $grub_type = 'redhat_old'
         $grub_packages = ['grub']
+      } elsif versioncmp($::operatingsystemrelease, '7.4') >= 0 and $::operatingsystem != 'Fedora' {
+        $grub_type = 'redhat'
+        $grub_packages = ['grub2-efi-x64','grub2-efi-x64-modules','grub2-tools','shim-x64']
       } else {
         $grub_type = 'redhat'
         $grub_packages = ['grub2-efi','grub2-efi-modules','grub2-tools','shim']


### PR DESCRIPTION
There were several packages referenced in grub_packages that were obsoleted in RHEL 7.4 by packages suffixed with "-x64".

shim -> shim-x64
grub-efi -> grub-efi-x64
grub-efi-modules -> grub-efi-x64-modules

Example:

```
# cat /etc/redhat-release 
Red Hat Enterprise Linux Server release 7.4 (Maipo)
# yum install shim grub2-efi grub2-efi-modules
Loaded plugins: priorities, product-id, ps, search-disabled-repos, subscription-manager
osc_repo                                                                                                                                                                             | 2.9 kB  00:00:00     
Package shim-0.9-2.el7.x86_64 is obsoleted by shim-x64-12-1.el7.x86_64 which is already installed
Package 1:grub2-efi-2.02-0.44.el7.x86_64 is obsoleted by 1:grub2-efi-x64-2.02-0.64.el7.x86_64 which is already installed
Package 1:grub2-efi-modules-2.02-0.44.el7.x86_64 is obsoleted by 1:grub2-efi-x64-modules-2.02-0.64.el7.noarch which is already installed
Nothing to do

```