### PR TITLE
Use puppet4 functions-api

### DIFF
--- a/lib/puppet/functions/foreman_proxy/get_network_in_addr.rb
+++ b/lib/puppet/functions/foreman_proxy/get_network_in_addr.rb
@@ -1,21 +1,22 @@
-module Puppet::Parser::Functions
-  newfunction(:get_network_in_addr, :type => :rvalue,
-              :doc => 'Get the in-addr.arpa notation for the given IP address and a netmask'
-  ) do |args|
-    require 'ipaddr'
+# Get the in-addr.arpa notation for the given IP address and a netmask
 
-    if args.length != 2 then
-      raise Puppet::ParseError, ("get_network_in_addr(): must give an address and a netmask)")
-    end
+require 'ipaddr'
 
+Puppet::Functions.create_function(:'foreman_proxy::get_network_in_addr') do
+  dispatch :get_network_in_addr do
+    required_param 'String', :addr
+    required_param 'String', :netm
+  end
+
+  def get_network_in_addr(addr, netm)
     begin
-      address = IPAddr.new(args[0])
+      address = IPAddr.new(addr)
     rescue
       raise Puppet::ParseError.new("get_network_in_addr(): address is not a valid IPv4 address")
     end
 
     begin
-      netmask = IPAddr.new(args[1])
+      netmask = IPAddr.new(netm)
     rescue
       raise Puppet::ParseError.new("get_network_in_addr(): netmask is not a valid IPv4 address")
     end

--- a/manifests/proxydns.pp
+++ b/manifests/proxydns.pp
@@ -48,7 +48,7 @@ class foreman_proxy::proxydns(
     unless is_ip_address($netmask) {
       fail("Could not get the netmask from fact netmask_${interface_fact_name}")
     }
-    $reverse = get_network_in_addr($ip, $netmask)
+    $reverse = foreman_proxy::get_network_in_addr($ip, $netmask)
     assert_type(String[1], $reverse) |$expected, $actual| {
       fail("Could not determine reverse for ${ip}/${netmask}")
     }

--- a/spec/functions/get_network_in_addr_spec.rb
+++ b/spec/functions/get_network_in_addr_spec.rb
@@ -12,10 +12,10 @@ describe 'foreman_proxy::get_network_in_addr' do
   end
 
   it 'should throw an error on invalid parameters' do
-    is_expected.to run.with_params('192.168.1', '255.255.255.0').and_raise_error(Puppet::ParseError)
-    is_expected.to run.with_params('2001:db8::1', '255.255.255.0').and_raise_error(Puppet::ParseError)
-    is_expected.to run.with_params('192.168.1.0', '32').and_raise_error(Puppet::ParseError)
-    is_expected.to run.with_params('192.168.1.0', '2001:db8::1').and_raise_error(Puppet::ParseError)
+    is_expected.to run.with_params('192.168.1', '255.255.255.0').and_raise_error(ArgumentError)
+    is_expected.to run.with_params('2001:db8::1', '255.255.255.0').and_raise_error(ArgumentError)
+    is_expected.to run.with_params('192.168.1.0', '32').and_raise_error(ArgumentError)
+    is_expected.to run.with_params('192.168.1.0', '2001:db8::1').and_raise_error(ArgumentError)
   end
 
   it 'should work on IPv4 /8 to /32' do
@@ -33,7 +33,7 @@ describe 'foreman_proxy::get_network_in_addr' do
 
   it 'should fail on IPv4 /0 to /7' do
     ['0.0.0.0.0', '128.0.0.0', '192.0.0.0', '224.0.0.0', '240.0.0.0', '248.0.0.0', '252.0.0.0', '254.0.0.0'].each do |netmask|
-      is_expected.to run.with_params('192.168.1.0', netmask).and_raise_error(Puppet::ParseError)
+      is_expected.to run.with_params('192.168.1.0', netmask).and_raise_error(ArgumentError)
     end
   end
 end

--- a/spec/functions/get_network_in_addr_spec.rb
+++ b/spec/functions/get_network_in_addr_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
-describe 'get_network_in_addr' do
+describe 'foreman_proxy::get_network_in_addr' do
   it 'should exist' do
-    expect(Puppet::Parser::Functions.function('get_network_in_addr')).to eq 'function_get_network_in_addr'
+    is_expected.not_to eq(nil)
   end
 
   it 'should throw an error with bad number of arguments' do
-    is_expected.to run.with_params().and_raise_error(Puppet::ParseError)
-    is_expected.to run.with_params('192.168.1.0').and_raise_error(Puppet::ParseError)
-    is_expected.to run.with_params('192.168.1.0', '255.255.255.0', 'additional').and_raise_error(Puppet::ParseError)
+    is_expected.to run.with_params().and_raise_error(ArgumentError)
+    is_expected.to run.with_params('192.168.1.0').and_raise_error(ArgumentError)
+    is_expected.to run.with_params('192.168.1.0', '255.255.255.0', 'additional').and_raise_error(ArgumentError)
   end
 
   it 'should throw an error on invalid parameters' do


### PR DESCRIPTION
The legacy puppet3 functions-api should be avoided.
This migrates the existing function and its test to the new api and uses it in the module.