### PR TITLE
Only manage DNS for the nsupdate provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ To use the PowerDNS plugin, the following variables need to be set on the main
 ```puppet
 class{'::foreman_proxy':
   dns          => true,
-  dns_managed  => false,
   dns_provider => 'powerdns',
 }
 ```

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,7 +19,7 @@ class foreman_proxy::config {
   # Somehow, calling these DHCP and DNS seems to conflict. So, they get a prefix...
   if $foreman_proxy::dhcp and $foreman_proxy::dhcp_managed { include ::foreman_proxy::proxydhcp }
 
-  if $foreman_proxy::dns and $foreman_proxy::dns_managed {
+  if $foreman_proxy::dns and $foreman_proxy::dns_provider in ['nsupdate', 'nsupdate_gss'] and $foreman_proxy::dns_managed {
     include ::foreman_proxy::proxydns
     $dns_groups = [$foreman_proxy::proxydns::user_group]
   } else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -200,7 +200,7 @@
 #
 # $dns_listen_on::              DNS proxy to listen on https, http, or both
 #
-# $dns_managed::                The DNS daemon is managed by this module
+# $dns_managed::                The DNS daemon is managed by this module. Only supported for the nsupdate and nsupdate_gss DNS providers.
 #
 # $dns_provider::               DNS provider
 #

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -31,4 +31,8 @@ class foreman_proxy::install {
   if $foreman_proxy::bmc and $foreman_proxy::bmc_default_provider != 'shell' {
     ensure_packages([$foreman_proxy::bmc_default_provider], { ensure => $foreman_proxy::ensure_packages_version, })
   }
+
+  if $foreman_proxy::dns and $foreman_proxy::dns_provider in ['nsupdate', 'nsupdate_gss'] {
+    ensure_packages([$foreman_proxy::nsupdate], { ensure => $foreman_proxy::ensure_packages_version })
+  }
 }

--- a/manifests/proxydns.pp
+++ b/manifests/proxydns.pp
@@ -1,9 +1,5 @@
 # Configure the DNS component
 #
-# $nsupdate:: The nsupdate package name
-#
-# $ensure_packages_version:: The ensure to use on the nsupdate package
-#
 # $forwarders:: The DNS forwarders to use
 #
 # $interface:: The interface to use for fact determination. By default the IP
@@ -18,8 +14,6 @@
 #        DNS entry.
 #
 class foreman_proxy::proxydns(
-  $nsupdate = $::foreman_proxy::nsupdate,
-  $ensure_packages_version = $::foreman_proxy::ensure_packages_version,
   $forwarders = $::foreman_proxy::dns_forwarders,
   $interface = $::foreman_proxy::dns_interface,
   $forward_zone = $::foreman_proxy::dns_zone,
@@ -31,8 +25,6 @@ class foreman_proxy::proxydns(
   }
 
   $user_group = $dns::group
-
-  ensure_packages([$nsupdate], { ensure => $ensure_packages_version, })
 
   # puppet fact names are converted from ethX.X and ethX:X to ethX_X
   # so for alias and vlan interfaces we have to modify the name accordingly

--- a/spec/classes/foreman_proxy__proxydns__spec.rb
+++ b/spec/classes/foreman_proxy__proxydns__spec.rb
@@ -15,23 +15,10 @@ describe 'foreman_proxy::proxydns' do
           'include ::foreman_proxy'
         end
 
-        nsupdate_pkg = case facts[:osfamily]
-                       when 'RedHat'
-                         'bind-utils'
-                       when 'FreeBSD', 'DragonFly'
-                         'bind910'
-                       when 'Archlinux'
-                         'bind-tools'
-                       else
-                         'dnsutils'
-                       end
-
         it { should compile.with_all_deps }
 
         it 'should inherit the correct parameters' do
           should contain_class('foreman_proxy::proxydns')
-            .with_nsupdate(nsupdate_pkg)
-            .with_ensure_packages_version('present')
             .with_forwarders([])
             .with_interface('eth0')
             .with_forward_zone('example.com')
@@ -43,12 +30,10 @@ describe 'foreman_proxy::proxydns' do
       context 'with explicit parameters' do
         let :base_params do
           {
-            :nsupdate                => 'nsupdate',
-            :ensure_packages_version => 'installed',
-            :forwarders              => [],
-            :interface               => 'eth0',
-            :forward_zone            => 'example.com',
-            :reverse_zone            => false,
+            forwarders: [],
+            interface: 'eth0',
+            forward_zone: 'example.com',
+            reverse_zone: false,
           }
         end
 
@@ -68,10 +53,6 @@ describe 'foreman_proxy::proxydns' do
 
           it 'should include the dns class' do
             should contain_class('dns').with_forwarders([])
-          end
-
-          it 'should install nsupdate' do
-            should contain_package('nsupdate').with_ensure('present')
           end
 
           it 'should include the forward zone' do


### PR DESCRIPTION
When using any other provider than nsupdate, it doesn't make sense to include a managed bind and can only cause problems.

The nsupdate package manage is needed for nsupdate so moved to the installation part.