### PR TITLE
Add dhcp_includes parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -299,6 +299,8 @@
 #
 # $dhcp_load_balance::          Cutoff after which load balancing is disabled
 #
+# $dhcp_includes::              Array of additional configuration files to be included into DHCP server configuration
+#
 # $dhcp_manage_acls::           Whether to manage DHCP directory ACLs. This allows the Foreman Proxy user to access even if the directory mode is 0750.
 #
 # $httpboot::                   Enable HTTPBoot feature
@@ -427,6 +429,7 @@ class foreman_proxy (
   Optional[Integer[0]] $dhcp_mclt = $::foreman_proxy::params::dhcp_mclt,
   Optional[Integer[0, 255]] $dhcp_load_split = $::foreman_proxy::params::dhcp_load_split,
   Optional[Integer[0]] $dhcp_load_balance = $::foreman_proxy::params::dhcp_load_balance,
+  Variant[Array[String], Optional[String]] $dhcp_includes = $::foreman_proxy::params::dhcp_includes,
   Boolean $dhcp_manage_acls = $::foreman_proxy::params::dhcp_manage_acls,
   Boolean $dns = $::foreman_proxy::params::dns,
   Foreman_proxy::ListenOn $dns_listen_on = $::foreman_proxy::params::dns_listen_on,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -271,6 +271,7 @@ class foreman_proxy::params {
   $dhcp_pxefilename        = 'pxelinux.0'
   $dhcp_network            = undef
   $dhcp_netmask            = undef
+  $dhcp_includes           = undef
   # This will use the IP of the interface in $dhcp_interface, override
   # if you need to. You can make this a comma-separated string too - it
   # will be split into an array

--- a/manifests/proxydhcp.pp
+++ b/manifests/proxydhcp.pp
@@ -38,6 +38,7 @@ class foreman_proxy::proxydhcp {
     pxefilename => $foreman_proxy::dhcp_pxefilename,
     omapi_name  => $foreman_proxy::dhcp_key_name,
     omapi_key   => $foreman_proxy::dhcp_key_secret,
+    includes    => $foreman_proxy::dhcp_includes,
   }
 
   ::dhcp::pool{ $::domain:


### PR DESCRIPTION
Add dhcp_includes parameter to allow expand configuration of DHCP server by passing additional configuration files.