### PR TITLE
Fixes #25481 - Set ProxyCommand=none for Ansible

### DIFF
--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -24,6 +24,8 @@
 #
 # $roles_path:: Paths where we look for ansible roles.
 #
+# $ssh_args::          The ssh_args parameter in ansible.cfg under [ssh_connection]
+#
 class foreman_proxy::plugin::ansible (
   Boolean $enabled = $::foreman_proxy::plugin::ansible::params::enabled,
   Foreman_proxy::ListenOn $listen_on = $::foreman_proxy::plugin::ansible::params::listen_on,
@@ -32,6 +34,7 @@ class foreman_proxy::plugin::ansible (
   Boolean $host_key_checking = $::foreman_proxy::plugin::ansible::params::host_key_checking,
   String $stdout_callback = $::foreman_proxy::plugin::ansible::params::stdout_callback,
   Array[Stdlib::Absolutepath] $roles_path = $::foreman_proxy::plugin::ansible::params::roles_path,
+  String $ssh_args = $::foreman_proxy::plugin::ansible::params::ssh_args,
 ) inherits foreman_proxy::plugin::ansible::params {
   $foreman_url = $::foreman_proxy::foreman_base_url
   $foreman_ssl_cert = pick($::foreman_proxy::foreman_ssl_cert, $::foreman_proxy::ssl_cert)

--- a/manifests/plugin/ansible/params.pp
+++ b/manifests/plugin/ansible/params.pp
@@ -7,4 +7,5 @@ class foreman_proxy::plugin::ansible::params {
   $host_key_checking = false
   $stdout_callback = 'yaml'
   $roles_path = ['/etc/ansible/roles', '/usr/share/ansible/roles']
+  $ssh_args = '-o ProxyCommand=none'
 }

--- a/spec/classes/foreman_proxy__plugin__ansible_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__ansible_spec.rb
@@ -34,6 +34,8 @@ describe 'foreman_proxy::plugin::ansible' do
             'ssl_cert = /var/lib/puppet/ssl/certs/foo.example.com.pem',
             'verify_certs = /var/lib/puppet/ssl/certs/ca.pem',
             'roles_path = /etc/ansible/roles:/usr/share/ansible/roles',
+            '[ssh_connection]',
+            'ssh_args = -o ProxyCommand=none',
           ])
         end
       end
@@ -75,6 +77,8 @@ describe 'foreman_proxy::plugin::ansible' do
             'ssl_cert = /var/lib/puppet/ssl/certs/foo.example.com.pem',
             'verify_certs = /var/lib/puppet/ssl/certs/ca.pem',
             'roles_path = /etc/ansible/roles:/usr/share/ansible/roles',
+            '[ssh_connection]',
+            'ssh_args = -o ProxyCommand=none',
           ])
         end
       end

--- a/templates/plugin/ansible.cfg.erb
+++ b/templates/plugin/ansible.cfg.erb
@@ -10,3 +10,6 @@ url = <%= @foreman_url %>
 ssl_cert = <%= @foreman_ssl_cert %>
 ssl_key = <%= @foreman_ssl_key %>
 verify_certs = <%= @foreman_ssl_ca %>
+
+[ssh_connection]
+ssh_args = <%= @ssh_args %>


### PR DESCRIPTION
In case of IPA there's a ProxyCommand set that handles known hosts, but `foreman_ansible` has its own way of handling known hosts. This sets the ssh args to force override this.