### PR TITLE
Add {dns,network}_view parameters to infoblox

### DIFF
--- a/manifests/plugin/dhcp/infoblox.pp
+++ b/manifests/plugin/dhcp/infoblox.pp
@@ -12,11 +12,17 @@
 #
 # $use_ranges::  Use pre-definded ranges in networks to find available IP's
 #
+# $dns_view::    The DNS view to use
+#
+# $network_view:: The network view to use
+#
 class foreman_proxy::plugin::dhcp::infoblox (
   String $username = undef,
   String $password = undef,
   Enum['host', 'fixedaddress'] $record_type = 'fixedaddress',
   Boolean $use_ranges = false,
+  String $dns_view = 'default',
+  String $network_view = 'default',
 ) {
   foreman_proxy::plugin { 'dhcp_infoblox':
   }

--- a/manifests/plugin/dhcp/infoblox.pp
+++ b/manifests/plugin/dhcp/infoblox.pp
@@ -8,16 +8,16 @@
 #
 # $password::    The password of the Infoblox user
 #
-# $record_type:: Record type to manage, can be "host" or "fixedaddress"
+# $record_type:: Record type to manage
 #
 # $use_ranges::  Use pre-definded ranges in networks to find available IP's
 #
 class foreman_proxy::plugin::dhcp::infoblox (
-  String $username = $::foreman_proxy::plugin::dhcp::infoblox::params::username,
-  String $password = $::foreman_proxy::plugin::dhcp::infoblox::params::password,
-  Enum['host', 'fixedaddress'] $record_type = $::foreman_proxy::plugin::dhcp::infoblox::params::record_type,
-  Boolean $use_ranges = $::foreman_proxy::plugin::dhcp::infoblox::params::use_ranges,
-) inherits foreman_proxy::plugin::dhcp::infoblox::params {
+  String $username = undef,
+  String $password = undef,
+  Enum['host', 'fixedaddress'] $record_type = 'fixedaddress',
+  Boolean $use_ranges = false,
+) {
   foreman_proxy::plugin { 'dhcp_infoblox':
   }
   -> foreman_proxy::settings_file { 'dhcp_infoblox':

--- a/manifests/plugin/dhcp/infoblox/params.pp
+++ b/manifests/plugin/dhcp/infoblox/params.pp
@@ -1,6 +1,0 @@
-class foreman_proxy::plugin::dhcp::infoblox::params {
-  $username    = undef
-  $password    = undef
-  $record_type = 'fixedaddress'
-  $use_ranges  = false
-}

--- a/spec/classes/foreman_proxy__plugin__dhcp__infoblox_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__dhcp__infoblox_spec.rb
@@ -30,6 +30,8 @@ describe 'foreman_proxy::plugin::dhcp::infoblox' do
         ':password: "infoblox"',
         ':record_type: "fixedaddress"',
         ':use_ranges: false',
+        ':dns_view: "default"',
+        ':network_view: "default"',
       ])
     end
   end
@@ -37,10 +39,12 @@ describe 'foreman_proxy::plugin::dhcp::infoblox' do
   context 'all parameters' do
     let :params do
       {
-        :username    => 'admin',
-        :password    => 'infoblox',
-        :use_ranges  => true,
-        :record_type => 'host'
+        :username     => 'admin',
+        :password     => 'infoblox',
+        :use_ranges   => true,
+        :record_type  => 'host',
+        :dns_view     => 'non-default',
+        :network_view => 'another-non-default',
       }
     end
 
@@ -51,6 +55,8 @@ describe 'foreman_proxy::plugin::dhcp::infoblox' do
         ':password: "infoblox"',
         ':record_type: "host"',
         ':use_ranges: true',
+        ':dns_view: "non-default"',
+        ':network_view: "another-non-default"',
       ])
     end
   end

--- a/templates/plugin/dhcp_infoblox.yml.erb
+++ b/templates/plugin/dhcp_infoblox.yml.erb
@@ -15,3 +15,6 @@
 # Use  pre-definded ranges in networks to find available IP's
 #
 :use_ranges: <%= scope.lookupvar('::foreman_proxy::plugin::dhcp::infoblox::use_ranges') %>
+
+:dns_view: "<%= scope.lookupvar('::foreman_proxy::plugin::dhcp::infoblox::dns_view') %>"
+:network_view: "<%= scope.lookupvar('::foreman_proxy::plugin::dhcp::infoblox::network_view') %>"


### PR DESCRIPTION
These are supported since smart_proxy_dhcp_infoblox 0.0.8. The defaults are copied from what the plugin uses and makes the implementation easier.

Closes GH-431