### PR TITLE
define $pulp3_master instead of $pulp3_mirror

### DIFF
--- a/manifests/plugin/pulp.pp
+++ b/manifests/plugin/pulp.pp
@@ -23,7 +23,7 @@
 #
 # $pulp3_enabled::      enables/disables the pulp3 plugin
 #
-# $pulp3_mirror::       Whether this pulp3 plugin acts as a mirror or another pulp node. A pulp3 mirror is the pulp3 equivalent of a pulpnode.
+# $pulp3_master::       Whether this pulp3 plugin acts as a pulp node (master) or mirror. A pulp3 mirror is the pulp3 equivalent of a pulpnode.
 #
 # $puppet_content_dir:: directory for puppet content
 #
@@ -34,7 +34,7 @@ class foreman_proxy::plugin::pulp (
   Foreman_proxy::ListenOn $listen_on = $::foreman_proxy::plugin::pulp::params::listen_on,
   Boolean $pulpnode_enabled = $::foreman_proxy::plugin::pulp::params::pulpnode_enabled,
   Boolean $pulp3_enabled = $::foreman_proxy::plugin::pulp::params::pulp3_enabled,
-  Boolean $pulp3_mirror = $::foreman_proxy::plugin::pulp::params::pulp3_mirror,
+  Boolean $pulp3_master = $::foreman_proxy::plugin::pulp::params::pulp3_master,
   Optional[String] $version = $::foreman_proxy::plugin::pulp::params::version,
   Optional[String] $group = $::foreman_proxy::plugin::pulp::params::group,
   Stdlib::HTTPUrl $pulp_url = $::foreman_proxy::plugin::pulp::params::pulp_url,

--- a/manifests/plugin/pulp/params.pp
+++ b/manifests/plugin/pulp/params.pp
@@ -8,7 +8,7 @@ class foreman_proxy::plugin::pulp::params {
   $group              = undef
   $pulpnode_enabled   = false
   $pulp3_enabled      = false
-  $pulp3_mirror       = false
+  $pulp3_master       = true
   $pulp_url           = "https://${::fqdn}/pulp"
   $pulp_dir           = '/var/lib/pulp'
   $pulp_content_dir   = '/var/lib/pulp/content'


### PR DESCRIPTION
As a result of the discussion at https://github.com/theforeman/puppet-foreman_proxy_content/pull/222 we will define and drive pulp3 configuration here so params like $pulp3_master are not exposed to the user of FPC.