### PR TITLE
Fix path to mco in example

### DIFF
--- a/templates/puppet_proxy_mcollective.yml.erb
+++ b/templates/puppet_proxy_mcollective.yml.erb
@@ -7,6 +7,6 @@
 #
 # For Puppet Enterprise this means
 # Defaults:foreman-proxy !requiretty
-# foreman-proxy ALL=(peadmin) NOPASSWD: /opt/puppet/bin/mco *',
+# foreman-proxy ALL=(peadmin) NOPASSWD: /opt/puppetlabs/bin/mco *
 #
 :user: <%= scope.lookupvar("foreman_proxy::mcollective_user") %>


### PR DESCRIPTION
The AIO package install puppet in `/opt/puppetlabs`, not `/opt/puppet`.

While here, remove garbage at end of line.