### PR TITLE
Reduce PARALLEL_TEST_PROCESSORS to 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   matrix:
     - PUPPET_VERSION=4.9
   global:
-    - PARALLEL_TEST_PROCESSORS=16
+    - PARALLEL_TEST_PROCESSORS=8
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
This is mostly to test if it fixes the build. If it does, it should be handled through modulesync.