### PR TITLE
Fixes #22479 - Handle remote directory with undefined parent

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,5 +1,8 @@
 ---
 .travis.yml:
+  beaker_sets:
+    - docker/centos-7
+    - docker/debian-9
   env:
     global:
       - PARALLEL_TEST_PROCESSORS=8

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,18 @@ matrix:
   include:
     - rvm: 2.4.1
       env: PUPPET_VERSION=5.0
+    # Acceptance tests
+    - rvm: 2.3.1
+      dist: trusty
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7
+      script: bundle exec rake beaker
+      services: docker
+      bundler_args: --without development
+    - rvm: 2.3.1
+      dist: trusty
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/debian-9
+      script: bundle exec rake beaker
+      services: docker
+      bundler_args: --without development
 bundler_args: --without system_tests development
 sudo: false

--- a/manifests/plugin/discovery.pp
+++ b/manifests/plugin/discovery.pp
@@ -26,10 +26,9 @@ class foreman_proxy::plugin::discovery (
   if $install_images {
     $tftp_root_clean = regsubst($tftp_root, '/$', '')
 
-    foreman::remote_file {"${tftp_root_clean}/boot/${image_name}":
+    foreman_proxy::remote_file {"${tftp_root_clean}/boot/${image_name}":
       remote_location => "${source_url}${image_name}",
       mode            => '0644',
-      require         => File["${tftp_root_clean}/boot"],
     } ~> exec { "untar ${image_name}":
       command => "tar xf ${image_name}",
       path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',

--- a/manifests/remote_file.pp
+++ b/manifests/remote_file.pp
@@ -1,0 +1,17 @@
+# Downloads a file from a URL to a local file given by the title
+define foreman_proxy::remote_file(
+  $remote_location,
+  $mode='0644',
+) {
+  $parent = dirname($title)
+  File <| title == $parent |>
+  -> exec { "mkdir -p ${parent}":
+    path    => ['/bin', '/usr/bin'],
+    creates => $parent,
+  }
+  -> file { $title:
+    source  => $remote_location,
+    mode    => $mode,
+    replace => false,
+  }
+}

--- a/spec/acceptance/foreman_remote_file_spec.rb
+++ b/spec/acceptance/foreman_remote_file_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper_acceptance'
+
+describe 'remote_file works' do
+  let(:pp) do
+    <<-MANIFEST
+    foreman_proxy::remote_file { '/var/tmp/test':
+      remote_location => 'https://codeload.github.com/theforeman/puppet-foreman/tar.gz/9.0.0',
+    }
+    MANIFEST
+  end
+
+  it_behaves_like 'a idempotent resource'
+
+  describe file('/var/tmp/test') do
+    its(:md5sum) { should eq '5ef89571e3775b4bc17e4f5a55d1c146' }
+  end
+end

--- a/spec/classes/foreman_proxy__plugin__discovery_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__discovery_spec.rb
@@ -18,11 +18,12 @@ describe 'foreman_proxy::plugin::discovery' do
           tftproot = '/var/lib/tftpboot'
       end
 
-      it { should contain_foreman_proxy__plugin('discovery') }
-      it { should contain_foreman_proxy__feature('Discovery') }
-
       describe 'without paramaters' do
-        it { should_not contain_foreman__remote_file("#{tftproot}/boot/fdi-image-latest.tar") }
+        it { should compile.with_all_deps }
+        it { should contain_foreman_proxy__plugin('discovery') }
+        it { should contain_foreman_proxy__feature('Discovery') }
+        it { should_not contain_foreman_proxy__remote_file("#{tftproot}/boot/fdi-image-latest.tar") }
+        it { should_not contain_exec('untar fdi-image-latest.tar') }
       end
 
       describe 'with install_images => true' do
@@ -32,8 +33,12 @@ describe 'foreman_proxy::plugin::discovery' do
           }
         end
 
+        it { should compile.with_all_deps }
+        it { should contain_foreman_proxy__plugin('discovery') }
+        it { should contain_foreman_proxy__feature('Discovery') }
+
         it 'should download and install tarball' do
-          should contain_foreman__remote_file("#{tftproot}/boot/fdi-image-latest.tar").
+          should contain_foreman_proxy__remote_file("#{tftproot}/boot/fdi-image-latest.tar").
             with_remote_location('http://downloads.theforeman.org/discovery/releases/latest/fdi-image-latest.tar')
         end
 

--- a/spec/defines/foreman_proxy_remote_file_spec.rb
+++ b/spec/defines/foreman_proxy_remote_file_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'foreman_proxy::remote_file' do
+  let(:title) { '/tmp/a' }
+
+  let(:params) do
+    {
+      remote_location: 'https://example.com/tmp/a',
+      mode: '0664'
+    }
+  end
+
+  context 'default scenario' do
+    it { is_expected.to contain_exec('mkdir -p /tmp') }
+
+    it do
+      is_expected.to contain_file('/tmp/a')
+        .with_source('https://example.com/tmp/a')
+        .with_mode('0664')
+        .that_requires('Exec[mkdir -p /tmp]')
+    end
+  end
+
+  context 'with parent file defined' do
+    let :pre_condition do
+      "file { '/tmp': }"
+    end
+
+    it { is_expected.to contain_exec('mkdir -p /tmp').that_requires('File[/tmp]') }
+  end
+end


### PR DESCRIPTION
This can happen when tftp is set to false or unmanaged.

We move the remote_file define to this module since puppet-foreman no longer uses it itself. That will allow us to remove it there in a next major release.