### PR TITLE
Fixes #25591 - Remove $use_ranges from infoblox dhcp

### DIFF
--- a/manifests/plugin/dhcp/infoblox.pp
+++ b/manifests/plugin/dhcp/infoblox.pp
@@ -10,8 +10,6 @@
 #
 # $record_type:: Record type to manage
 #
-# $use_ranges::  Use pre-definded ranges in networks to find available IP's
-#
 # $dns_view::    The DNS view to use
 #
 # $network_view:: The network view to use
@@ -20,7 +18,6 @@ class foreman_proxy::plugin::dhcp::infoblox (
   String $username = undef,
   String $password = undef,
   Enum['host', 'fixedaddress'] $record_type = 'fixedaddress',
-  Boolean $use_ranges = false,
   String $dns_view = 'default',
   String $network_view = 'default',
 ) {

--- a/spec/classes/foreman_proxy__plugin__dhcp__infoblox_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__dhcp__infoblox_spec.rb
@@ -29,7 +29,6 @@ describe 'foreman_proxy::plugin::dhcp::infoblox' do
         ':username: "admin"',
         ':password: "infoblox"',
         ':record_type: "fixedaddress"',
-        ':use_ranges: false',
         ':dns_view: "default"',
         ':network_view: "default"',
       ])
@@ -41,7 +40,6 @@ describe 'foreman_proxy::plugin::dhcp::infoblox' do
       {
         :username     => 'admin',
         :password     => 'infoblox',
-        :use_ranges   => true,
         :record_type  => 'host',
         :dns_view     => 'non-default',
         :network_view => 'another-non-default',
@@ -54,7 +52,6 @@ describe 'foreman_proxy::plugin::dhcp::infoblox' do
         ':username: "admin"',
         ':password: "infoblox"',
         ':record_type: "host"',
-        ':use_ranges: true',
         ':dns_view: "non-default"',
         ':network_view: "another-non-default"',
       ])

--- a/templates/plugin/dhcp_infoblox.yml.erb
+++ b/templates/plugin/dhcp_infoblox.yml.erb
@@ -11,10 +11,5 @@
 # Record type to manage: can be "host" or "fixedaddress"
 #
 :record_type: "<%= scope.lookupvar('::foreman_proxy::plugin::dhcp::infoblox::record_type') %>"
-#
-# Use  pre-definded ranges in networks to find available IP's
-#
-:use_ranges: <%= scope.lookupvar('::foreman_proxy::plugin::dhcp::infoblox::use_ranges') %>
-
 :dns_view: "<%= scope.lookupvar('::foreman_proxy::plugin::dhcp::infoblox::dns_view') %>"
 :network_view: "<%= scope.lookupvar('::foreman_proxy::plugin::dhcp::infoblox::network_view') %>"


### PR DESCRIPTION
This parameter was removed in smart_proxy_dhcp_infobox 0.0.12.