### PR TITLE
Fixes #26839 - added dns_view option

### DIFF
--- a/manifests/plugin/dns/infoblox.pp
+++ b/manifests/plugin/dns/infoblox.pp
@@ -10,10 +10,13 @@
 #
 # $password::   The password of the Infoblox user
 #
+# $dns_view::   The Infoblox DNS View
+#
 class foreman_proxy::plugin::dns::infoblox (
   String $dns_server = $::foreman_proxy::plugin::dns::infoblox::params::dns_server,
   String $username = $::foreman_proxy::plugin::dns::infoblox::params::username,
   String $password = $::foreman_proxy::plugin::dns::infoblox::params::password,
+  String $dns_view = $::foreman_proxy::plugin::dns::infoblox::params::dns_view,
 ) inherits foreman_proxy::plugin::dns::infoblox::params {
   foreman_proxy::plugin { 'dns_infoblox':
   }

--- a/manifests/plugin/dns/infoblox/params.pp
+++ b/manifests/plugin/dns/infoblox/params.pp
@@ -2,4 +2,5 @@ class foreman_proxy::plugin::dns::infoblox::params {
   $dns_server = undef
   $username   = undef
   $password   = undef
+  $dns_view   = 'default'
 }

--- a/spec/classes/foreman_proxy__plugin__dns__infoblox_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__dns__infoblox_spec.rb
@@ -15,6 +15,7 @@ describe 'foreman_proxy::plugin::dns::infoblox' do
         :dns_server => 'localhost',
         :username   => 'admin',
         :password   => 'infoblox',
+        :dns_view   => 'default',
       }
     end
 
@@ -30,6 +31,7 @@ describe 'foreman_proxy::plugin::dns::infoblox' do
         ':dns_server: "localhost"',
         ':username: "admin"',
         ':password: "infoblox"',
+        ':dns_view: "default"',
       ])
     end
   end

--- a/templates/plugin/dns_infoblox.yml.erb
+++ b/templates/plugin/dns_infoblox.yml.erb
@@ -2,3 +2,4 @@
 :dns_server: "<%= scope.lookupvar('::foreman_proxy::plugin::dns::infoblox::dns_server') %>"
 :username: "<%= scope.lookupvar('::foreman_proxy::plugin::dns::infoblox::username') %>"
 :password: "<%= scope.lookupvar('::foreman_proxy::plugin::dns::infoblox::password') %>"
+:dns_view: "<%= scope.lookupvar('::foreman_proxy::plugin::dns::infoblox::dns_view') %>"


### PR DESCRIPTION
I am pushing without testing this as my `rake spec` fails about 90% of all tests. This is a new install, Ruby 2.6, `bundle install` did not work as it wanted to upgrade `beaker` gem which I upgraded and then all tests were failing.