### PR TITLE
Move to a fixed repository

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -167,7 +167,7 @@ class foreman_proxy::params {
   $groups = []
 
   # Packaging
-  $repo                    = 'stable'
+  $repo                    = '1.18'
   $gpgcheck                = true
   $version                 = 'present'
   $ensure_packages_version = 'present'


### PR DESCRIPTION
In puppet-foreman we removed the support for the stable repository. This new default reflects that change.