### PR TITLE
Enforce external Dynflow core on Debian based distibutions 

### DIFF
--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -73,7 +73,7 @@ class foreman_proxy::plugin::ansible (
     template_path => 'foreman_proxy/plugin/ansible.yml.erb',
   }
 
-  if $::osfamily == 'RedHat' and $::operatingsystem != 'Fedora' {
+  if $::osfamily == 'Debian' or ($::osfamily == 'RedHat' and $::operatingsystem != 'Fedora') {
     Foreman_proxy::Settings_file['ansible'] ~> Service['smart_proxy_dynflow_core']
   }
 }

--- a/manifests/plugin/dynflow.pp
+++ b/manifests/plugin/dynflow.pp
@@ -52,9 +52,9 @@ class foreman_proxy::plugin::dynflow (
     template_path => 'foreman_proxy/plugin/dynflow.yml.erb',
   }
 
-  if $facts['osfamily'] == 'RedHat' {
+  if $facts['osfamily'] == 'RedHat' or $facts['osfamily'] == 'Debian' {
 
-    if versioncmp($facts['operatingsystemmajrelease'], '8') >= 0 {
+    if $facts['osfamily'] == 'Debian' or versioncmp($facts['operatingsystemmajrelease'], '8') >= 0 {
       $scl_prefix = '' # lint:ignore:empty_string_assignment
     } else {
       $scl_prefix = 'tfm-'

--- a/manifests/plugin/dynflow/params.pp
+++ b/manifests/plugin/dynflow/params.pp
@@ -11,7 +11,7 @@ class foreman_proxy::plugin::dynflow::params {
   $tls_disabled_versions = undef
   $open_file_limit       = 1000000
   $external_core         = $facts['osfamily'] ? {
-    'RedHat' => true,
-    default  => undef
+    /RedHat|Debian/ => true,
+    default         => undef
   }
 }

--- a/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
@@ -20,7 +20,7 @@ describe 'foreman_proxy::plugin::dynflow' do
         end
       end
 
-      has_core = facts[:osfamily] == 'RedHat' && facts[:operatingsystem] != 'Fedora'
+      has_core = facts[:osfamily] == 'Debian' || (facts[:osfamily] == 'RedHat' && facts[:operatingsystem] != 'Fedora')
 
       describe 'with default settings' do
         it { should compile.with_all_deps }


### PR DESCRIPTION
Follows (and includes) https://github.com/theforeman/puppet-foreman_proxy/pull/512