### PR TITLE
Add support for additional DHCP listen interfaces

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -174,6 +174,11 @@
 #
 # $dhcp_interface::             DHCP listen interface
 #
+# $dhcp_additional_interfaces:: Additional DHCP listen interfaces (in addition to dhcp_interface). Note: as opposed to dhcp_interface
+#                               *no* subnet will be provisioned for any of the additional DHCP listen interfaces. Please configure any
+#                               additional subnets using `dhcp::pool` and related resource types (provided by the theforeman/puppet-dhcp
+#                               module).
+#
 # $dhcp_gateway::               DHCP pool gateway
 #
 # $dhcp_range::                 Space-separated DHCP pool range
@@ -366,6 +371,7 @@ class foreman_proxy (
   Array[String] $dhcp_option_domain = $::foreman_proxy::params::dhcp_option_domain,
   Optional[Array[String]] $dhcp_search_domains = $::foreman_proxy::params::dhcp_search_domains,
   String $dhcp_interface = $::foreman_proxy::params::dhcp_interface,
+  Array[String] $dhcp_additional_interfaces = $::foreman_proxy::params::dhcp_additional_interfaces,
   Optional[String] $dhcp_gateway = $::foreman_proxy::params::dhcp_gateway,
   Variant[Undef, Boolean, String] $dhcp_range = $::foreman_proxy::params::dhcp_range,
   Optional[String] $dhcp_pxeserver = $::foreman_proxy::params::dhcp_pxeserver,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -285,6 +285,7 @@ class foreman_proxy::params {
   $dhcp_provider           = 'isc'
   $dhcp_subnets            = []
   $dhcp_interface          = 'eth0'
+  $dhcp_additional_interfaces = []
   $dhcp_gateway            = '192.168.100.1'
   $dhcp_range              = undef
   $dhcp_option_domain      = [$::domain]

--- a/manifests/proxydhcp.pp
+++ b/manifests/proxydhcp.pp
@@ -33,7 +33,7 @@ class foreman_proxy::proxydhcp {
   class { '::dhcp':
     dnsdomain   => $foreman_proxy::dhcp_option_domain,
     nameservers => $nameservers,
-    interfaces  => [$foreman_proxy::dhcp_interface],
+    interfaces  => [$foreman_proxy::dhcp_interface] + $foreman_proxy::dhcp_additional_interfaces,
     pxeserver   => $ip,
     pxefilename => 'pxelinux.0',
     omapi_name  => $foreman_proxy::dhcp_key_name,


### PR DESCRIPTION
This change adds a new parameter foreman_proxy::dhcp_additional_interfaces which defaults to the empty array `[]`. The parameter's value must be an array of interface names (i.e. an array of strings). When set the managed DHCP server will listen for DHCP requests on these interfaces, in addition to the interface specified in foreman_proxy::dhcp_interface. No subnets will be provisioned for these additional DHCP listen interfaces.

Fixes GH-400.