### PR TITLE
Pin facterdb to 0.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'rspec', '~> 3.0'
 gem 'rdoc', '~> 5.1.0', {"platforms"=>["ruby_21"]}
 gem 'rspec-puppet', '~> 2.3'
 gem 'rspec-puppet-facts', '>= 1.7'
+gem 'facterdb', '0.5.0'
 gem 'puppetlabs_spec_helper', '>= 2.1.1'
 gem 'puppet-lint', '>= 2'
 gem 'puppet-lint-absolute_classname-check'


### PR DESCRIPTION
Facterdb 0.5.1 has ArchLinux facts which lack the legacy facts we rely on. These facts are still available, but not in facterdb. We can't rely on the new networking facts yet because facter 2.x (used on Debian and Fedora without AIO) doesn't have them.

Longer term we should support both fact styles and remove this pin.