### PR TITLE
Disable repository management by default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,14 +2,6 @@
 #
 # === Parameters:
 #
-# $repo::                       This can be stable, rc, or nightly
-#
-# $gpgcheck::                   Turn on/off gpg check in repo files (effective only on RedHat family systems)
-#
-# $custom_repo::                No need to change anything here by default
-#                               if set to true, no repo will be added by this module, letting you to
-#                               set it to some custom location.
-#
 # $version::                    foreman package version, it's passed to ensure parameter of package resource
 #                               can be set to specific version number, 'latest', 'present' etc.
 #
@@ -289,6 +281,10 @@
 #
 # === Advanced parameters:
 #
+# $repo::                       Which repository to use. Can be a specific version or nightly. Will not configure anything when undefined.
+#
+# $gpgcheck::                   Turn on/off gpg check in repo files (effective only on RedHat family systems)
+#
 # $dhcp_failover_address::      Address for DHCP to listen for connections from its peer
 #
 # $dhcp_failover_port::         Port for DHCP to listen & communicate with it DHCP peer
@@ -316,9 +312,8 @@
 # $puppetca_certificate::       Token-whitelisting only: Certificate to use when encrypting tokens (undef to use SSL certificate)
 #
 class foreman_proxy (
-  String $repo = $::foreman_proxy::params::repo,
+  Optional[String] $repo = $::foreman_proxy::params::repo,
   Boolean $gpgcheck = $::foreman_proxy::params::gpgcheck,
-  Boolean $custom_repo = $::foreman_proxy::params::custom_repo,
   String $version = $::foreman_proxy::params::version,
   Enum['latest', 'present', 'installed', 'absent'] $ensure_packages_version = $::foreman_proxy::params::ensure_packages_version,
   Enum['latest', 'present', 'installed', 'absent'] $plugin_version = $::foreman_proxy::params::plugin_version,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,7 +7,6 @@ class foreman_proxy::params {
     'RedHat': {
       # if set to true, no repo will be added by this module, letting you to
       # set it to some custom location.
-      $custom_repo         = false
       $plugin_prefix       = 'rubygem-smart_proxy_'
 
       $dir   = '/usr/share/foreman-proxy'
@@ -36,7 +35,6 @@ class foreman_proxy::params {
     'Debian': {
       # if set to true, no repo will be added by this module, letting you to
       # set it to some custom location.
-      $custom_repo         = false
       $plugin_prefix       = 'ruby-smart-proxy-'
 
       $dir   = '/usr/share/foreman-proxy'
@@ -72,7 +70,6 @@ class foreman_proxy::params {
     /^(FreeBSD|DragonFly)$/: {
       # if set to true, no repo will be added by this module, letting you to
       # set it to some custom location.
-      $custom_repo         = true # as foreman packages are in standard FreeBSD ports
       $plugin_prefix       = 'rubygem-smart_proxy_'
 
       $dir   = '/usr/local/share/foreman-proxy'
@@ -107,7 +104,6 @@ class foreman_proxy::params {
     'Archlinux': {
       # if set to true, no repo will be added by this module, letting you to
       # set it to some custom location.
-      $custom_repo         = true # package is in the AUR
       $plugin_prefix       = 'ruby-smart-proxy-'
 
       $dir   = '/usr/share/foreman-proxy'
@@ -167,7 +163,7 @@ class foreman_proxy::params {
   $groups = []
 
   # Packaging
-  $repo                    = '1.18'
+  $repo                    = undef
   $gpgcheck                = true
   $version                 = 'present'
   $ensure_packages_version = 'present'

--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -27,7 +27,6 @@ describe 'Scenario: install foreman-proxy' do
 
     # Actual test
     class { '::foreman_proxy':
-      custom_repo         => false,
       repo                => 'nightly',
       puppet_group        => 'root',
       register_in_foreman => false,

--- a/spec/acceptance/http_spec.rb
+++ b/spec/acceptance/http_spec.rb
@@ -27,7 +27,6 @@ describe 'Scenario: install foreman-proxy with http enabled' do
 
     # Actual test
     class { '::foreman_proxy':
-      custom_repo         => false,
       repo                => 'nightly',
       puppet_group        => 'root',
       register_in_foreman => false,

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -11,6 +11,8 @@ describe 'foreman_proxy' do
         should contain_class('foreman_proxy::service')
         should contain_class('foreman_proxy::register')
       end
+
+      it { should_not contain_class('foreman::repo') }
     end
   end
 end


### PR DESCRIPTION
Because we're trying to move people away from the latest repository, we
set it to configure an explicit version with a default. Because this
default would need to be updated all the time, it's a bad idea.

This patch removes the $custom_repo and makes $repo undef by default.
This means users get no repository by default and need to explicitly
choose which repository to use.

Because repo management would not be of much interest to installer
users, we move it together with $gpgcheck to the advanced section.