### PR TITLE
Add dhcp options to allow overrides

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -185,6 +185,12 @@
 #
 # $dhcp_pxeserver::             DHCP "next-server" value, defaults otherwise to IP of dhcp_interface
 #
+# $dhcp_pxefilename::           DHCP "filename" value, defaults otherwise to pxelinux.0
+#
+# $dhcp_network::               DHCP server network value, defaults otherwise to undef
+#
+# $dhcp_netmask::               DHCP server netmask value, defaults otherwise to undef
+#
 # $dhcp_server::                Address of DHCP server to manage
 #
 # $dhcp_config::                DHCP config file path
@@ -370,6 +376,9 @@ class foreman_proxy (
   Optional[String] $dhcp_gateway = $::foreman_proxy::params::dhcp_gateway,
   Variant[Undef, Boolean, String] $dhcp_range = $::foreman_proxy::params::dhcp_range,
   Optional[String] $dhcp_pxeserver = $::foreman_proxy::params::dhcp_pxeserver,
+  Optional[String] $dhcp_pxefilename = $::foreman_proxy::params::dhcp_pxefilename,
+  Optional[String] $dhcp_network = $::foreman_proxy::params::dhcp_network,
+  Optional[String] $dhcp_netmask = $::foreman_proxy::params::dhcp_netmask,
   String $dhcp_nameservers = $::foreman_proxy::params::dhcp_nameservers,
   String $dhcp_server = $::foreman_proxy::params::dhcp_server,
   Stdlib::Absolutepath $dhcp_config = $::foreman_proxy::params::dhcp_config,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -290,6 +290,9 @@ class foreman_proxy::params {
   $dhcp_option_domain      = [$::domain]
   $dhcp_search_domains     = undef
   $dhcp_pxeserver          = undef
+  $dhcp_pxefilename        = 'pxelinux.0'
+  $dhcp_network            = undef
+  $dhcp_netmask            = undef
   # This will use the IP of the interface in $dhcp_interface, override
   # if you need to. You can make this a comma-separated string too - it
   # will be split into an array

--- a/manifests/proxydhcp.pp
+++ b/manifests/proxydhcp.pp
@@ -8,12 +8,12 @@ class foreman_proxy::proxydhcp {
     fail("Could not get the ip address from fact ipaddress_${interface_fact_name}")
   }
 
-  $net  = fact("network_${interface_fact_name}")
+  $net  = pick_default($::foreman_proxy::dhcp_network, fact("network_${interface_fact_name}"))
   unless ($net =~ Stdlib::Compat::Ipv4) {
     fail("Could not get the network address from fact network_${interface_fact_name}")
   }
 
-  $mask = fact("netmask_${interface_fact_name}")
+  $mask = pick_default($::foreman_proxy::dhcp_netmask, fact("netmask_${interface_fact_name}"))
   unless ($mask =~ Stdlib::Compat::Ipv4) {
     fail("Could not get the network mask from fact netmask_${interface_fact_name}")
   }
@@ -35,7 +35,7 @@ class foreman_proxy::proxydhcp {
     nameservers => $nameservers,
     interfaces  => [$foreman_proxy::dhcp_interface] + $foreman_proxy::dhcp_additional_interfaces,
     pxeserver   => $ip,
-    pxefilename => 'pxelinux.0',
+    pxefilename => $foreman_proxy::dhcp_pxefilename,
     omapi_name  => $foreman_proxy::dhcp_key_name,
     omapi_key   => $foreman_proxy::dhcp_key_secret,
   }


### PR DESCRIPTION
 - pxefilename (defaults to pxelinux.0) - for example if it was desired to use lpxelinux.0
 - network (of the dhcp server, defaults to undef) - the pxeserver is already a variable so it seems reasonable to allow the network to also be variable
 - netmask (of the dhcp server, defaults to undef) - the pxeserver is already a variable so it seems reasonable to allow the netmask to also be variable