### PR TITLE
Ensure shim permissions

### DIFF
--- a/manifests/tftp/netboot.pp
+++ b/manifests/tftp/netboot.pp
@@ -34,6 +34,8 @@ class foreman_proxy::tftp::netboot (
       file { "${root}/grub2/shim.efi":
         ensure => file,
         source => "/boot/efi/EFI/${grub_efi_path}/shim.efi",
+        mode   => '0644',
+        owner  => 'root',
       }
     }
     'redhat': {
@@ -50,6 +52,8 @@ class foreman_proxy::tftp::netboot (
       file { "${root}/grub2/shim.efi":
         ensure => file,
         source => "/boot/efi/EFI/${grub_efi_path}/shim.efi",
+        mode   => '0644',
+        owner  => 'root',
       }
     }
     'redhat_old': {

--- a/spec/classes/foreman_proxy__tftp_spec.rb
+++ b/spec/classes/foreman_proxy__tftp_spec.rb
@@ -108,13 +108,13 @@ describe 'foreman_proxy::tftp' do
           case facts[:operatingsystem]
           when /^(RedHat|Scientific|OracleLinux)$/
             it { should contain_file("#{tftp_root}/grub2/grubx64.efi").with_source('/boot/efi/EFI/redhat/grubx64.efi') }
-            it { should contain_file("#{tftp_root}/grub2/shim.efi").with_source('/boot/efi/EFI/redhat/shim.efi') }
+            it { should contain_file("#{tftp_root}/grub2/shim.efi").with_source('/boot/efi/EFI/redhat/shim.efi').with_owner('root').with_mode('0644') }
           when 'Fedora'
             it { should contain_file("#{tftp_root}/grub2/grubx64.efi").with_source('/boot/efi/EFI/fedora/grubx64.efi') }
-            it { should contain_file("#{tftp_root}/grub2/shim.efi").with_source('/boot/efi/EFI/fedora/shim.efi') }
+            it { should contain_file("#{tftp_root}/grub2/shim.efi").with_source('/boot/efi/EFI/fedora/shim.efi').with_owner('root').with_mode('0644') }
           when 'CentOS'
             it { should contain_file("#{tftp_root}/grub2/grubx64.efi").with_source('/boot/efi/EFI/centos/grubx64.efi') }
-            it { should contain_file("#{tftp_root}/grub2/shim.efi").with_source('/boot/efi/EFI/centos/shim.efi') }
+            it { should contain_file("#{tftp_root}/grub2/shim.efi").with_source('/boot/efi/EFI/centos/shim.efi').with_owner('root').with_mode('0644') }
           end
         else
           it { should contain_package('grub').with_ensure('present') }


### PR DESCRIPTION
It appears that `shim.efi` which is copied from boot partition has 700 permissions by default. That does not work with TFTP server, so the change makes sure it has the correct owner and also permissions (read for others).