### PR TITLE
Fixes #26330 - Conditionally handle the puppet group

### DIFF
--- a/manifests/proxydns.pp
+++ b/manifests/proxydns.pp
@@ -30,6 +30,8 @@ class foreman_proxy::proxydns(
     forwarders => $forwarders,
   }
 
+  $user_group = $dns::group
+
   ensure_packages([$nsupdate], { ensure => $ensure_packages_version, })
 
   # puppet fact names are converted from ethX.X and ethX:X to ethX_X


### PR DESCRIPTION
The puppet group isn't as relevant anymore in various cases. This PR aims to make it fully optional.