### PR TITLE
Add tftp_replace_grub2_cfg parameter to disable replace of grub2.cfg

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -154,6 +154,8 @@
 #
 # $tftp_servername::            Defines the TFTP Servername to use, overrides the name in the subnet declaration
 #
+# $tftp_replace_grub2_cfg::     Determines if grub2.cfg will be replaced
+#
 # $dhcp::                       Enable DHCP feature
 #
 # $dhcp_listen_on::             DHCP proxy to listen on https, http, or both
@@ -350,6 +352,7 @@ class foreman_proxy (
   Stdlib::Absolutepath $tftp_root = $::foreman_proxy::params::tftp_root,
   Array[Stdlib::Absolutepath] $tftp_dirs = $::foreman_proxy::params::tftp_dirs,
   Optional[String] $tftp_servername = $::foreman_proxy::params::tftp_servername,
+  Boolean $tftp_replace_grub2_cfg = $::foreman_proxy::params::tftp_replace_grub2_cfg,
   Boolean $dhcp = $::foreman_proxy::params::dhcp,
   Foreman_proxy::ListenOn $dhcp_listen_on = $::foreman_proxy::params::dhcp_listen_on,
   Boolean $dhcp_managed = $::foreman_proxy::params::dhcp_managed,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -255,12 +255,13 @@ class foreman_proxy::params {
   $logs_listen_on = 'https'
 
   # TFTP settings - requires optional TFTP puppet module
-  $tftp             = true
-  $tftp_listen_on   = 'https'
-  $tftp_managed     = true
-  $tftp_manage_wget = true
-  $tftp_dirs        = ["${tftp_root}/pxelinux.cfg","${tftp_root}/grub","${tftp_root}/grub2","${tftp_root}/boot","${tftp_root}/ztp.cfg","${tftp_root}/poap.cfg"]
-  $tftp_servername  = undef
+  $tftp                   = true
+  $tftp_listen_on         = 'https'
+  $tftp_managed           = true
+  $tftp_manage_wget       = true
+  $tftp_dirs              = ["${tftp_root}/pxelinux.cfg","${tftp_root}/grub","${tftp_root}/grub2","${tftp_root}/boot","${tftp_root}/ztp.cfg","${tftp_root}/poap.cfg"]
+  $tftp_servername        = undef
+  $tftp_replace_grub2_cfg = false
 
   # DHCP settings - requires optional DHCP puppet module
   $dhcp                    = false

--- a/manifests/tftp.pp
+++ b/manifests/tftp.pp
@@ -6,6 +6,7 @@ class foreman_proxy::tftp (
   $syslinux_filenames = $::foreman_proxy::tftp_syslinux_filenames,
   $manage_wget = $::foreman_proxy::tftp_manage_wget,
   $wget_version = $::foreman_proxy::ensure_packages_version,
+  $tftp_replace_grub2_cfg = $::foreman_proxy::tftp_replace_grub2_cfg,
 ) {
   class { '::tftp':
     root => $root,
@@ -24,6 +25,7 @@ class foreman_proxy::tftp (
     owner   => $user,
     mode    => '0644',
     content => file('foreman_proxy/grub.cfg'),
+    replace => $tftp_replace_grub2_cfg,
   }
 
   $syslinux_filenames.each |$source_file| {


### PR DESCRIPTION
Seems Foreman (at least in 1.13) will replace grub2.cfg when "Build PXE Default" is invoked in web interface.  This allows the Puppet module to be told to not replace the file that is managed by Foreman.