### PR TITLE
Remove the default gateway

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -281,7 +281,7 @@ class foreman_proxy::params {
   $dhcp_subnets            = []
   $dhcp_interface          = pick(fact('networking.primary'), 'eth0')
   $dhcp_additional_interfaces = []
-  $dhcp_gateway            = '192.168.100.1'
+  $dhcp_gateway            = undef
   $dhcp_range              = undef
   $dhcp_option_domain      = [$::domain]
   $dhcp_search_domains     = undef


### PR DESCRIPTION
This is likely incorrect. We also have the type as an Optional[String] but there's no way to unset the default. This forces a user to pick a gateway if they have one.