### PR TITLE
Listen on IPv6 on EL7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -184,7 +184,11 @@ class foreman_proxy::params {
   $plugin_version          = 'installed'
 
   # Enable listening on http
-  $bind_host = ['*']
+  if $::osfamily == 'RedHat' and versioncmp($::operatingsystemmajrelease, '7') <= 0 {
+    $bind_host = ['::']
+  } else {
+    $bind_host = ['*']
+  }
   $http      = false
   $http_port = 8000
 

--- a/spec/classes/foreman_proxy__config__spec.rb
+++ b/spec/classes/foreman_proxy__config__spec.rb
@@ -32,6 +32,12 @@ describe 'foreman_proxy::config' do
         ssl_dir = '/var/lib/puppet/ssl'
       end
 
+      if facts[:osfamily] == 'RedHat' and facts[:operatingsystemmajrelease].to_i <= 7
+        bind_host = '::'
+      else
+        bind_host = '*'
+      end
+
       puppetca_command = "#{usr_dir}/bin/puppet cert *"
       puppetrun_command = "#{usr_dir}/bin/puppet kick *"
 
@@ -103,7 +109,7 @@ describe 'foreman_proxy::config' do
             "  - #{facts[:fqdn]}",
             ":foreman_url: https://#{facts[:fqdn]}",
             ':daemon: true',
-            ':bind_host: \'*\'',
+            ":bind_host: '#{bind_host}'",
             ':https_port: 8443',
             ':log_file: /var/log/foreman-proxy/proxy.log',
             ':log_level: INFO',


### PR DESCRIPTION
On Ruby 2.0 listening on * only listens on IPv4. Listening on :: listens on both IPv4 and IPv6.

Original issue:

https://bugs.ruby-lang.org/issues/7100
https://github.com/ruby/ruby/commit/b1f493dcd1092fe17cccec998e175516ed5c6e47

This will need a proper verification but I think we're seeing this issue in our CI pipeline where we set `/etc/hosts` with IPv6.