### PR TITLE
Fixes #22845 - Install python-requests with Ansible

### DIFF
--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -41,4 +41,6 @@ class foreman_proxy::plugin::ansible (
   if $::osfamily == 'RedHat' and $::operatingsystem != 'Fedora' {
     Foreman_proxy::Settings_file['ansible'] ~> Service['smart_proxy_dynflow_core']
   }
+
+  ensure_packages(['python-requests'], { ensure => 'present', })
 }


### PR DESCRIPTION
The callback needs this. It's already a very common package to have, but
if there's a clean installation of Foreman without Pulp, it will not be
there and the callback will not run until this dependency is installed.