### PR TITLE
Fixes #20939 - stop enabling the openscap repo

### DIFF
--- a/manifests/plugin/openscap/params.pp
+++ b/manifests/plugin/openscap/params.pp
@@ -7,7 +7,7 @@ class foreman_proxy::plugin::openscap::params {
     $major_version = $::operatingsystemmajrelease # facter 1.7+
   }
 
-  $configure_openscap_repo = $::osfamily == 'RedHat' and $major_version == '6'
+  $configure_openscap_repo = false
   $enabled                 = true
   $version                 = undef
   $listen_on               = 'https'


### PR DESCRIPTION
We already ship our packages and we no longer support el6. We could drop the param completely, but I suppose that'd break class API.