### PR TITLE
Add support for SSH BMC provider

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -243,6 +243,18 @@
 #
 # $bmc_default_provider::       BMC default provider.
 #
+# $bmc_ssh_user::               BMC SSH user.
+#
+# $bmc_ssh_key::                BMC SSH key location.
+#
+# $bmc_ssh_powerstatus::        BMC SSH powerstatus command.
+#
+# $bmc_ssh_powercycle::         BMC SSH powercycle command.
+#
+# $bmc_ssh_poweroff::           BMC SSH poweroff command.
+#
+# $bmc_ssh_poweron::            BMC SSH poweron command.
+#
 # $keyfile::                    DNS server keyfile path
 #
 # $realm::                      Enable realm management feature
@@ -430,7 +442,13 @@ class foreman_proxy (
   String $libvirt_connection = $::foreman_proxy::params::libvirt_connection,
   Boolean $bmc = $::foreman_proxy::params::bmc,
   Foreman_proxy::ListenOn $bmc_listen_on = $::foreman_proxy::params::bmc_listen_on,
-  Enum['ipmitool', 'freeipmi', 'shell'] $bmc_default_provider = $::foreman_proxy::params::bmc_default_provider,
+  Enum['ipmitool', 'freeipmi', 'shell', 'ssh'] $bmc_default_provider = $::foreman_proxy::params::bmc_default_provider,
+  String $bmc_ssh_user = $::foreman_proxy::params::bmc_ssh_user,
+  String $bmc_ssh_key = $::foreman_proxy::params::bmc_ssh_key,
+  String $bmc_ssh_powerstatus = $::foreman_proxy::params::bmc_ssh_powerstatus,
+  String $bmc_ssh_powercycle = $::foreman_proxy::params::bmc_ssh_powercycle,
+  String $bmc_ssh_poweroff = $::foreman_proxy::params::bmc_ssh_poweroff,
+  String $bmc_ssh_poweron = $::foreman_proxy::params::bmc_ssh_poweron,
   Boolean $realm = $::foreman_proxy::params::realm,
   Foreman_proxy::ListenOn $realm_listen_on = $::foreman_proxy::params::realm_listen_on,
   String $realm_provider = $::foreman_proxy::params::realm_provider,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -444,7 +444,7 @@ class foreman_proxy (
   Foreman_proxy::ListenOn $bmc_listen_on = $::foreman_proxy::params::bmc_listen_on,
   Enum['ipmitool', 'freeipmi', 'shell', 'ssh'] $bmc_default_provider = $::foreman_proxy::params::bmc_default_provider,
   String $bmc_ssh_user = $::foreman_proxy::params::bmc_ssh_user,
-  String $bmc_ssh_key = $::foreman_proxy::params::bmc_ssh_key,
+  Stdlib::Absolutepath $bmc_ssh_key = $::foreman_proxy::params::bmc_ssh_key,
   String $bmc_ssh_powerstatus = $::foreman_proxy::params::bmc_ssh_powerstatus,
   String $bmc_ssh_powercycle = $::foreman_proxy::params::bmc_ssh_powercycle,
   String $bmc_ssh_poweroff = $::foreman_proxy::params::bmc_ssh_poweroff,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -337,6 +337,12 @@ class foreman_proxy::params {
   $bmc                  = false
   $bmc_listen_on        = 'https'
   $bmc_default_provider = 'ipmitool'
+  $bmc_ssh_user         = 'root'
+  $bmc_ssh_key          = '/usr/share/foreman/.ssh/id_rsa'
+  $bmc_ssh_powerstatus  = 'true'
+  $bmc_ssh_powercycle   = 'shutdown -r +1'
+  $bmc_ssh_poweroff     = 'shutdown +1'
+  $bmc_ssh_poweron      = 'false'
 
   # Realm management options
   $realm              = false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -339,10 +339,12 @@ class foreman_proxy::params {
   $bmc_default_provider = 'ipmitool'
   $bmc_ssh_user         = 'root'
   $bmc_ssh_key          = '/usr/share/foreman/.ssh/id_rsa'
-  $bmc_ssh_powerstatus  = 'true'
   $bmc_ssh_powercycle   = 'shutdown -r +1'
   $bmc_ssh_poweroff     = 'shutdown +1'
+  # lint:ignore:quoted_booleans
   $bmc_ssh_poweron      = 'false'
+  $bmc_ssh_powerstatus  = 'true'
+  # lint:endignore
 
   # Realm management options
   $realm              = false

--- a/templates/bmc.yml.erb
+++ b/templates/bmc.yml.erb
@@ -8,8 +8,8 @@
 <% if scope.lookupvar("foreman_proxy::bmc_default_provider") == 'ssh' -%>
 :bmc_ssh_user: <%= scope.lookupvar("foreman_proxy::bmc_ssh_user") %>
 :bmc_ssh_key: <%= scope.lookupvar("foreman_proxy::bmc_ssh_key") %>
-:bmc_ssh_powerstatus: <%= scope.lookupvar("foreman_proxy::bmc_ssh_powerstatus") %>
-:bmc_ssh_powercycle: <%= scope.lookupvar("foreman_proxy::bmc_ssh_powercycle") %>
-:bmc_ssh_poweroff: <%= scope.lookupvar("foreman_proxy::bmc_ssh_poweroff") %>
-:bmc_ssh_poweron: <%= scope.lookupvar("foreman_proxy::bmc_ssh_poweron") %>
+:bmc_ssh_powerstatus: "<%= scope.lookupvar("foreman_proxy::bmc_ssh_powerstatus") %>"
+:bmc_ssh_powercycle: "<%= scope.lookupvar("foreman_proxy::bmc_ssh_powercycle") %>"
+:bmc_ssh_poweroff: "<%= scope.lookupvar("foreman_proxy::bmc_ssh_poweroff") %>"
+:bmc_ssh_poweron: "<%= scope.lookupvar("foreman_proxy::bmc_ssh_poweron") %>"
 <% end -%>

--- a/templates/bmc.yml.erb
+++ b/templates/bmc.yml.erb
@@ -5,3 +5,11 @@
 # - freeipmi / ipmitool - requires the appropriate package installed, and the rubyipmi gem
 # - shell - for local reboot control (requires sudo access to /sbin/shutdown for the proxy user)
 :bmc_default_provider: <%= scope.lookupvar("foreman_proxy::bmc_default_provider") %>
+<% if scope.lookupvar("foreman_proxy::bmc_default_provider") == 'ssh' -%>
+:bmc_ssh_user: <%= scope.lookupvar("foreman_proxy::bmc_ssh_user") %>
+:bmc_ssh_key: <%= scope.lookupvar("foreman_proxy::bmc_ssh_key") %>
+:bmc_ssh_powerstatus: <%= scope.lookupvar("foreman_proxy::bmc_ssh_powerstatus") %>
+:bmc_ssh_powercycle: <%= scope.lookupvar("foreman_proxy::bmc_ssh_powercycle") %>
+:bmc_ssh_poweroff: <%= scope.lookupvar("foreman_proxy::bmc_ssh_poweroff") %>
+:bmc_ssh_poweron: <%= scope.lookupvar("foreman_proxy::bmc_ssh_poweron") %>
+<% end -%>


### PR DESCRIPTION
This commit adds support for the SSH BMC provider and all configuration options that come with it. Defaults have been copied from the official foreman docs.