### PR TITLE
Fixes #22843 - host_key_checking should be False

### DIFF
--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -13,11 +13,19 @@
 #
 # $listen_on::   Proxy feature listens on https, http, or both
 #
+# $host_key_checking:: Whether to ignore errors when a host is reinstalled
+#                      so it has a different key in ~/.ssh/known_hosts
+#                      If a host is not initially in 'known_hosts' setting
+#                      this to True will result in prompting for confirmation
+#                      of the key, which is not possible from non-interactive
+#                      environments like Foreman Remote Execution or cron
+#
 class foreman_proxy::plugin::ansible (
   Boolean $enabled = $::foreman_proxy::plugin::ansible::params::enabled,
   Foreman_proxy::ListenOn $listen_on = $::foreman_proxy::plugin::ansible::params::listen_on,
   Stdlib::Absolutepath $ansible_dir = $::foreman_proxy::plugin::ansible::params::ansible_dir,
   Optional[Stdlib::Absolutepath] $working_dir = $::foreman_proxy::plugin::ansible::params::working_dir,
+  Boolean $host_key_checking = $::foreman_proxy::plugin::ansible::params::host_key_checking,
 ) inherits foreman_proxy::plugin::ansible::params {
   file {"${::foreman_proxy::dir}/.ansible.cfg":
     ensure  => file,

--- a/manifests/plugin/ansible/params.pp
+++ b/manifests/plugin/ansible/params.pp
@@ -4,4 +4,5 @@ class foreman_proxy::plugin::ansible::params {
   $listen_on   = 'https'
   $ansible_dir = '/etc/ansible'
   $working_dir = '/tmp'
+  $host_key_checking = false
 }

--- a/templates/plugin/ansible.cfg.erb
+++ b/templates/plugin/ansible.cfg.erb
@@ -1,3 +1,4 @@
 [defaults]
 callback_whitelist = foreman
 local_tmp = <%= @working_dir %>
+host_key_checking = <%= @host_key_checking ? 'True' : 'False' %>


### PR DESCRIPTION
Otherwise the user may encounter the situation where they have to log in as
the foreman-proxy user, then accept the authenticity of a host, or add it
to known hosts manually.