### PR TITLE
Fixes #23905 - Use /usr/share/foreman-proxy as ansible_dir

### DIFF
--- a/manifests/plugin/ansible/params.pp
+++ b/manifests/plugin/ansible/params.pp
@@ -2,7 +2,7 @@
 class foreman_proxy::plugin::ansible::params {
   $enabled     = true
   $listen_on   = 'https'
-  $ansible_dir = '/etc/ansible'
+  $ansible_dir = '/usr/share/foreman-proxy'
   $working_dir = '/tmp'
   $host_key_checking = false
 }

--- a/spec/classes/foreman_proxy__plugin__ansible_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__ansible_spec.rb
@@ -18,7 +18,7 @@ describe 'foreman_proxy::plugin::ansible' do
         it 'should configure ansible.yml' do
           should contain_file('/etc/foreman-proxy/settings.d/ansible.yml').
             with_content(/:enabled: https/).
-            with_content(%r{:ansible_dir: /etc/ansible})
+            with_content(%r{:ansible_dir: /usr/share/foreman-proxy})
         end
 
         it 'should configure ansible.cfg' do


### PR DESCRIPTION
Using /etc/ansible means that the ~foreman-proxy/.ansible.cfg file we
had set up will be ignored. This means the callback is ignored and any
other options we might set in /etc/foreman-proxy/ansible.cfg

To reproduce, you can just start a centos7-katello-nightly box, install foreman-ansible and try to run a job. You'll run into the host key verification problem we try to solve in https://github.com/theforeman/foreman_ansible/pull/176 - even with `host_key_checking = False` in `/etc/foreman-proxy/ansible.cfg`