### PR TITLE
Fixes #25481 - Manage foreman_proxy's ssh config

### DIFF
--- a/manifests/plugin/remote_execution/ssh.pp
+++ b/manifests/plugin/remote_execution/ssh.pp
@@ -84,6 +84,13 @@ class foreman_proxy::plugin::remote_execution::ssh (
       cwd     => $ssh_identity_dir,
       creates => $ssh_identity_path,
     }
+    file { "${ssh_identity_dir}/config":
+      ensure  => file,
+      owner   => $::foreman_proxy::user,
+      group   => $::foreman_proxy::user,
+      mode    => '0640',
+      content => "Host *\n  ProxyCommand none\n",
+    }
     if $install_key {
       # Ensure the .ssh directory exists with the right permissions
       file { '/root/.ssh':

--- a/spec/classes/foreman_proxy__plugin__remote_execution__ssh_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__remote_execution__ssh_spec.rb
@@ -33,6 +33,18 @@ describe 'foreman_proxy::plugin::remote_execution::ssh' do
         })
     end
 
+    it 'should configure the foreman-proxy\'s ssh client options' do
+      is_expected.to contain_file('/var/lib/foreman-proxy/ssh/config').
+        with_content(%r{^Host \*$}).
+        with_content(%r{^  ProxyCommand none$}).
+        with({
+        :ensure => 'file',
+        :owner  => 'foreman-proxy',
+        :group  => 'foreman-proxy',
+        :mode   => '0640',
+      })
+    end
+
     it 'should not install the ssh key' do
       should_not contain_file('/root/.ssh')
     end


### PR DESCRIPTION
This overrides the system wide ssh client config for ProxyCommand
allowing the Ansible plugin to work on systems that have been configured
as IPA clients.