### PR TITLE
Fixes #21419 - Fix DHCP directory ACL

### DIFF
--- a/manifests/proxydhcp.pp
+++ b/manifests/proxydhcp.pp
@@ -55,15 +55,14 @@ class foreman_proxy::proxydhcp {
     package {'acl':
       ensure => 'installed',
     }
-    -> exec { 'setfacl_etc_dhcp':
-      command => "setfacl -R -m u:${::foreman_proxy::user}:rx /etc/dhcp",
-      path    => '/usr/bin',
-      onlyif  => "getfacl -p /etc/dhcp | grep user:${::foreman_proxy::user}:r-x",
-    }
-    -> exec { 'setfacl_var_lib_dhcp':
-      command => "setfacl -R -m u:${::foreman_proxy::user}:rx /var/lib/dhcpd",
-      path    => '/usr/bin',
-      onlyif  => "getfacl -p /var/lib/dhcp | grep user:${::foreman_proxy::user}:r-x",
+
+    ['/etc/dhcp', '/var/lib/dhcpd'].each |$path| {
+      exec { "Allow ${::foreman_proxy::user} to read ${path}":
+        command => "setfacl -R -m u:${::foreman_proxy::user}:rx ${path}",
+        path    => '/usr/bin',
+        unless  => "getfacl -p ${path} | grep user:${::foreman_proxy::user}:r-x",
+        require => Package['acl'],
+      }
     }
 
   }

--- a/spec/classes/foreman_proxy__proxydhcp__spec.rb
+++ b/spec/classes/foreman_proxy__proxydhcp__spec.rb
@@ -223,11 +223,11 @@ describe 'foreman_proxy::proxydhcp' do
           }"
         end
 
-        it do should contain_exec('setfacl_etc_dhcp').
+        it do should contain_exec('Allow foreman-proxy to read /etc/dhcp').
           with_command("setfacl -R -m u:foreman-proxy:rx /etc/dhcp")
         end
 
-        it do should contain_exec('setfacl_var_lib_dhcp').
+        it do should contain_exec('Allow foreman-proxy to read /var/lib/dhcpd').
           with_command("setfacl -R -m u:foreman-proxy:rx /var/lib/dhcpd")
         end
       end
@@ -246,20 +246,22 @@ describe 'foreman_proxy::proxydhcp' do
 
         case facts[:osfamily]
         when 'RedHat'
-          it do should contain_exec('setfacl_etc_dhcp').
-            with_command("setfacl -R -m u:foreman-proxy:rx /etc/dhcp")
+          it do should contain_exec('Allow foreman-proxy to read /etc/dhcp').
+            with_command('setfacl -R -m u:foreman-proxy:rx /etc/dhcp').
+            with_unless('getfacl -p /etc/dhcp | grep user:foreman-proxy:r-x')
           end
         else
-          it { should_not contain_exec('setfacl_etc_dhcp') }
+          it { should_not contain_exec('Allow foreman-proxy to read /etc/dhcp') }
         end
 
         case facts[:osfamily]
         when 'RedHat'
-          it do should contain_exec('setfacl_var_lib_dhcp').
-            with_command("setfacl -R -m u:foreman-proxy:rx /var/lib/dhcpd")
+          it do should contain_exec('Allow foreman-proxy to read /var/lib/dhcpd').
+            with_command("setfacl -R -m u:foreman-proxy:rx /var/lib/dhcpd").
+            with_unless('getfacl -p /var/lib/dhcpd | grep user:foreman-proxy:r-x')
           end
         else
-          it { should_not contain_exec('setfacl_var_lib_dhcp') }
+          it { should_not contain_exec('Allow foreman-proxy to read /var/lib/dhcpd') }
         end
       end
     end


### PR DESCRIPTION
Due to the onlyif this was never executed. There was also a typo in the /var/lib/dhcp path. By using a loop we can use a variable that prevents this mismatch.

Spotted by @lpramuk