### PR TITLE
Fixes #27552 - Fix journald logging

### DIFF
--- a/examples/journald.pp
+++ b/examples/journald.pp
@@ -1,0 +1,33 @@
+$directory = '/etc/foreman-proxy'
+$certificate = "${directory}/certificate.pem"
+$key = "${directory}/key.pem"
+
+# Install a proxy
+class { 'foreman_proxy':
+  log                 => 'JOURNAL',
+  repo                => 'nightly',
+  puppet_group        => 'root',
+  register_in_foreman => false,
+  ssl_ca              => $certificate,
+  ssl_cert            => $certificate,
+  ssl_key             => $key,
+}
+
+# Create the certificates - this is after the proxy because we need the user variable
+exec { 'Create certificate directory':
+  command => "mkdir -p ${directory}",
+  path    => ['/bin', '/usr/bin'],
+  creates => $directory,
+}
+-> exec { 'Generate certificate':
+  command => "openssl req -nodes -x509 -newkey rsa:2048 -subj '/CN=${facts['fqdn']}' -keyout '${key}' -out '${certificate}' -days 365",
+  path    => ['/bin', '/usr/bin'],
+  creates => $certificate,
+  umask   => '0022',
+}
+-> file { [$key, $certificate]:
+  owner  => $foreman_proxy::user,
+  group  => $foreman_proxy::user,
+  mode   => '0640',
+  before => Class['foreman_proxy::service'],
+}

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,9 +12,12 @@ class foreman_proxy::install {
     ensure => $foreman_proxy::version,
   }
 
-  if $foreman_proxy::log == 'JOURNALD' {
+  if $foreman_proxy::log == 'JOURNAL' {
     package { 'foreman-proxy-journald':
       ensure => installed,
+    }
+    if $foreman_proxy::repo {
+      Foreman::Repos['foreman_proxy'] -> Package['foreman-proxy-journald']
     }
   }
 

--- a/spec/acceptance/journald_spec.rb
+++ b/spec/acceptance/journald_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper_acceptance'
+
+describe 'Scenario: install foreman-proxy with journald' do
+  before(:context) do
+    case os[:family]
+    when /redhat|fedora/
+      on default, 'yum -y remove foreman* tfm-*'
+    when /debian|ubuntu/
+      on default, 'apt-get purge -y foreman*', { :acceptable_exit_codes => [0, 100] }
+    end
+  end
+
+  include_examples 'the example', 'journald.pp'
+
+  describe package('foreman-proxy-journald') do
+    it { is_expected.to be_installed }
+  end
+
+  describe service('foreman-proxy') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe port(8000) do
+    it { is_expected.not_to be_listening }
+  end
+
+  describe port(8443) do
+    it { is_expected.to be_listening }
+  end
+
+  # Logging to the journal is broken on Travis and EL7 but works in Vagrant VMs
+  # and regular docker containers
+  describe command('journalctl -u foreman-proxy'), unless: ENV['TRAVIS'] == 'true' && os[:family] == 'redhat' && os[:release] =~ /^7\./ do
+    its(:stdout) { is_expected.to match(%r{WEBrick::HTTPServer#start}) }
+  end
+end

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -917,6 +917,12 @@ describe 'foreman_proxy' do
         end
       end
 
+      context 'with journald' do
+        let(:params) { super().merge(log: 'JOURNAL') }
+        it { is_expected.to contain_package('foreman-proxy-journald') }
+        it { is_expected.to contain_file("#{etc_dir}/foreman-proxy/settings.yml").with_content(%r{^:log_file: JOURNAL$}) }
+      end
+
       context 'with dhcp enabled' do
         case facts[:osfamily]
         when 'FreeBSD', 'DragonFly'


### PR DESCRIPTION
fde8d9b9547b1dc50b6010616b4aaf5bde51fbf4 attempted to implement installing foreman-proxy-journald when the logging was set to JOURNAL.  The check was comparing JOURNAL to JOURNALD.

This patch corrects it and adds both unit and acceptance tests.