### PR TITLE
Refs #27196 - Remote empty line

### DIFF
--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -23,7 +23,6 @@
 # $stdout_callback:: Ansible's stdout_callback setting
 #
 # $roles_path:: Paths where we look for ansible roles.
-
 #
 class foreman_proxy::plugin::ansible (
   Boolean $enabled = $::foreman_proxy::plugin::ansible::params::enabled,


### PR DESCRIPTION
This empty line breaks puppet-strings parsing which only looks at the comment block right above the class. puppet-lint-param-docs is more flexible in what it accepts so didn't catch it.