### PR TITLE
Fix tests by using a better IPv6 check

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -6,11 +6,6 @@
   env:
     global:
       - PARALLEL_TEST_PROCESSORS=8
-Gemfile:
-  extra:
-    # 0.5.1+ has ArchLinux without the legacy facts which we rely on
-    - gem: facterdb
-      version: '0.5.0'
 Rakefile:
   param_docs_pattern:
     - manifests/init.pp

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,5 @@ gem 'beaker-puppet_install_helper', {"groups"=>["system_tests"]}
 gem 'metadata-json-lint'
 gem 'kafo_module_lint'
 gem 'parallel_tests'
-gem 'facterdb', '0.5.0'
 
 # vim:ft=ruby

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -148,7 +148,7 @@ class foreman_proxy::params {
   $plugin_version          = 'installed'
 
   # Enable listening on http
-  if $::osfamily == 'RedHat' and versioncmp($::operatingsystemmajrelease, '7') <= 0 and has_key($facts, 'ipaddress6') {
+  if $::osfamily == 'RedHat' and versioncmp($::operatingsystemmajrelease, '7') <= 0 and fact('ipaddress6') {
     $bind_host = ['::']
   } else {
     $bind_host = ['*']

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -148,7 +148,7 @@ describe 'foreman_proxy' do
         end
 
         context 'without IPv6' do
-          let(:facts) { super().reject { |fact| fact == :ipaddress6 } }
+          let(:facts) { super().merge(ipaddress6: nil) }
 
           it 'should generate correct settings.yml' do
             bind_host = '*'

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -932,24 +932,22 @@ describe 'foreman_proxy' do
       context 'with dhcp enabled' do
         case facts[:osfamily]
         when 'FreeBSD', 'DragonFly'
-          dhcp_interface = 'lo0'
           dhcp_leases    = '/var/db/dhcpd/dhcpd.leases'
           dhcp_config    = "#{etc_dir}/dhcpd.conf"
         when 'Debian'
-          dhcp_interface = 'lo'
           dhcp_leases    = '/var/lib/dhcp/dhcpd.leases'
           dhcp_config    = "#{etc_dir}/dhcp/dhcpd.conf"
         when 'Archlinux'
-          dhcp_interface = 'lo'
           dhcp_leases    = '/var/lib/dhcp/dhcpd.leases'
           dhcp_config    = "#{etc_dir}/dhcpd.conf"
         else
-          dhcp_interface = 'lo'
           dhcp_leases    = '/var/lib/dhcpd/dhcpd.leases'
           dhcp_config    = "#{etc_dir}/dhcp/dhcpd.conf"
         end
 
-        let(:params) { super().merge(dhcp: true, dhcp_interface: dhcp_interface) }
+        let(:facts) { super().merge(ipaddress_dhcpif: '192.0.2.1', network_dhcpif: '192.0.2.0', netmask_dhcpif: '255.255.255.0') }
+
+        let(:params) { super().merge(dhcp: true, dhcp_interface: 'dhcpif') }
 
         it 'should generate correct dhcp.yml' do
           verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/dhcp.yml", [

--- a/spec/classes/foreman_proxy__tftp__netboot_spec.rb
+++ b/spec/classes/foreman_proxy__tftp__netboot_spec.rb
@@ -17,6 +17,45 @@ describe 'foreman_proxy::tftp::netboot' do
         should contain_file("/tftproot/grub2/boot").
           with_ensure('link').with_target("../boot")
       end
+
+      if facts[:osfamily] == 'Debian'
+        it { should contain_package('grub-common').with_ensure('present') }
+        it { should contain_package('grub-efi-amd64-bin').with_ensure('present') }
+
+        it 'should generate efi image from grub2 modules for Debian' do
+          should contain_exec('build-grub2-efi-image').with_unless("/bin/grep -q regexp '/tftproot/grub2/grubx64.efi'")
+          should contain_file("/tftproot/grub2/grubx64.efi")
+            .with_mode('0644')
+            .with_owner('root')
+            .that_requires('Exec[build-grub2-efi-image]')
+        end
+        it { should contain_file("/tftproot/grub2/shim.efi").with_ensure('link') }
+      elsif facts[:osfamily] == 'RedHat'
+        if facts[:operatingsystemmajrelease].to_i > 6
+          it { should contain_package('grub2-efi').with_ensure('present') }
+          it { should contain_package('grub2-efi-modules').with_ensure('present') }
+          it { should contain_package('grub2-tools').with_ensure('present') }
+          it { should contain_package('shim').with_ensure('present') }
+
+          case facts[:operatingsystem]
+          when /^(RedHat|Scientific|OracleLinux)$/
+            it { should contain_file("/tftproot/grub2/grubx64.efi").with_source('/boot/efi/EFI/redhat/grubx64.efi') }
+            it { should contain_file("/tftproot/grub2/shim.efi").with_source('/boot/efi/EFI/redhat/shim.efi').with_owner('root').with_mode('0644') }
+          when 'Fedora'
+            it { should contain_file("/tftproot/grub2/grubx64.efi").with_source('/boot/efi/EFI/fedora/grubx64.efi') }
+            it { should contain_file("/tftproot/grub2/shim.efi").with_source('/boot/efi/EFI/fedora/shim.efi').with_owner('root').with_mode('0644') }
+          when 'CentOS'
+            it { should contain_file("/tftproot/grub2/grubx64.efi").with_source('/boot/efi/EFI/centos/grubx64.efi') }
+            it { should contain_file("/tftproot/grub2/shim.efi").with_source('/boot/efi/EFI/centos/shim.efi').with_owner('root').with_mode('0644') }
+          end
+        else
+          it { should contain_package('grub').with_ensure('present') }
+          it { should contain_file('/var/lib/tftpboot/grub/grubx64.efi').with_ensure('file').with_owner('root').with_mode('0644').with_source('/boot/efi/EFI/redhat/grub.efi') }
+          it { should contain_file('/var/lib/tftpboot/grub/shim.efi').with_ensure('link') }
+        end
+      else
+        # TODO: check if a warning is emited
+      end
     end
   end
 end

--- a/spec/classes/foreman_proxy__tftp__netboot_spec.rb
+++ b/spec/classes/foreman_proxy__tftp__netboot_spec.rb
@@ -19,6 +19,7 @@ describe 'foreman_proxy::tftp::netboot' do
       end
 
       if facts[:osfamily] == 'Debian'
+        it { is_expected.to contain_class('foreman_proxy::tftp::netboot').with_grub_installation_type('debian') }
         it { should contain_package('grub-common').with_ensure('present') }
         it { should contain_package('grub-efi-amd64-bin').with_ensure('present') }
 
@@ -32,10 +33,11 @@ describe 'foreman_proxy::tftp::netboot' do
         it { should contain_file("/tftproot/grub2/shim.efi").with_ensure('link') }
       elsif facts[:osfamily] == 'RedHat'
         if facts[:operatingsystemmajrelease].to_i > 6
-          it { should contain_package('grub2-efi').with_ensure('present') }
-          it { should contain_package('grub2-efi-modules').with_ensure('present') }
+          it { is_expected.to contain_class('foreman_proxy::tftp::netboot').with_grub_installation_type('redhat') }
+          it { should contain_package('grub2-efi-x64').with_ensure('present') }
+          it { should contain_package('grub2-efi-x64-modules').with_ensure('present') }
           it { should contain_package('grub2-tools').with_ensure('present') }
-          it { should contain_package('shim').with_ensure('present') }
+          it { should contain_package('shim-x64').with_ensure('present') }
 
           case facts[:operatingsystem]
           when /^(RedHat|Scientific|OracleLinux)$/
@@ -49,11 +51,13 @@ describe 'foreman_proxy::tftp::netboot' do
             it { should contain_file("/tftproot/grub2/shim.efi").with_source('/boot/efi/EFI/centos/shim.efi').with_owner('root').with_mode('0644') }
           end
         else
+          it { is_expected.to contain_class('foreman_proxy::tftp::netboot').with_grub_installation_type('redhat_old') }
           it { should contain_package('grub').with_ensure('present') }
           it { should contain_file('/var/lib/tftpboot/grub/grubx64.efi').with_ensure('file').with_owner('root').with_mode('0644').with_source('/boot/efi/EFI/redhat/grub.efi') }
           it { should contain_file('/var/lib/tftpboot/grub/shim.efi').with_ensure('link') }
         end
       else
+        it { is_expected.to contain_class('foreman_proxy::tftp::netboot').with_grub_installation_type('none') }
         # TODO: check if a warning is emited
       end
     end

--- a/spec/classes/foreman_proxy__tftp_spec.rb
+++ b/spec/classes/foreman_proxy__tftp_spec.rb
@@ -15,18 +15,6 @@ describe 'foreman_proxy::tftp' do
 
       it { is_expected.to contain_class('foreman_proxy::tftp::netboot') }
 
-      tftp_root = case facts[:osfamily]
-                  when 'Debian'
-                    case facts[:operatingsystem]
-                    when 'Ubuntu'
-                      '/var/lib/tftpboot'
-                    else
-                      '/srv/tftp'
-                    end
-                  when 'FreeBSD', 'DragonFly'
-                    '/tftpboot'
-                  end
-
       case facts[:osfamily]
       when 'Archlinux'
         tftp_root = '/srv/tftp'
@@ -80,50 +68,7 @@ describe 'foreman_proxy::tftp' do
         it { is_expected.to contain_file(target).with_source(source) }
       end
 
-      if facts[:osfamily] == 'Debian'
-        it { should contain_package('grub-common').with_ensure('present') }
-        it { should contain_package('grub-efi-amd64-bin').with_ensure('present') }
-
-        tftp_root = case facts[:operatingsystem]
-                    when 'Ubuntu'
-                      '/var/lib/tftpboot'
-                    else
-                      '/srv/tftp'
-                    end
-        it 'should generate efi image from grub2 modules for Debian' do
-          should contain_exec('build-grub2-efi-image').with_unless("/bin/grep -q regexp '#{tftp_root}/grub2/grubx64.efi'")
-          should contain_file("#{tftp_root}/grub2/grubx64.efi")
-            .with_mode('0644')
-            .with_owner('root')
-            .that_requires('Exec[build-grub2-efi-image]')
-        end
-        it { should contain_file("#{tftp_root}/grub2/shim.efi").with_ensure('link') }
-      elsif facts[:osfamily] == 'RedHat'
-        if facts[:operatingsystemmajrelease].to_i > 6
-          it { should contain_package('grub2-efi').with_ensure('present') }
-          it { should contain_package('grub2-efi-modules').with_ensure('present') }
-          it { should contain_package('grub2-tools').with_ensure('present') }
-          it { should contain_package('shim').with_ensure('present') }
-
-          case facts[:operatingsystem]
-          when /^(RedHat|Scientific|OracleLinux)$/
-            it { should contain_file("#{tftp_root}/grub2/grubx64.efi").with_source('/boot/efi/EFI/redhat/grubx64.efi') }
-            it { should contain_file("#{tftp_root}/grub2/shim.efi").with_source('/boot/efi/EFI/redhat/shim.efi').with_owner('root').with_mode('0644') }
-          when 'Fedora'
-            it { should contain_file("#{tftp_root}/grub2/grubx64.efi").with_source('/boot/efi/EFI/fedora/grubx64.efi') }
-            it { should contain_file("#{tftp_root}/grub2/shim.efi").with_source('/boot/efi/EFI/fedora/shim.efi').with_owner('root').with_mode('0644') }
-          when 'CentOS'
-            it { should contain_file("#{tftp_root}/grub2/grubx64.efi").with_source('/boot/efi/EFI/centos/grubx64.efi') }
-            it { should contain_file("#{tftp_root}/grub2/shim.efi").with_source('/boot/efi/EFI/centos/shim.efi').with_owner('root').with_mode('0644') }
-          end
-        else
-          it { should contain_package('grub').with_ensure('present') }
-          it { should contain_file('/var/lib/tftpboot/grub/grubx64.efi').with_ensure('file').with_owner('root').with_mode('0644').with_source('/boot/efi/EFI/redhat/grub.efi') }
-          it { should contain_file('/var/lib/tftpboot/grub/shim.efi').with_ensure('link') }
-        end
-      else
-        # TODO: check if a warning is emited
-      end
+      it { is_expected.to contain_class('foreman_proxy::tftp::netboot').with_root(tftp_root) }
 
       case facts[:osfamily]
       when 'FreeBSD', 'DragonFly'


### PR DESCRIPTION
7dff714 More robust check for IPv6

rspec-puppet 2.7.8 has started to always set an ipaddress6 fact and deleting no longer works. Setting it to nil does work. The fact() function returns a fact or undef if it can't be found which means it's still a valid way to check if IPv6 is present.

0c5514c Unpin facterdb

The latest version has ArchLinux facts with legacy facts.