### PR TITLE
realm_ad: Allow using unspecified DC

### DIFF
--- a/manifests/plugin/realm/ad.pp
+++ b/manifests/plugin/realm/ad.pp
@@ -25,7 +25,7 @@
 #
 class foreman_proxy::plugin::realm::ad (
   String $realm = $::foreman_proxy::plugin::realm::ad::params::realm,
-  String $domain_controller = $::foreman_proxy::plugin::realm::ad::params::domain_controller,
+  Optional[String] $domain_controller = $::foreman_proxy::plugin::realm::ad::params::domain_controller,
   Optional[String] $ou = $::foreman_proxy::plugin::realm::ad::params::ou,
   Optional[String] $computername_prefix = $::foreman_proxy::plugin::realm::ad::params::computername_prefix,
   Optional[Boolean] $computername_hash = $::foreman_proxy::plugin::realm::ad::params::computername_hash,


### PR DESCRIPTION
This will instead discover the DC using an SRV record lookup in (r)adcli.

Requires theforeman/smart_proxy_realm_ad_plugin#19 on the proxy side