### PR TITLE
Allow empty string for dns_server param

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -221,7 +221,7 @@
 #
 # $dns_reverse::                DNS reverse zone name
 #
-# $dns_server::                 Address of DNS server to manage
+# $dns_server::                 Address of DNS server to manage, set to an empty string to let nsupdate automatically determine the master server
 #
 # $dns_ttl::                    DNS default TTL override
 #

--- a/templates/dns_nsupdate_gss.yml.erb
+++ b/templates/dns_nsupdate_gss.yml.erb
@@ -3,8 +3,10 @@
 # Configuration file for 'nsupdate_gss' dns provider with GSS-TSIG support
 #
 
-# use this setting if you are managing a dns server which is not localhost though this proxy
+# DNS server to talk to, usually localhost but can be an arbitrary (remote) host.
+# This can be also set to a blank value to let nsupdate to detect master server of a zone.
 :dns_server: <%= scope.lookupvar("foreman_proxy::dns_server") %>
+
 # use dns_tsig_* for GSS-TSIG updates using Kerberos.  Required for Windows MS DNS with
 # Secure Dynamic Updates, or BIND as used in FreeIPA.  Set dns_provider to nsupdate_gss.
 :dns_tsig_keytab: <%= scope.lookupvar("foreman_proxy::dns_tsig_keytab") %>


### PR DESCRIPTION
This is my blind attempt to document new behavior introduced by:

https://github.com/theforeman/smart-proxy/pull/602