### PR TITLE
Release 8.0.1

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,7 +6,9 @@ fixtures:
     dhcp:     'https://github.com/theforeman/puppet-dhcp'
     dns:      'https://github.com/theforeman/puppet-dns'
     extlib:   'https://github.com/voxpupuli/puppet-extlib'
-    foreman:  'https://github.com/theforeman/puppet-foreman'
+    foreman:
+      repo:   'https://github.com/theforeman/puppet-foreman'
+      branch: '9.2-stable'
     mysql:    'https://github.com/puppetlabs/puppetlabs-mysql'
     puppet:   'https://github.com/theforeman/puppet-puppet'
     stdlib:   'https://github.com/puppetlabs/puppetlabs-stdlib'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [8.0.1](https://github.com/theforeman/puppet-foreman_proxy/tree/8.0.1) (2018-08-29)
+
+[Full Changelog](https://github.com/theforeman/puppet-foreman_proxy/compare/8.0.0...8.0.1)
+
+**Fixed bugs:**
+
+- Move the REX SSH directory to /var/lib/foreman-proxy [\#451](https://github.com/theforeman/puppet-foreman_proxy/pull/451) ([ekohl](https://github.com/ekohl))
+- fixes [\#24690](https://projects.theforeman.org/issues/24690) - add symlink grub2/boot to ../boot [\#449](https://github.com/theforeman/puppet-foreman_proxy/pull/449) ([stbenjam](https://github.com/stbenjam))
+
 ## [8.0.0](https://github.com/theforeman/puppet-foreman_proxy/tree/8.0.0) (2018-07-16)
 
 [Full Changelog](https://github.com/theforeman/puppet-foreman_proxy/compare/7.2.3...8.0.0)


### PR DESCRIPTION
I created a 8.0-stable branch to avoid 69bf82aaab938dd88a86c0241a0fbc2a6253feef in 1.19 for now. It's probably going to be a breaking change for users.