### PR TITLE
Re-add :puppet_version setting to puppet.yml

### DIFF
--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -231,6 +231,7 @@ describe 'foreman_proxy' do
           verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/puppet.yml", [
             '---',
             ':enabled: https',
+            ":puppet_version: #{Puppet.version}",
           ])
         end
 

--- a/templates/puppet.yml.erb
+++ b/templates/puppet.yml.erb
@@ -11,3 +11,5 @@
 <% else -%>
 #:use_provider: puppet_proxy_customrun
 <% end -%>
+
+:puppet_version: <%= @puppetversion %>


### PR DESCRIPTION
Release 12.0.0 erroneously removed the :puppet_version setting from the
configuration file managing the "puppet" feature, preventing
foreman-proxy from starting up correctly.

Fixes GH-527