### PR TITLE
Use the correct variables when checking

### DIFF
--- a/manifests/proxydhcp.pp
+++ b/manifests/proxydhcp.pp
@@ -9,12 +9,12 @@ class foreman_proxy::proxydhcp {
   }
 
   $net  = fact("network_${interface_fact_name}")
-  unless ($ip =~ Stdlib::Compat::Ipv4) {
+  unless ($net =~ Stdlib::Compat::Ipv4) {
     fail("Could not get the network address from fact network_${interface_fact_name}")
   }
 
   $mask = fact("netmask_${interface_fact_name}")
-  unless ($ip =~ Stdlib::Compat::Ipv4) {
+  unless ($mask =~ Stdlib::Compat::Ipv4) {
     fail("Could not get the network mask from fact netmask_${interface_fact_name}")
   }
 


### PR DESCRIPTION
f291aa33fbb6cef2428fd55fd2a23e52622fca0d refactored this to use Puppet 4 types but a copy-paste error means we no longer check the correct values.