### PR TITLE
Move the REX SSH directory to /var/lib/foreman-proxy

### DIFF
--- a/manifests/plugin/remote_execution/ssh/params.pp
+++ b/manifests/plugin/remote_execution/ssh/params.pp
@@ -1,14 +1,12 @@
 # Remote Execution SSH default parameters
 class foreman_proxy::plugin::remote_execution::ssh::params {
-  include ::foreman_proxy::params
-
   $enabled            = true
   $listen_on          = 'https'
   $local_working_dir  = '/var/tmp'
   $remote_working_dir = '/var/tmp'
   $generate_keys      = true
   $install_key        = false
-  $ssh_identity_dir   = "${::foreman_proxy::params::dir}/.ssh"
+  $ssh_identity_dir   = '/var/lib/foreman-proxy/ssh'
   $ssh_identity_file  = 'id_rsa_foreman_proxy'
   $ssh_keygen         = '/usr/bin/ssh-keygen'
   $ssh_kerberos_auth  = false

--- a/spec/classes/foreman_proxy__plugin__remote_execution__ssh_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__remote_execution__ssh_spec.rb
@@ -17,7 +17,7 @@ describe 'foreman_proxy::plugin::remote_execution::ssh' do
     it 'should configure remote_execution_ssh.yml' do
       should contain_file('/etc/foreman-proxy/settings.d/remote_execution_ssh.yml').
         with_content(/^:enabled: https/).
-        with_content(%r{:ssh_identity_key_file: /usr/share/foreman-proxy/.ssh/id_rsa_foreman_proxy}).
+        with_content(%r{:ssh_identity_key_file: /var/lib/foreman-proxy/ssh/id_rsa_foreman_proxy}).
         with_content(%r{:kerberos_auth: false}).
         with({
           :ensure  => 'file',
@@ -29,7 +29,7 @@ describe 'foreman_proxy::plugin::remote_execution::ssh' do
     it 'should configure ssh key' do
       should contain_exec('generate_ssh_key').
         with({
-          :command => "/usr/bin/ssh-keygen -f /usr/share/foreman-proxy/.ssh/id_rsa_foreman_proxy -N ''"
+          :command => "/usr/bin/ssh-keygen -f /var/lib/foreman-proxy/ssh/id_rsa_foreman_proxy -N ''"
         })
     end
 


### PR DESCRIPTION
Starting 0.2.0-2 for Debs and 1.5.2 for RPMs we've moved the .ssh directory to /var/lib/foreman-proxy/ssh with a symlink in /usr/share/foreman-proxy/.ssh.

Depends on https://github.com/theforeman/foreman-packaging/pull/2891