### PR TITLE
Remove unused setting from pulp3

### DIFF
--- a/spec/classes/foreman_proxy__plugin__pulp_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__pulp_spec.rb
@@ -63,7 +63,6 @@ describe 'foreman_proxy::plugin::pulp' do
                               ":pulp_url: https://#{facts[:fqdn]}/pulp",
                               ':pulp_dir: /var/lib/pulp',
                               ':pulp_content_dir: /var/lib/pulp/content',
-                              ':puppet_content_dir: /etc/puppetlabs/code/environments',
                               ':mirror: false'
                             ])
     end

--- a/templates/plugin/pulp3.yml.erb
+++ b/templates/plugin/pulp3.yml.erb
@@ -4,5 +4,4 @@
 :pulp_url: <%= scope.lookupvar("foreman_proxy::plugin::pulp::pulp_url") %>
 :pulp_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::pulp_dir") %>
 :pulp_content_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::pulp_content_dir") %>
-:puppet_content_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::puppet_content_dir") %>
 :mirror: <%= scope.lookupvar("foreman_proxy::plugin::pulp::pulp3_mirror") %>


### PR DESCRIPTION
This was included in the sample config, but wasn't actually read by the
pulp3 plugin. It should remain as a class parameter for the other config
files.