### PR TITLE
Configure ansible's stdout_callback to yaml for nicer output

### DIFF
--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -20,12 +20,15 @@
 #                      of the key, which is not possible from non-interactive
 #                      environments like Foreman Remote Execution or cron
 #
+# $stdout_callback:: Ansible's stdout_callback setting
+#
 class foreman_proxy::plugin::ansible (
   Boolean $enabled = $::foreman_proxy::plugin::ansible::params::enabled,
   Foreman_proxy::ListenOn $listen_on = $::foreman_proxy::plugin::ansible::params::listen_on,
   Stdlib::Absolutepath $ansible_dir = $::foreman_proxy::plugin::ansible::params::ansible_dir,
   Optional[Stdlib::Absolutepath] $working_dir = $::foreman_proxy::plugin::ansible::params::working_dir,
   Boolean $host_key_checking = $::foreman_proxy::plugin::ansible::params::host_key_checking,
+  String $stdout_callback = $::foreman_proxy::plugin::ansible::params::stdout_callback,
 ) inherits foreman_proxy::plugin::ansible::params {
   $foreman_url = $::foreman_proxy::foreman_base_url
   $foreman_ssl_cert = pick($::foreman_proxy::foreman_ssl_cert, $::foreman_proxy::ssl_cert)

--- a/manifests/plugin/ansible/params.pp
+++ b/manifests/plugin/ansible/params.pp
@@ -5,4 +5,5 @@ class foreman_proxy::plugin::ansible::params {
   $ansible_dir = '/usr/share/foreman-proxy'
   $working_dir = '/tmp'
   $host_key_checking = false
+  $stdout_callback = 'yaml'
 }

--- a/spec/classes/foreman_proxy__plugin__ansible_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__ansible_spec.rb
@@ -27,6 +27,7 @@ describe 'foreman_proxy::plugin::ansible' do
             'callback_whitelist = foreman',
             'local_tmp = /tmp',
             'host_key_checking = False',
+            'stdout_callback = yaml',
             '[callback_foreman]',
             'url = https://foo.example.com',
             'ssl_key = /var/lib/puppet/ssl/private_keys/foo.example.com.pem',
@@ -47,6 +48,7 @@ describe 'foreman_proxy::plugin::ansible' do
             :ansible_dir       => '/etc/ansible-test',
             :working_dir       => '/tmp/ansible',
             :host_key_checking => true,
+            :stdout_callback   => 'debug',
           }
         end
 
@@ -65,6 +67,7 @@ describe 'foreman_proxy::plugin::ansible' do
             'callback_whitelist = foreman',
             'local_tmp = /tmp/ansible',
             'host_key_checking = True',
+            'stdout_callback = debug',
             '[callback_foreman]',
             'url = https://foo.example.com',
             'ssl_key = /var/lib/puppet/ssl/private_keys/foo.example.com.pem',

--- a/templates/plugin/ansible.cfg.erb
+++ b/templates/plugin/ansible.cfg.erb
@@ -2,6 +2,7 @@
 callback_whitelist = foreman
 local_tmp = <%= @working_dir %>
 host_key_checking = <%= @host_key_checking ? 'True' : 'False' %>
+stdout_callback = <%= @stdout_callback %>
 
 [callback_foreman]
 url = <%= @foreman_url %>


### PR DESCRIPTION
Before:

![ansible-stdout-before](https://user-images.githubusercontent.com/190443/53155349-25c0e380-35bd-11e9-93be-7064051367b9.png)

After:

![ansible-stdout-after](https://user-images.githubusercontent.com/190443/53155355-29546a80-35bd-11e9-9ad5-68d6f71ca29d.png)
