### PR TITLE
Gracefully handle a missing IP address

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -278,7 +278,7 @@ class foreman_proxy::params {
   $dhcp_key_secret = undef
   $dhcp_omapi_port = 7911
   $dhcp_node_type = 'standalone'
-  $dhcp_failover_address = $::ipaddress
+  $dhcp_failover_address = fact('ipaddress')
   $dhcp_peer_address = undef
   $dhcp_failover_port = 519
   $dhcp_max_response_delay = 30

--- a/spec/classes/foreman_proxy__plugin__pulp_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__pulp_spec.rb
@@ -131,7 +131,6 @@ describe 'foreman_proxy::plugin::pulp' do
                               ':pulp_url: https://pulp.example.com',
                               ':pulp_dir: /tmp/pulp',
                               ':pulp_content_dir: /tmp/content',
-                              ':puppet_content_dir: /tmp/puppet',
                               ':mirror: true'
                             ])
     end

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -141,6 +141,12 @@ describe 'foreman_proxy' do
           end
         end
 
+        context 'without IPv4' do
+          let(:facts) { super().reject { |fact| fact == :ipaddress } }
+
+          it { is_expected.to compile.with_all_deps }
+        end
+
         context 'without IPv6' do
           let(:facts) { super().reject { |fact| fact == :ipaddress6 } }
 


### PR DESCRIPTION
Not all machines have an IPv4 address. The datatype is `Optional[String]` so this is valid.