### PR TITLE
Refs #24012 - Add PuppetCA providers settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,22 @@ Part of the Foreman installer: <https://github.com/theforeman/foreman-installer>
 
 | Module version | Proxy versions | Notes                                           |
 |----------------|----------------|-------------------------------------------------|
-| 5.x            | 1.16 and newer |                                                 |
+| 5.x            | 1.16 and newer | See compatibility notes here for 1.16-1.18      |
 | 4.x            | 1.12 - 1.17    | See compatibility notes in its README for 1.15+ |
 | 3.x            | 1.11           |                                                 |
 | 2.x            | 1.5 - 1.10     |                                                 |
 | 1.x            | 1.4 and older  |                                                 |
+
+### Compatibility notes for Smart Proxy < 1.18
+
+On Smart Proxy 1.16, 1.17 & 1.18, also set
+
+```puppet
+puppetca_modular => false,
+```
+
+to ensure that it only uses the `puppetca.yml` configuration not the provider settings files.
+
 
 ## Examples
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -87,6 +87,13 @@ class foreman_proxy::config {
     feature   => 'Puppet CA',
     listen_on => $::foreman_proxy::puppetca_listen_on,
   }
+  if $::foreman_proxy::puppetca_modular {
+    foreman_proxy::settings_file { [
+        'puppetca_hostname_whitelisting',
+      ]:
+        module => false,
+    }
+  }
   foreman_proxy::settings_file { 'realm':
     enabled   => $::foreman_proxy::realm,
     feature   => 'Realm',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,7 +81,7 @@
 #
 # $puppet_group::               Groups of Foreman proxy user
 #
-# $autosignfile::               Path to the autosign file
+# $autosignfile::               Hostname-Whitelisting only: Location of puppets autosign.conf
 #
 # $manage_puppet_group::        Whether to ensure the $puppet_group exists.  Also ensures group owner of ssl keys and certs is $puppet_group
 #                               Not applicable when ssl is false.
@@ -291,6 +291,10 @@
 #
 # $dhcp_manage_acls::           Whether to manage DHCP directory ACLs. This allows the Foreman Proxy user to access even if the directory mode is 0750.
 #
+# $puppetca_modular::           Whether the PuppetCa implementation is modular. This is true for 1.19 or later.
+#
+# $puppetca_provider::          Whether to use puppetca_hostname_whitelisting or puppetca_token_whitelisting
+#
 class foreman_proxy (
   String $repo = $::foreman_proxy::params::repo,
   Boolean $gpgcheck = $::foreman_proxy::params::gpgcheck,
@@ -328,6 +332,8 @@ class foreman_proxy (
   Stdlib::Absolutepath $puppetdir = $::foreman_proxy::params::puppetdir,
   String $puppetca_cmd = $::foreman_proxy::params::puppetca_cmd,
   String $puppet_group = $::foreman_proxy::params::puppet_group,
+  Boolean $puppetca_modular = $::foreman_proxy::params::puppetca_modular,
+  String $puppetca_provider = $::foreman_proxy::params::puppetca_provider,
   Stdlib::Absolutepath $autosignfile = $::foreman_proxy::params::autosignfile,
   Boolean $manage_puppet_group = $::foreman_proxy::params::manage_puppet_group,
   Boolean $puppet = $::foreman_proxy::params::puppet,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -237,11 +237,13 @@ class foreman_proxy::params {
   $puppet_api_timeout         = 30
 
   # puppetca settings
-  $puppetca           = true
-  $puppetca_listen_on = 'https'
-  $puppetca_cmd       = "${puppet_cmd} cert"
-  $puppet_group       = 'puppet'
-  $autosignfile       = "${puppetdir}/autosign.conf"
+  $puppetca              = true
+  $puppetca_modular      = true
+  $puppetca_provider     = 'puppetca_hostname_whitelisting'
+  $puppetca_listen_on    = 'https'
+  $puppetca_cmd          = "${puppet_cmd} cert"
+  $puppet_group          = 'puppet'
+  $autosignfile          = "${puppetdir}/autosign.conf"
 
   # The puppet-agent package, (puppet 4 AIO) doesn't create a puppet group
   $manage_puppet_group = versioncmp($::puppetversion, '4.0') > 0

--- a/templates/puppetca.yml.erb
+++ b/templates/puppetca.yml.erb
@@ -2,4 +2,8 @@
 # PuppetCA management
 :enabled: <%= @module_enabled %>
 :ssldir: <%= scope.lookupvar("foreman_proxy::ssldir") %>
+<% if scope.lookupvar("foreman_proxy::puppetca_modular") -%>
+:use_provider: <%= scope.lookupvar("foreman_proxy::puppetca_provider") %>
+<% else -%>
 :autosignfile: <%= scope.lookupvar("foreman_proxy::autosignfile") %>
+<% end -%>

--- a/templates/puppetca_hostname_whitelisting.yml.erb
+++ b/templates/puppetca_hostname_whitelisting.yml.erb
@@ -1,0 +1,6 @@
+---
+#
+# Configuration of the PuppetCA hostname_whitelisting provider
+#
+
+:autosignfile: <%= scope.lookupvar('foreman_proxy::autosignfile') %>


### PR DESCRIPTION
This adds the settings for the `puppetca_hostname_whitelisting` provider for the new modular PuppetCa module. This should fix the current nightlies.
This is a part of #433 but without the `token_whitelisting` provider's settings and with the suggested additions.

This is a working copy of #434 because I sometimes am unable to work with git properly. See [previous commit](https://github.com/theforeman/puppet-foreman_proxy/pull/434/commits/3962a68e7987cc6a8455e34b9309daa27dc44fff).