### PR TITLE
Fixes #27264 - Install ansible-runner package

### DIFF
--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -26,6 +26,8 @@
 #
 # $ssh_args::          The ssh_args parameter in ansible.cfg under [ssh_connection]
 #
+# $manage_runner_repo:: If true, adds upstream repositories to install ansible-runner package from
+#
 class foreman_proxy::plugin::ansible (
   Boolean $enabled = $::foreman_proxy::plugin::ansible::params::enabled,
   Foreman_proxy::ListenOn $listen_on = $::foreman_proxy::plugin::ansible::params::listen_on,
@@ -35,6 +37,7 @@ class foreman_proxy::plugin::ansible (
   String $stdout_callback = $::foreman_proxy::plugin::ansible::params::stdout_callback,
   Array[Stdlib::Absolutepath] $roles_path = $::foreman_proxy::plugin::ansible::params::roles_path,
   String $ssh_args = $::foreman_proxy::plugin::ansible::params::ssh_args,
+  Boolean $manage_runner_repo = $::foreman_proxy::plugin::ansible::params::manage_runner_repo,
 ) inherits foreman_proxy::plugin::ansible::params {
   $foreman_url = $::foreman_proxy::foreman_base_url
   $foreman_ssl_cert = pick($::foreman_proxy::foreman_ssl_cert, $::foreman_proxy::ssl_cert)
@@ -54,6 +57,7 @@ class foreman_proxy::plugin::ansible (
   }
 
   include ::foreman_proxy::plugin::dynflow
+  include ::foreman_proxy::plugin::ansible::runner
 
   foreman_proxy::plugin { 'ansible':
   }

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -26,6 +26,8 @@
 #
 # $ssh_args::          The ssh_args parameter in ansible.cfg under [ssh_connection]
 #
+# $install_runner:: If true, installs ansible-runner package to support running ansible by ansible-runner
+#
 # $manage_runner_repo:: If true, adds upstream repositories to install ansible-runner package from
 #
 class foreman_proxy::plugin::ansible (
@@ -37,6 +39,7 @@ class foreman_proxy::plugin::ansible (
   String $stdout_callback = $::foreman_proxy::plugin::ansible::params::stdout_callback,
   Array[Stdlib::Absolutepath] $roles_path = $::foreman_proxy::plugin::ansible::params::roles_path,
   String $ssh_args = $::foreman_proxy::plugin::ansible::params::ssh_args,
+  Boolean $install_runner = $::foreman_proxy::plugin::ansible::params::install_runner,
   Boolean $manage_runner_repo = $::foreman_proxy::plugin::ansible::params::manage_runner_repo,
 ) inherits foreman_proxy::plugin::ansible::params {
   $foreman_url = $::foreman_proxy::foreman_base_url
@@ -57,7 +60,9 @@ class foreman_proxy::plugin::ansible (
   }
 
   include ::foreman_proxy::plugin::dynflow
-  include ::foreman_proxy::plugin::ansible::runner
+  if $install_runner {
+    include ::foreman_proxy::plugin::ansible::runner
+  }
 
   foreman_proxy::plugin { 'ansible':
   }

--- a/manifests/plugin/ansible/params.pp
+++ b/manifests/plugin/ansible/params.pp
@@ -8,5 +8,6 @@ class foreman_proxy::plugin::ansible::params {
   $stdout_callback = 'yaml'
   $roles_path = ['/etc/ansible/roles', '/usr/share/ansible/roles']
   $ssh_args = '-o ProxyCommand=none'
+  $install_runner = true
   $manage_runner_repo = true
 }

--- a/manifests/plugin/ansible/params.pp
+++ b/manifests/plugin/ansible/params.pp
@@ -8,4 +8,5 @@ class foreman_proxy::plugin::ansible::params {
   $stdout_callback = 'yaml'
   $roles_path = ['/etc/ansible/roles', '/usr/share/ansible/roles']
   $ssh_args = '-o ProxyCommand=none'
+  $manage_runner_repo = true
 }

--- a/manifests/plugin/ansible/runner.pp
+++ b/manifests/plugin/ansible/runner.pp
@@ -28,7 +28,7 @@ class foreman_proxy::plugin::ansible::runner(
       'RedHat': {
         yumrepo { 'ansible-runner':
           descr    => 'Ansible runner',
-          baseurl  => "https://releases.ansible.com/ansible-runner/rpm/epel-${facts['os']['release']['major']}-\$basearch}/",
+          baseurl  => "https://releases.ansible.com/ansible-runner/rpm/epel-${facts['os']['release']['major']}-\$basearch/",
           gpgcheck => true,
           gpgkey   => 'https://releases.ansible.com/keys/RPM-GPG-KEY-ansible-release.pub',
           enabled  => '1',

--- a/manifests/plugin/ansible/runner.pp
+++ b/manifests/plugin/ansible/runner.pp
@@ -28,7 +28,7 @@ class foreman_proxy::plugin::ansible::runner(
       'RedHat': {
         yumrepo { 'ansible-runner':
           descr    => 'Ansible runner',
-          baseurl  => "https://releases.ansible.com/ansible-runner/rpm/epel-${facts['os']['release']['major']}-${facts['architecture']}/",
+          baseurl  => "https://releases.ansible.com/ansible-runner/rpm/epel-${facts['os']['release']['major']}-\$basearch}/",
           gpgcheck => true,
           gpgkey   => 'https://releases.ansible.com/keys/RPM-GPG-KEY-ansible-release.pub',
           enabled  => '1',

--- a/manifests/plugin/ansible/runner.pp
+++ b/manifests/plugin/ansible/runner.pp
@@ -1,0 +1,47 @@
+# = Ansible runner package installation
+#
+# $manage_runner_repo:: If true, adds upstream repositories to install ansible-runner package from
+#
+# $package_name:: Name of the package to install to provide 'ansible-runner' command
+#
+class foreman_proxy::plugin::ansible::runner(
+  Boolean $manage_runner_repo = $foreman_proxy::plugin::ansible::manage_runner_repo,
+  String  $package_name = 'ansible-runner',
+) {
+
+  if $manage_runner_repo {
+    case $facts['os']['family'] {
+      'Debian': {
+        include ::apt
+        apt::source { 'ansible-runner':
+          repos    => 'main',
+          location => 'https://releases.ansible.com/ansible-runner/deb',
+          key      => {
+            id     => 'AC48AC71DA695CA15F2D39C4B84E339C442667A9',
+            source => 'https://releases.ansible.com/keys/RPM-GPG-KEY-ansible-release.pub',
+          },
+          include  => {
+            src => false,
+          },
+        }
+      }
+      'RedHat': {
+        yumrepo { 'ansible-runner':
+          descr    => 'Ansible runner',
+          baseurl  => "https://releases.ansible.com/ansible-runner/rpm/epel-${facts['os']['release']['major']}-${facts['architecture']}/",
+          gpgcheck => true,
+          gpgkey   => 'https://releases.ansible.com/keys/RPM-GPG-KEY-ansible-release.pub',
+          enabled  => '1',
+        }
+      }
+      default: {
+        fail("Repository containing 'ansible-runner' not known for '${facts['os']['family']}'")
+      }
+    }
+  }
+
+  package { $package_name:
+    ensure => 'installed',
+  }
+
+}

--- a/spec/classes/foreman_proxy__plugin__ansible_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__ansible_spec.rb
@@ -8,11 +8,11 @@ describe 'foreman_proxy::plugin::ansible' do
         on_supported_os[os]
       end
 
-      describe 'with default settings' do
-        let :pre_condition do
-          "include foreman_proxy"
-        end
+      let :pre_condition do
+        "include foreman_proxy"
+      end
 
+      describe 'with default settings' do
         it { should contain_foreman_proxy__plugin('dynflow') }
 
         case os
@@ -29,7 +29,7 @@ describe 'foreman_proxy::plugin::ansible' do
         when 'redhat-7-x86_64'
           it 'should include ansible-runner upstream repo' do
             should contain_yumrepo('ansible-runner')
-                   .with_baseurl("https://releases.ansible.com/ansible-runner/rpm/epel-7-x86_64/")
+                   .with_baseurl("https://releases.ansible.com/ansible-runner/rpm/epel-7-$basearch/")
                    .with_gpgcheck(true)
                    .with_gpgkey('https://releases.ansible.com/keys/RPM-GPG-KEY-ansible-release.pub')
                    .with_enabled('1')
@@ -64,10 +64,6 @@ describe 'foreman_proxy::plugin::ansible' do
       end
 
       describe 'with override parameters' do
-        let :pre_condition do
-          "include foreman_proxy"
-        end
-
         let :params do
           {
             enabled: true,
@@ -113,6 +109,23 @@ describe 'foreman_proxy::plugin::ansible' do
             'ssh_args = -o ProxyCommand=none',
           ])
         end
+      end
+
+      describe 'with disabled ansible-runner install' do
+        let :params do
+          { install_runner: false }
+        end
+
+        it { should_not contain_class('foreman_proxy::plugin::ansible::runner') }
+
+        case os
+        when 'debian-9-x86_64'
+          it { should_not contain_apt__source('ansible-runner') }
+        when 'redhat-7-x86_64'
+          it { should_not contain_yumrepo('ansible-runner') }
+        end
+
+        it { should_not contain_package('ansible-runner') }
       end
     end
   end


### PR DESCRIPTION
As ansible-runner is going to be default way to run ansible, it should become a dependency at install time.