### PR TITLE
Fixes #24012 - Add PuppetCA providers settings

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -90,6 +90,7 @@ class foreman_proxy::config {
   if $::foreman_proxy::puppetca_modular {
     foreman_proxy::settings_file { [
         'puppetca_hostname_whitelisting',
+        'puppetca_token_whitelisting',
       ]:
         module => false,
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,6 +83,8 @@
 #
 # $autosignfile::               Hostname-Whitelisting only: Location of puppets autosign.conf
 #
+# $puppetca_tokens_file::       Token-Whitelisting only: Location of the tokens.yaml
+#
 # $manage_puppet_group::        Whether to ensure the $puppet_group exists.  Also ensures group owner of ssl keys and certs is $puppet_group
 #                               Not applicable when ssl is false.
 #
@@ -295,6 +297,12 @@
 #
 # $puppetca_provider::          Whether to use puppetca_hostname_whitelisting or puppetca_token_whitelisting
 #
+# $puppetca_sign_all::          Token-whitelisting only: Whether to sign all CSRs without checking their token
+#
+# $puppetca_token_ttl::         Token-whitelisting only: Fallback time (in minutes) after which tokens will expire
+#
+# $puppetca_certificate::       Token-whitelisting only: Certificate to use when encrypting tokens (undef to use SSL certificate)
+#
 class foreman_proxy (
   String $repo = $::foreman_proxy::params::repo,
   Boolean $gpgcheck = $::foreman_proxy::params::gpgcheck,
@@ -335,6 +343,10 @@ class foreman_proxy (
   Boolean $puppetca_modular = $::foreman_proxy::params::puppetca_modular,
   String $puppetca_provider = $::foreman_proxy::params::puppetca_provider,
   Stdlib::Absolutepath $autosignfile = $::foreman_proxy::params::autosignfile,
+  Boolean $puppetca_sign_all = $::foreman_proxy::params::puppetca_sign_all,
+  Stdlib::Absolutepath $puppetca_tokens_file = $::foreman_proxy::params::puppetca_tokens_file,
+  Integer[0] $puppetca_token_ttl = $::foreman_proxy::params::puppetca_token_ttl,
+  Optional[Stdlib::Absolutepath] $puppetca_certificate = $::foreman_proxy::params::puppetca_certificate,
   Boolean $manage_puppet_group = $::foreman_proxy::params::manage_puppet_group,
   Boolean $puppet = $::foreman_proxy::params::puppet,
   Foreman_proxy::ListenOn $puppet_listen_on = $::foreman_proxy::params::puppet_listen_on,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -244,6 +244,10 @@ class foreman_proxy::params {
   $puppetca_cmd          = "${puppet_cmd} cert"
   $puppet_group          = 'puppet'
   $autosignfile          = "${puppetdir}/autosign.conf"
+  $puppetca_sign_all     = false
+  $puppetca_tokens_file  = '/var/lib/foreman-proxy/tokens.yml'
+  $puppetca_token_ttl    = 360
+  $puppetca_certificate  = undef
 
   # The puppet-agent package, (puppet 4 AIO) doesn't create a puppet group
   $manage_puppet_group = versioncmp($::puppetversion, '4.0') > 0

--- a/templates/puppetca_token_whitelisting.yml.erb
+++ b/templates/puppetca_token_whitelisting.yml.erb
@@ -1,0 +1,11 @@
+---
+#
+# Configuration of the PuppetCA token_whitelisting provider
+#
+
+:sign_all: <%= scope.lookupvar('foreman_proxy::puppetca_sign_all') %>
+:tokens_file: <%= scope.lookupvar('foreman_proxy::puppetca_tokens_file') %>
+:token_ttl: <%= scope.lookupvar('foreman_proxy::puppetca_token_ttl') %>
+<% unless [nil, :undefined, :undef].include?(scope.lookupvar("foreman_proxy::puppetca_certificate")) -%>
+:certificate: <%= scope.lookupvar('foreman_proxy::puppetca_certificate') %>
+<% end -%>


### PR DESCRIPTION
As we are adding new providers to the PuppetCa SmartProxy module, we need to add its settings-file to the puppet module and add the settings as params to have them configurable.

See [SmartProxy-Refactor](https://github.com/theforeman/smart-proxy/pull/586) and new TokenWhitelistingProvider (to be pull-requested after refactor gets merged).

Waiting for both of the SmartProxy-PRs to get merged before removing WIP-status.