### PR TITLE
Raise minimum foreman and puppet versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -28,11 +28,11 @@
     },
     {
       "name": "theforeman/foreman",
-      "version_requirement": ">= 8.0.0 < 12.0.0"
+      "version_requirement": ">= 10.0.0 < 12.0.0"
     },
     {
       "name": "theforeman/puppet",
-      "version_requirement": ">= 4.2.0 < 12.0.0"
+      "version_requirement": ">= 10.0.0 < 12.0.0"
     },
     {
       "name": "theforeman/tftp",


### PR DESCRIPTION
Because of the minimum extlib version the older versions were effectively uninstallable, even if they were API compatible. It's also unlikely anyone tested those combinations.

Fixes GH-482