### PR TITLE
Fixes #23477 - Add puppet user to foreman-proxy group

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -138,6 +138,11 @@ class foreman_proxy::config {
         changes => template('foreman_proxy/sudo_augeas.erb'),
       }
     }
+    if $foreman_proxy::puppetca {
+      if $::foreman_proxy::puppet_user != 'root' {
+        ensure_resources('user', { $::foreman_proxy::puppet_user => { groups => $::foreman_proxy::user } }, { ensure => 'present' })
+      }
+    }
   } else {
     # The puppet-agent (puppet 4 AIO package) doesn't create a puppet user and group
     # but the foreman proxy still needs to be able to read the agent's private key


### PR DESCRIPTION
Adds the script to a PuppetCA-SmartProxy-Host that is
called by puppet with the incoming csr and forwards
it to the smart proxy where the request will be processed.

See also PRs in [foreman-core](https://github.com/theforeman/foreman/pull/5465), [smart-proxy](https://github.com/theforeman/smart-proxy/pull/576), [community-templates](https://github.com/theforeman/community-templates/pull/475) & [puppet-puppet](https://github.com/theforeman/puppet-puppet/pull/591).

We would like to see some feedback early on while we are testing this thoroughly.