### PR TITLE
Use modern defaults and document compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,28 +22,13 @@ required.
 
 ## Compatibility
 
-This module only supports Smart Proxy 1.12 or higher as of version 4.0, as the
-configuration layout changed significantly.
-
-To configure older versions of the Smart Proxy use version 2.x of this module
-for 1.5 to 1.10 and 3.x for 1.11.
-
-### 1.16 compatibility notes
-
-On Smart Proxy 1.16+ with puppetca support, also set:
-
-    use_autosignfile => true,
-
-to ensure the new `autosignfile` parameter is used instead of `puppetdir`.
-
-### 1.15 compatibility notes
-
-On Smart Proxy 1.15+ with realm support, also set:
-
-    realm_split_config_files => true,
-
-to ensure the new separate `realm.yml` and `realm_freeipa.yaml` files are
-configured correctly.
+| Module version | Proxy versions | Notes                                           |
+|----------------|----------------|-------------------------------------------------|
+| 5.x            | 1.16 and newer |                                                 |
+| 4.x            | 1.12 - 1.17    | See compatibility notes in its README for 1.15+ |
+| 3.x            | 1.11           |                                                 |
+| 2.x            | 1.5 - 1.10     |                                                 |
+| 1.x            | 1.4 and older  |                                                 |
 
 ## Examples
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -92,10 +92,8 @@ class foreman_proxy::config {
     feature   => 'Realm',
     listen_on => $::foreman_proxy::realm_listen_on,
   }
-  if $::foreman_proxy::realm_split_config_files {
-    foreman_proxy::settings_file { 'realm_freeipa':
-      module => false,
-    }
+  foreman_proxy::settings_file { 'realm_freeipa':
+    module => false,
   }
   foreman_proxy::settings_file { 'tftp':
     enabled   => $::foreman_proxy::tftp,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,9 +81,7 @@
 #
 # $puppet_group::               Groups of Foreman proxy user
 #
-# $autosignfile::               Path to the autosign file. This is needed since version 1.16.
-#
-# $use_autosignfile::           Use $autosignfile? This is needed since version 1.16.
+# $autosignfile::               Path to the autosign file
 #
 # $manage_puppet_group::        Whether to ensure the $puppet_group exists.  Also ensures group owner of ssl keys and certs is $puppet_group
 #                               Not applicable when ssl is false.
@@ -236,8 +234,6 @@
 #
 # $realm::                      Enable realm management feature
 #
-# $realm_split_config_files::   Split realm configuration files. This is needed since version 1.15.
-#
 # $realm_listen_on::            Realm proxy to listen on https, http, or both
 #
 # $realm_provider::             Realm management provider
@@ -322,7 +318,6 @@ class foreman_proxy (
   String $puppetca_cmd = $::foreman_proxy::params::puppetca_cmd,
   String $puppet_group = $::foreman_proxy::params::puppet_group,
   Stdlib::Absolutepath $autosignfile = $::foreman_proxy::params::autosignfile,
-  Boolean $use_autosignfile = $::foreman_proxy::params::use_autosignfile,
   Boolean $manage_puppet_group = $::foreman_proxy::params::manage_puppet_group,
   Boolean $puppet = $::foreman_proxy::params::puppet,
   Foreman_proxy::ListenOn $puppet_listen_on = $::foreman_proxy::params::puppet_listen_on,
@@ -404,7 +399,6 @@ class foreman_proxy (
   Foreman_proxy::ListenOn $bmc_listen_on = $::foreman_proxy::params::bmc_listen_on,
   Enum['ipmitool', 'freeipmi', 'shell'] $bmc_default_provider = $::foreman_proxy::params::bmc_default_provider,
   Boolean $realm = $::foreman_proxy::params::realm,
-  Boolean $realm_split_config_files = $::foreman_proxy::params::realm_split_config_files,
   Foreman_proxy::ListenOn $realm_listen_on = $::foreman_proxy::params::realm_listen_on,
   String $realm_provider = $::foreman_proxy::params::realm_provider,
   Stdlib::Absolutepath $realm_keytab = $::foreman_proxy::params::realm_keytab,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -238,7 +238,6 @@ class foreman_proxy::params {
   $puppetca_cmd       = "${puppet_cmd} cert"
   $puppet_group       = 'puppet'
   $autosignfile       = "${puppetdir}/autosign.conf"
-  $use_autosignfile   = false
 
   # The puppet-agent package, (puppet 4 AIO) doesn't create a puppet group
   $manage_puppet_group = versioncmp($::puppetversion, '4.0') > 0
@@ -343,7 +342,6 @@ class foreman_proxy::params {
   $realm_principal    = 'realm-proxy@EXAMPLE.COM'
   $freeipa_config     = '/etc/ipa/default.conf'
   $freeipa_remove_dns = true
-  $realm_split_config_files = false
 
   # Proxy can register itself within a Foreman instance
   $register_in_foreman = true

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -247,7 +247,7 @@ describe 'foreman_proxy::config' do
             '---',
             ':enabled: https',
             ":ssldir: #{ssl_dir}",
-            ":puppetdir: #{puppet_etc_dir}",
+            ":autosignfile: #{puppet_etc_dir}/autosign.conf",
           ])
         end
 
@@ -287,10 +287,17 @@ describe 'foreman_proxy::config' do
           verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/realm.yml", [
             '---',
             ':enabled: false',
-            ':realm_provider: freeipa',
-            ":realm_keytab: #{etc_dir}/foreman-proxy/freeipa.keytab",
-            ':realm_principal: realm-proxy@EXAMPLE.COM',
-            ':freeipa_remove_dns: true',
+            ':use_provider: realm_freeipa',
+          ])
+        end
+
+        it 'should generate correct realm_freeipa.yml' do
+          verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/realm_freeipa.yml", [
+            '---',
+            ":keytab_path: #{etc_dir}/foreman-proxy/freeipa.keytab",
+            ':principal: realm-proxy@EXAMPLE.COM',
+            ':ipa_config: /etc/ipa/default.conf',
+            ':remove_dns: true',
           ])
         end
 
