### PR TITLE
Mark compatible with theforeman/puppet 10.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -32,7 +32,7 @@
     },
     {
       "name": "theforeman/puppet",
-      "version_requirement": ">= 4.2.0 < 10.0.0"
+      "version_requirement": ">= 4.2.0 < 11.0.0"
     },
     {
       "name": "theforeman/tftp",


### PR DESCRIPTION
This is in preparation for the 10.0.0 release that's currently master. See https://github.com/theforeman/puppet-puppet/pull/641 as well.