### PR TITLE
Fixes #22842 - Create .ansible.cfg in /etc/foreman-proxy

### DIFF
--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -27,12 +27,16 @@ class foreman_proxy::plugin::ansible (
   Optional[Stdlib::Absolutepath] $working_dir = $::foreman_proxy::plugin::ansible::params::working_dir,
   Boolean $host_key_checking = $::foreman_proxy::plugin::ansible::params::host_key_checking,
 ) inherits foreman_proxy::plugin::ansible::params {
-  file {"${::foreman_proxy::dir}/.ansible.cfg":
+  file {"${::foreman_proxy::etc}/foreman-proxy/ansible.cfg":
     ensure  => file,
     content => template('foreman_proxy/plugin/ansible.cfg.erb'),
     owner   => 'root',
     group   => $::foreman_proxy::user,
     mode    => '0640',
+  }
+  ~> file { "${::foreman_proxy::dir}/.ansible.cfg":
+    ensure => link,
+    target => "${::foreman_proxy::etc}/foreman-proxy/ansible.cfg",
   }
 
   include ::foreman_proxy::plugin::dynflow

--- a/spec/classes/foreman_proxy__plugin__ansible_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__ansible_spec.rb
@@ -22,7 +22,7 @@ describe 'foreman_proxy::plugin::ansible' do
         end
 
         it 'should configure ansible.cfg' do
-          verify_exact_contents(catalogue, '/usr/share/foreman-proxy/.ansible.cfg', [
+          verify_exact_contents(catalogue, '/etc/foreman-proxy/ansible.cfg', [
             '[defaults]',
             'callback_whitelist = foreman',
             'local_tmp = /tmp',
@@ -55,7 +55,7 @@ describe 'foreman_proxy::plugin::ansible' do
         end
 
         it 'should configure ansible.cfg' do
-          verify_exact_contents(catalogue, '/usr/share/foreman-proxy/.ansible.cfg', [
+          verify_exact_contents(catalogue, '/etc/foreman-proxy/ansible.cfg', [
             '[defaults]',
             'callback_whitelist = foreman',
             'local_tmp = /tmp/ansible',


### PR DESCRIPTION
Currently we just mention it in the documentation https://github.com/theforeman/theforeman.org/pull/1033/files
but the installer should do this. The directory is used for some Ansible
tmp files