@@ -420,33 +427,6 @@ describe 'foreman_proxy::config' do
           verify_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/bmc.yml", [
             ':enabled: https',
             ':bmc_default_provider: shell',
-          ])
-        end
-      end
-
-      context 'with realm_split_config_files => true' do
-        let :pre_condition do
-          'class {"foreman_proxy":
-            realm => true,
-            realm_split_config_files => true,
-          }'
-        end
-
-        it 'should generate correct realm.yml' do
-          verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/realm.yml", [
-            '---',
-            ':enabled: https',
-            ':use_provider: realm_freeipa',
-          ])
-        end
-
-        it 'should generate correct realm_freeipa.yml' do
-          verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/realm_freeipa.yml", [
-            '---',
-            ":keytab_path: #{etc_dir}/foreman-proxy/freeipa.keytab",
-            ':principal: realm-proxy@EXAMPLE.COM',
-            ':ipa_config: /etc/ipa/default.conf',
-            ':remove_dns: true',
           ])
         end
       end
@@ -820,24 +800,6 @@ describe 'foreman_proxy::config' do
             "#{proxy_user_name} ALL = (root) NOPASSWD : #{puppetca_command}",
             "#{proxy_user_name} ALL = (some_puppet_user) NOPASSWD : #{puppetrun_command}",
             "Defaults:#{proxy_user_name} !requiretty",
-          ])
-        end
-      end
-
-      context 'with use_autosignfile => true' do
-        let :pre_condition do
-          'class {"foreman_proxy":
-            puppetca         => true,
-            use_autosignfile => true,
-          }'
-        end
-
-        it 'should generate correct puppetca.yml' do
-          verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/puppetca.yml", [
-              '---',
-              ':enabled: https',
-              ":ssldir: #{ssl_dir}",
-              ":autosignfile: #{puppet_etc_dir}/autosign.conf",
           ])
         end
       end

--- a/templates/puppetca.yml.erb
+++ b/templates/puppetca.yml.erb
@@ -2,8 +2,4 @@
 # PuppetCA management
 :enabled: <%= @module_enabled %>
 :ssldir: <%= scope.lookupvar("foreman_proxy::ssldir") %>
-<% if scope.lookupvar("foreman_proxy::use_autosignfile") -%>
 :autosignfile: <%= scope.lookupvar("foreman_proxy::autosignfile") %>
-<% else -%>
-:puppetdir: <%= scope.lookupvar("foreman_proxy::puppetdir") %>
-<% end -%>

--- a/templates/realm.yml.erb
+++ b/templates/realm.yml.erb
@@ -1,5 +1,4 @@
 ---
-<% if scope.lookupvar("foreman_proxy::realm_split_config_files") -%>
 # Can be true, false, or http/https to enable just one of the protocols
 :enabled: <%= @module_enabled %>
 
@@ -7,19 +6,3 @@
 #   realm_ad
 #   realm_freeipa
 :use_provider: realm_<%= scope.lookupvar("foreman_proxy::realm_provider") %>
-<% else -%>
-# Manage joining realms e.g. FreeIPA
-:enabled: <%= @module_enabled %>
-
-# Available providers:
-#   freeipa
-:realm_provider: <%= scope.lookupvar("foreman_proxy::realm_provider") %>
-
-# Authentication for Kerberos-based Realms
-:realm_keytab: <%= scope.lookupvar("foreman_proxy::realm_keytab") %>
-:realm_principal: <%= scope.lookupvar("foreman_proxy::realm_principal") %>
-
-# FreeIPA specific settings
-# Remove from DNS when deleting the FreeIPA entry
-:freeipa_remove_dns: <%= scope.lookupvar("foreman_proxy::freeipa_remove_dns") %>
-<% end -%>


### PR DESCRIPTION
We can assume new installations. Users of older versions should read the
notes on compatibility.