### PR TITLE
Fixes #25590 - Add httpboot support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -66,6 +66,11 @@ class foreman_proxy::config {
   foreman_proxy::settings_file { ['dns_libvirt', 'dhcp_libvirt']:
     module => false,
   }
+  foreman_proxy::settings_file { 'httpboot':
+    enabled   => pick($::foreman_proxy::httpboot, $::foreman_proxy::tftp),
+    feature   => 'HTTPBoot',
+    listen_on => $::foreman_proxy::httpboot_listen_on,
+  }
   foreman_proxy::settings_file { 'puppet':
     enabled   => $::foreman_proxy::puppet,
     feature   => 'Puppet',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -301,6 +301,10 @@
 #
 # $dhcp_manage_acls::           Whether to manage DHCP directory ACLs. This allows the Foreman Proxy user to access even if the directory mode is 0750.
 #
+# $httpboot::                   Enable HTTPBoot feature
+#
+# $httpboot_listen_on::         HTTPBoot proxy to listen on https, http, or both
+#
 # $puppetca_split_configs::     Whether to split the puppetca configs. This is only supported on 1.22+.
 #                               Set to false for older versions.
 #
@@ -381,6 +385,8 @@ class foreman_proxy (
   Stdlib::HTTPUrl $template_url = $::foreman_proxy::params::template_url,
   Boolean $logs = $::foreman_proxy::params::logs,
   Foreman_proxy::ListenOn $logs_listen_on = $::foreman_proxy::params::logs_listen_on,
+  Optional[Boolean] $httpboot = $::foreman_proxy::params::httpboot,
+  Foreman_proxy::ListenOn $httpboot_listen_on = $::foreman_proxy::params::httpboot_listen_on,
   Boolean $tftp = $::foreman_proxy::params::tftp,
   Foreman_proxy::ListenOn $tftp_listen_on = $::foreman_proxy::params::tftp_listen_on,
   Boolean $tftp_managed = $::foreman_proxy::params::tftp_managed,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -242,6 +242,10 @@ class foreman_proxy::params {
   $logs           = true
   $logs_listen_on = 'https'
 
+  # HTTPBoot settings - requires optional httpboot puppet module
+  $httpboot           = undef
+  $httpboot_listen_on = 'both'
+
   # TFTP settings - requires optional TFTP puppet module
   $tftp                   = true
   $tftp_listen_on         = 'https'

--- a/spec/classes/foreman_proxy__register__spec.rb
+++ b/spec/classes/foreman_proxy__register__spec.rb
@@ -44,7 +44,7 @@ describe 'foreman_proxy::register' do
           before { subject.resource('Datacat_collector[foreman_proxy::enabled_features]').provider.exists? }
 
           it 'should populate features on foreman_smartproxy' do
-            expect(subject.resource("Foreman_smartproxy[#{facts[:fqdn]}]").parameters[:features].should.sort).to match_array(["Logs", "Puppet", "Puppet CA", "TFTP"])
+            expect(subject.resource("Foreman_smartproxy[#{facts[:fqdn]}]").parameters[:features].should.sort).to match_array(["HTTPBoot", "Logs", "Puppet", "Puppet CA", "TFTP"])
           end
         end
       end

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -89,7 +89,7 @@ describe 'foreman_proxy' do
             'bmc',
             'dns', 'dns_libvirt', 'dns_nsupdate', 'dns_nsupdate_gss',
             'dhcp', 'dhcp_isc', 'dhcp_libvirt',
-            'logs',
+            'logs', 'httpboot',
             'puppet', 'puppet_proxy_legacy', 'puppet_proxy_puppet_api',
             'puppet_proxy_customrun', 'puppet_proxy_mcollective', 'puppet_proxy_puppetrun', 'puppet_proxy_salt', 'puppet_proxy_ssh',
             'puppetca', 'puppetca_http_api', 'puppetca_puppet_cert',
@@ -348,6 +348,14 @@ describe 'foreman_proxy' do
                     else
                       '/var/lib/tftpboot'
                     end
+
+        it 'should generate correct httpboot.yml' do
+          verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/httpboot.yml", [
+            '---',
+            ':enabled: both',
+            ":root_dir: #{tftp_root}",
+          ])
+        end
 
         it 'should generate correct tftp.yml' do
           verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/tftp.yml", [

--- a/templates/httpboot.yml.erb
+++ b/templates/httpboot.yml.erb
@@ -1,0 +1,10 @@
+---
+# Enable publishing of a given directory under /EFI and /httpboot paths.
+# Directory listing is not possible, symlinks are followed but not outside
+# of the root directory specified in this file.
+
+# Enables the module, make sure to enable TFTP module as well to allow
+# configuration files deployment.
+:enabled: <%= scope.lookupvar('foreman_proxy::httpboot_listen_on') %>
+
+:root_dir: <%= scope.lookupvar('foreman_proxy::tftp_root') %>


### PR DESCRIPTION
This adds support for the httpboot module that's shipped since 1.20.  It's added under advanced since the default value is derived from whether tftp is enabled, but can be explicitly enabled. Its root dir is also hardcoded to the tftp directory.