### PR TITLE
Add timeout option to Infoblox DNS module

### DIFF
--- a/manifests/plugin/dns/infoblox.pp
+++ b/manifests/plugin/dns/infoblox.pp
@@ -4,19 +4,25 @@
 #
 # === Parameters:
 #
-# $dns_server:: The address of the Infoblox server
+# $dns_server::   The address of the Infoblox server
 #
-# $username::   The username of the Infoblox user
+# $username::     The username of the Infoblox user
 #
-# $password::   The password of the Infoblox user
+# $password::     The password of the Infoblox user
 #
-# $dns_view::   The Infoblox DNS View
+# $dns_view::     The Infoblox DNS View
+#
+# === Advanced Parameters:
+#
+# $timeout::      Connection and read timeout when talking to the DNS server
 #
 class foreman_proxy::plugin::dns::infoblox (
   Stdlib::Host $dns_server = undef,
   String $username = undef,
   String $password = undef,
   String $dns_view = 'default',
+  Integer[0] $timeout = 60,
+
 ) {
   foreman_proxy::plugin::provider { 'dns_infoblox':
   }

--- a/spec/classes/foreman_proxy__plugin__dns__infoblox_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__dns__infoblox_spec.rb
@@ -26,6 +26,7 @@ describe 'foreman_proxy::plugin::dns::infoblox' do
           verify_exact_contents(catalogue, '/etc/foreman-proxy/settings.d/dns_infoblox.yml', [
             '---',
             ':dns_server: "localhost"',
+            ':dns_timeout: 60',
             ':username: "admin"',
             ':password: "infoblox"',
             ':dns_view: "default"',

--- a/templates/plugin/dns_infoblox.yml.erb
+++ b/templates/plugin/dns_infoblox.yml.erb
@@ -1,5 +1,6 @@
 ---
 :dns_server: "<%= scope.lookupvar('::foreman_proxy::plugin::dns::infoblox::dns_server') %>"
+:dns_timeout: <%= scope.lookupvar('::foreman_proxy::plugin::dns::infoblox::timeout') %>
 :username: "<%= scope.lookupvar('::foreman_proxy::plugin::dns::infoblox::username') %>"
 :password: "<%= scope.lookupvar('::foreman_proxy::plugin::dns::infoblox::password') %>"
 :dns_view: "<%= scope.lookupvar('::foreman_proxy::plugin::dns::infoblox::dns_view') %>"


### PR DESCRIPTION
Any chance getting this into 1.24 RC? RH infra team is suffering from slow Infoblox responses and they need the timeout option to be configured on all of their instances. Thanks.