### PR TITLE
Drop Archlinux support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -90,41 +90,12 @@ class foreman_proxy::params {
         '/usr/local/share/syslinux/bios/com32/menu/menu.c32',
       ]
     }
-    'Archlinux': {
-      $plugin_prefix = 'ruby-smart-proxy-'
-
-      $dir   = '/usr/share/foreman-proxy'
-      $etc   = '/etc'
-      $shell = '/usr/bin/false'
-      $user  = 'foreman-proxy'
-
-      $puppet_bindir = '/usr/bin'
-      $puppetdir     = '/etc/puppetlabs/puppet'
-      $ssldir        = "${puppetdir}/ssl"
-
-      $dhcp_config = '/etc/dhcpd.conf'
-      $dhcp_leases = '/var/lib/dhcp/dhcpd.leases'
-      $dhcp_manage_acls = false
-
-      $keyfile  = '/etc/rndc.key'
-      $nsupdate = 'bind-tools'
-
-      $tftp_root = '/srv/tftp'
-      $tftp_syslinux_filenames = [
-        '/usr/lib/syslinux/bios/pxelinux.0',
-        '/usr/lib/syslinux/bios/memdisk',
-        '/usr/lib/syslinux/bios/chain.c32',
-        '/usr/lib/syslinux/bios/ldlinux.c32',
-        '/usr/lib/syslinux/bios/libutil.c32',
-        '/usr/lib/syslinux/bios/menu.c32',
-      ]
-    }
     default: {
       fail("${::hostname}: This module does not support osfamily ${::osfamily}")
     }
   }
 
-  if $::osfamily !~ /^(FreeBSD|DragonFly|Archlinux)$/ {
+  if $::osfamily !~ /^(FreeBSD|DragonFly)$/ {
     if $::rubysitedir =~ /\/opt\/puppetlabs\/puppet/ {
       $puppet_bindir = '/opt/puppetlabs/bin'
       $puppetdir     = '/etc/puppetlabs/puppet'

--- a/metadata.json
+++ b/metadata.json
@@ -96,9 +96,6 @@
       ]
     },
     {
-      "operatingsystem": "Archlinux"
-    },
-    {
       "operatingsystem": "DragonFly",
       "operatingsystemrelease": [
         "4"

--- a/spec/classes/foreman_proxy__plugin__discovery_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__discovery_spec.rb
@@ -10,7 +10,7 @@ describe 'foreman_proxy::plugin::discovery' do
       end
 
       case facts[:operatingsystem]
-        when 'Debian', 'Archlinux'
+        when 'Debian'
           tftproot = '/srv/tftp'
         when 'FreeBSD'
           tftproot = '/tftpboot'

--- a/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
@@ -3,22 +3,9 @@ require 'spec_helper'
 describe 'foreman_proxy::plugin::dynflow' do
   on_os_under_test.each do |os, facts|
     context "on #{os}" do
-      let :facts do
-        facts
-      end
-
-      let :pre_condition do
-        "include foreman_proxy"
-      end
-
-      let :etc_dir do
-        case facts[:osfamily]
-        when 'FreeBSD', 'DragonFly'
-          '/usr/local/etc'
-        else
-          '/etc'
-        end
-      end
+      let(:facts) { facts }
+      let(:pre_condition) { 'include foreman_proxy' }
+      let(:etc_dir) { ['FreeBSD', 'DragonFly'].include?(facts[:osfamily]) ? '/usr/local/etc' : '/etc' }
 
       has_core = facts[:osfamily] == 'RedHat' && facts[:operatingsystem] != 'Fedora'
 

--- a/spec/classes/foreman_proxy__proxydhcp__spec.rb
+++ b/spec/classes/foreman_proxy__proxydhcp__spec.rb
@@ -1,365 +1,226 @@
 require 'spec_helper'
 
-describe 'foreman_proxy::proxydhcp' do
+describe 'foreman_proxy' do
   on_os_under_test.each do |os, facts|
     context "on #{os}" do
 
+      let(:params) do
+        {
+          dhcp: true,
+          dhcp_managed: true,
+          dhcp_provider: 'isc',
+          dhcp_gateway: '192.0.2.1',
+          # Disable some integration for faster compiles
+          dns: false,
+          tftp: false,
+          puppet: false,
+          puppetca: false,
+        }
+      end
+
       context "on physical interface" do
         let :facts do
-          facts.merge({:ipaddress_eth0 => '127.0.1.1',
-                       :netmask_eth0   => '255.0.0.0',
-                       :network_eth0   => '127.0.0.0'})
+          facts.merge(
+            ipaddress: '192.0.2.10',
+            ipaddress_eth0: '192.0.2.10',
+            netmask_eth0: '255.255.255.0',
+            network_eth0: '192.0.2.0',
+          )
         end
 
-        let :pre_condition do
-          "class {'foreman_proxy':
-            dhcp_gateway => '127.0.0.254',
-          }"
+        let(:params) { super().merge(dhcp_interface: 'eth0') }
+
+        it do
+          should contain_class('dhcp')
+            .with_dnsdomain(['example.com'])
+            .with_nameservers(['192.0.2.10'])
+            .with_interfaces(['eth0'])
+            .with_pxeserver('192.0.2.10')
+            .with_pxefilename('pxelinux.0')
         end
 
-        it do should contain_class('dhcp').with(
-          'dnsdomain'   => ['example.com'],
-          'nameservers' => ['127.0.1.1'],
-          'interfaces'  => ['eth0'],
-          'pxeserver'   => '127.0.1.1',
-          'pxefilename' => 'pxelinux.0'
-        ) end
-
-        it do should contain_dhcp__pool('example.com').with(
-          'network'  => '127.0.0.0',
-          'mask'     => '255.0.0.0',
-          'range'    => nil,
-          'gateway'  => '127.0.0.254',
-          'failover' => nil
-        ) end
+        it do
+          should contain_dhcp__pool('example.com')
+            .with_network('192.0.2.0')
+            .with_mask('255.255.255.0')
+            .with_range(nil)
+            .with_gateway('192.0.2.1')
+            .with_failover(nil)
+        end
 
         it { should_not contain_class('dhcp::failover') }
+
+        context "as manager of ACLs for dhcp", unless: ['FreeBSD', 'DragonFly'].include?(facts[:osfamily]) do
+          let(:params) { super().merge(dhcp_manage_acls: true) }
+
+          it do should contain_exec('Allow foreman-proxy to read /etc/dhcp').
+            with_command("setfacl -R -m u:foreman-proxy:rx /etc/dhcp")
+          end
+
+          it do should contain_exec('Allow foreman-proxy to read /var/lib/dhcpd').
+            with_command("setfacl -R -m u:foreman-proxy:rx /var/lib/dhcpd")
+          end
+        end
+
+        context "as manager of ACLs for dhcp for RedHat only by default" do
+          case facts[:osfamily]
+          when 'RedHat'
+            it do should contain_exec('Allow foreman-proxy to read /etc/dhcp').
+              with_command('setfacl -R -m u:foreman-proxy:rx /etc/dhcp').
+              with_unless('getfacl -p /etc/dhcp | grep user:foreman-proxy:r-x')
+            end
+          else
+            it { should_not contain_exec('Allow foreman-proxy to read /etc/dhcp') }
+          end
+
+          case facts[:osfamily]
+          when 'RedHat'
+            it do should contain_exec('Allow foreman-proxy to read /var/lib/dhcpd').
+              with_command("setfacl -R -m u:foreman-proxy:rx /var/lib/dhcpd").
+              with_unless('getfacl -p /var/lib/dhcpd | grep user:foreman-proxy:r-x')
+            end
+          else
+            it { should_not contain_exec('Allow foreman-proxy to read /var/lib/dhcpd') }
+          end
+        end
+
+        context "with additional dhcp listen interfaces" do
+          let(:params) { super().merge(dhcp_additional_interfaces: [ 'vlan8', 'vlan9', 'vlan120' ]) }
+
+          it { should contain_class('dhcp').with_interfaces(['eth0', 'vlan8', 'vlan9', 'vlan120' ]) }
+        end
+
+        context "with one additional dhcp listen interface" do
+          let(:params) { super().merge(dhcp_additional_interfaces: ['vlan83']) }
+
+          it { should contain_class('dhcp').with_interfaces(['eth0', 'vlan83']) }
+        end
+
+        context "with additional dhcp listen interfaces wrongly specified as String data type" do
+          let(:params) { super().merge(dhcp_additional_interfaces: 'vlan55') }
+
+          it { should compile.and_raise_error(/expects an Array value, got String/) }
+        end
+
+        context "with additional dhcp listen interfaces wrongly specified as Hash data type" do
+          let(:params) { super().merge(dhcp_additional_interfaces: { name: 'vlan55' }) }
+
+          it { should compile.and_raise_error(/parameter 'dhcp_additional_interfaces' expects an Array value, got Struct/) }
+        end
+
+        context "with dhcp_search_domains" do
+          let(:params) { super().merge(dhcp_search_domains: ['example.com', 'example.org']) }
+
+          it { should contain_dhcp__pool('example.com').with_search_domains(['example.com','example.org']) }
+        end
+
+        context "with dhcp_pxeserver" do
+          let(:params) { super().merge(dhcp_pxeserver: '203.0.113.10') }
+
+          it { should contain_class('dhcp').with_pxeserver('203.0.113.10') }
+        end
+
+        context "as primary dhcp server" do
+          let(:params) do
+            super().merge(
+              dhcp_node_type: 'primary',
+              dhcp_peer_address: '203.0.113.40',
+            )
+          end
+
+          it do
+            should contain_class('dhcp::failover')
+              .with_role('primary')
+              .with_peer_address('203.0.113.40')
+              .with_address('192.0.2.10')
+          end
+        end
+
+        context "as secondary dhcp server" do
+          let(:params) do
+            super().merge(
+              dhcp_node_type: 'secondary',
+              dhcp_peer_address: '203.0.113.50',
+            )
+          end
+
+          it do
+            should contain_class('dhcp::failover')
+              .with_role('secondary')
+              .with_peer_address('203.0.113.50')
+              .with_address('192.0.2.10')
+          end
+        end
       end
 
       context "on vlan interface" do
         let :facts do
-          facts.merge({:ipaddress_eth0_0 => '127.0.1.1',
-                       :netmask_eth0_0   => '255.0.0.0',
-                       :network_eth0_0   => '127.0.0.0'})
+          facts.merge(
+            ipaddress_eth0_0: '203.0.113.10',
+            netmask_eth0_0: '255.255.255.0',
+            network_eth0_0: '203.0.113.0',
+          )
         end
 
-        let :pre_condition do
-          "class {'foreman_proxy':
-            dhcp_gateway   => '127.0.0.254',
-            dhcp_interface => 'eth0.0',
-          }"
+        let(:params) { super().merge(dhcp_interface: 'eth0.0') }
+
+        it do
+          should contain_class('dhcp')
+            .with_dnsdomain(['example.com'])
+            .with_nameservers(['203.0.113.10'])
+            .with_interfaces(['eth0.0'])
+            .with_pxeserver('203.0.113.10')
+            .with_pxefilename('pxelinux.0')
         end
 
-        it do should contain_class('dhcp').with(
-          'dnsdomain'   => ['example.com'],
-          'nameservers' => ['127.0.1.1'],
-          'interfaces'  => ['eth0.0'],
-          'pxeserver'   => '127.0.1.1',
-          'pxefilename' => 'pxelinux.0'
-        ) end
-
-        it do should contain_dhcp__pool('example.com').with(
-          'network'  => '127.0.0.0',
-          'mask'     => '255.0.0.0',
-          'range'    => nil,
-          'gateway'  => '127.0.0.254',
-          'failover' => nil
-        ) end
+        it do
+          should contain_dhcp__pool('example.com')
+            .with_network('203.0.113.0')
+            .with_mask('255.255.255.0')
+            .with_range(nil)
+            .with_gateway('192.0.2.1')
+            .with_failover(nil)
+        end
 
         it { should_not contain_class('dhcp::failover') }
       end
 
       context "on alias interface" do
         let :facts do
-          facts.merge({:ipaddress_eth0_0 => '127.0.1.1',
-                       :netmask_eth0_0   => '255.0.0.0',
-                       :network_eth0_0   => '127.0.0.0'})
+          facts.merge(
+            ipaddress_eth0_0: '198.51.100.10',
+            netmask_eth0_0: '255.255.255.0',
+            network_eth0_0: '198.51.100.0',
+          )
         end
 
-        let :pre_condition do
-          "class {'foreman_proxy':
-            dhcp_gateway   => '127.0.0.254',
-            dhcp_interface => 'eth0:0',
-          }"
-        end
+        let(:params) { super().merge(dhcp_interface: 'eth0:0') }
 
-        it do should contain_class('dhcp').with(
-            'dnsdomain'   => ['example.com'],
-            'nameservers' => ['127.0.1.1'],
-            'interfaces'  => ['eth0:0'],
-            'pxeserver'   => '127.0.1.1',
-            'pxefilename' => 'pxelinux.0'
-        ) end
-        it do should contain_dhcp__pool('example.com').with(
-            'network'  => '127.0.0.0',
-            'mask'     => '255.0.0.0',
-            'range'    => nil,
-            'gateway'  => '127.0.0.254',
-            'failover' => nil
-        ) end
+        it do
+          should contain_class('dhcp')
+            .with_dnsdomain(['example.com'])
+            .with_nameservers(['198.51.100.10'])
+            .with_interfaces(['eth0:0'])
+            .with_pxeserver('198.51.100.10')
+            .with_pxefilename('pxelinux.0')
+        end
+        it do
+          should contain_dhcp__pool('example.com')
+            .with_network('198.51.100.0')
+            .with_mask('255.255.255.0')
+            .with_range(nil)
+            .with_gateway('192.0.2.1')
+            .with_failover(nil)
+        end
 
         it { should_not contain_class('dhcp::failover') }
-      end
-
-      context "with additional dhcp listen interfaces" do
-        let :facts do
-          facts.merge({:ipaddress_eth0 => '127.0.1.1',
-                       :netmask_eth0   => '255.0.0.0',
-                       :network_eth0   => '127.0.0.0'})
-        end
-
-        let :pre_condition do
-          "class {'foreman_proxy':
-            dhcp_gateway => '127.0.0.254',
-            dhcp_additional_interfaces => [ 'vlan8', 'vlan9', 'vlan120' ],
-          }"
-        end
-
-        it do should contain_class('dhcp').with(
-          'dnsdomain'   => ['example.com'],
-          'nameservers' => ['127.0.1.1'],
-          'interfaces'  => ['eth0', 'vlan8', 'vlan9', 'vlan120' ],
-          'pxeserver'   => '127.0.1.1',
-          'pxefilename' => 'pxelinux.0'
-        ) end
-
-        it do should contain_dhcp__pool('example.com').with(
-          'network'  => '127.0.0.0',
-          'mask'     => '255.0.0.0',
-          'range'    => nil,
-          'gateway'  => '127.0.0.254',
-          'failover' => nil
-        ) end
-
-        it { should_not contain_class('dhcp::failover') }
-      end
-
-      context "with one additional dhcp listen interface" do
-        let :facts do
-          facts.merge({:ipaddress_eth0 => '127.0.1.1',
-                       :netmask_eth0   => '255.0.0.0',
-                       :network_eth0   => '127.0.0.0'})
-        end
-
-        let :pre_condition do
-          "class {'foreman_proxy':
-            dhcp_gateway => '127.0.0.254',
-            dhcp_additional_interfaces => [ 'vlan83' ]
-          }"
-        end
-
-        it do should contain_class('dhcp').with(
-          'dnsdomain'   => ['example.com'],
-          'nameservers' => ['127.0.1.1'],
-          'interfaces'  => ['eth0', 'vlan83'],
-          'pxeserver'   => '127.0.1.1',
-          'pxefilename' => 'pxelinux.0'
-        ) end
-
-        it do should contain_dhcp__pool('example.com').with(
-          'network'  => '127.0.0.0',
-          'mask'     => '255.0.0.0',
-          'range'    => nil,
-          'gateway'  => '127.0.0.254',
-          'failover' => nil
-        ) end
-
-        it { should_not contain_class('dhcp::failover') }
-      end
-
-      context "with additional dhcp listen interfaces wrongly specified as String data type" do
-        let :facts do
-          facts.merge({:ipaddress_eth0 => '127.0.1.1',
-                       :netmask_eth0   => '255.0.0.0',
-                       :network_eth0   => '127.0.0.0'})
-        end
-
-        let :pre_condition do
-          "class {'foreman_proxy':
-            dhcp_gateway => '127.0.0.254',
-            dhcp_additional_interfaces => 'vlan55',
-          }"
-        end
-        it { should raise_error(Puppet::PreformattedError, /expects an Array value, got String/) }
-      end
-
-      context "with additional dhcp listen interfaces wrongly specified as Hash data type" do
-        let :facts do
-          facts.merge({:ipaddress_eth0 => '127.0.1.1',
-                       :netmask_eth0   => '255.0.0.0',
-                       :network_eth0   => '127.0.0.0'})
-        end
-
-        let :pre_condition do
-          "class {'foreman_proxy':
-            dhcp_gateway => '127.0.0.254',
-            dhcp_additional_interfaces => { 'name' => 'vlan55' }
-          }"
-        end
-        it { should raise_error(Puppet::PreformattedError, /expects an Array value, got Struct/) }
-      end
-
-      context "with dhcp_search_domains" do
-        let :facts do
-          facts.merge({:ipaddress_eth0 => '127.0.1.1',
-                       :netmask_eth0   => '255.0.0.0',
-                       :network_eth0   => '127.0.0.0'})
-        end
-
-        let :pre_condition do
-          "class {'foreman_proxy':
-            dhcp_gateway        => '127.0.0.254',
-            dhcp_search_domains => ['example.com', 'example.org']
-          }"
-        end
-
-        it do should contain_dhcp__pool('example.com').with(
-            'search_domains' => ['example.com','example.org']
-        ) end
-      end
-
-      context "with dhcp_pxeserver" do
-        let :facts do
-          facts.merge({:ipaddress_eth0 => '127.0.1.1',
-                       :netmask_eth0   => '255.0.0.0',
-                       :network_eth0   => '127.0.0.0'})
-        end
-
-        let :pre_condition do
-          "class {'foreman_proxy':
-            dhcp_pxeserver => '127.0.1.200'
-          }"
-        end
-
-        it do should contain_class('dhcp').with(
-            'pxeserver'   => '127.0.1.200',
-        ) end
-      end
-
-      context "as primary dhcp server" do
-        let :facts do
-          facts.merge({:ipaddress_eth0 => '192.168.100.20',
-                       :ipaddress      => '192.168.100.20',
-                       :netmask_eth0   => '255.255.255.0',
-                       :network_eth0   => '192.168.100.0'})
-        end
-
-        let :pre_condition do
-          "class {'foreman_proxy':
-            dhcp_range        => '192.168.100.1 192.168.100.10',
-            dhcp_node_type    => 'primary',
-            dhcp_peer_address => '192.168.1.21',
-          }"
-        end
-
-        it do should contain_class('dhcp::failover').with(
-            'role'         => 'primary',
-            'peer_address' => '192.168.1.21',
-            'address'      => '192.168.100.20'
-        ) end
-
-        it do should contain_class('dhcp').with(
-            'dnsdomain'  => ['example.com'],
-            'interfaces' => ['eth0']
-        ) end
-      end
-
-      context "as secondary dhcp server" do
-        let :facts do
-          facts.merge({:ipaddress_eth0 => '192.168.100.21',
-                       :ipaddress      => '192.168.100.21',
-                       :netmask_eth0   => '255.255.255.0',
-                       :network_eth0   => '192.168.100.0'})
-        end
-
-        let :pre_condition do
-          "class {'foreman_proxy':
-            dhcp_range        => '192.168.100.1 192.168.100.10',
-            dhcp_node_type    => 'secondary',
-            dhcp_peer_address => '192.168.1.20',
-          }"
-        end
-
-        it do should contain_class('dhcp::failover').with(
-            'role'         => 'secondary',
-            'peer_address' => '192.168.1.20',
-            'address'      => '192.168.100.21'
-        ) end
-
-        it do should contain_class('dhcp').with(
-            'dnsdomain'  => ['example.com'],
-            'interfaces' => ['eth0']
-        ) end
       end
 
       context "on a non-existing interface" do
-        let :facts do
-          facts
-        end
+        let(:facts) { facts }
+        let(:params) { super().merge(dhcp_interface: 'doesnotexist') }
 
-        let :pre_condition do
-          "class { 'foreman_proxy':
-            dhcp_interface => 'doesnotexist',
-          }"
-        end
-
-        it { should raise_error(Puppet::Error, /Could not get the ip address from fact ipaddress_doesnotexist/) }
-      end
-
-      context "as manager of ACLs for dhcp" unless ['FreeBSD', 'DragonFly'].include?(facts[:osfamily]) do
-        let :facts do
-          facts.merge({:ipaddress_eth0 => '192.168.100.20',
-                       :ipaddress      => '192.168.100.20',
-                       :netmask_eth0   => '255.255.255.0',
-                       :network_eth0   => '192.168.100.0'})
-        end
-
-        let :pre_condition do
-          "class {'foreman_proxy':
-            dhcp_manage_acls  => true,
-          }"
-        end
-
-        it do should contain_exec('Allow foreman-proxy to read /etc/dhcp').
-          with_command("setfacl -R -m u:foreman-proxy:rx /etc/dhcp")
-        end
-
-        it do should contain_exec('Allow foreman-proxy to read /var/lib/dhcpd').
-          with_command("setfacl -R -m u:foreman-proxy:rx /var/lib/dhcpd")
-        end
-      end
-
-      context "as manager of ACLs for dhcp for RedHat only by default" do
-        let :facts do
-          facts.merge({:ipaddress_eth0 => '192.168.100.20',
-                       :ipaddress      => '192.168.100.20',
-                       :netmask_eth0   => '255.255.255.0',
-                       :network_eth0   => '192.168.100.0'})
-        end
-
-        let :pre_condition do
-          "class {'foreman_proxy': }"
-        end
-
-        case facts[:osfamily]
-        when 'RedHat'
-          it do should contain_exec('Allow foreman-proxy to read /etc/dhcp').
-            with_command('setfacl -R -m u:foreman-proxy:rx /etc/dhcp').
-            with_unless('getfacl -p /etc/dhcp | grep user:foreman-proxy:r-x')
-          end
-        else
-          it { should_not contain_exec('Allow foreman-proxy to read /etc/dhcp') }
-        end
-
-        case facts[:osfamily]
-        when 'RedHat'
-          it do should contain_exec('Allow foreman-proxy to read /var/lib/dhcpd').
-            with_command("setfacl -R -m u:foreman-proxy:rx /var/lib/dhcpd").
-            with_unless('getfacl -p /var/lib/dhcpd | grep user:foreman-proxy:r-x')
-          end
-        else
-          it { should_not contain_exec('Allow foreman-proxy to read /var/lib/dhcpd') }
-        end
+        it { should compile.and_raise_error(/Could not get the ip address from fact ipaddress_doesnotexist/) }
       end
     end
   end

--- a/spec/classes/foreman_proxy__proxydns__spec.rb
+++ b/spec/classes/foreman_proxy__proxydns__spec.rb
@@ -3,24 +3,22 @@ require 'spec_helper'
 describe 'foreman_proxy::proxydns' do
   on_os_under_test.each do |os, facts|
     context "on #{os}" do
-      context 'with inherited parameters' do
-        let :facts do
-          facts.merge(
-            :ipaddress_eth0 => '192.168.100.1',
-            :netmask_eth0   => '255.255.255.0',
-          )
-        end
+      let :facts do
+        facts.merge(
+          ipaddress_eth0: '192.168.100.1',
+          netmask_eth0: '255.255.255.0',
+        )
+      end
 
-        let :pre_condition do
-          'include ::foreman_proxy'
-        end
+      context 'with inherited parameters' do
+        let(:pre_condition) { 'include foreman_proxy' }
 
         it { should compile.with_all_deps }
 
         it 'should inherit the correct parameters' do
           should contain_class('foreman_proxy::proxydns')
             .with_forwarders([])
-            .with_interface('eth0')
+            .with_interface(facts[:networking]['primary'] || 'eth0')
             .with_forward_zone('example.com')
             .with_reverse_zone(nil)
             .with_soa('foo.example.com')
@@ -28,7 +26,7 @@ describe 'foreman_proxy::proxydns' do
       end
 
       context 'with explicit parameters' do
-        let :base_params do
+        let :params do
           {
             forwarders: [],
             interface: 'eth0',
@@ -37,18 +35,7 @@ describe 'foreman_proxy::proxydns' do
           }
         end
 
-        context 'with base parameters' do
-          let :facts do
-            facts.merge(
-              :ipaddress_eth0 => '192.168.100.1',
-              :netmask_eth0   => '255.255.255.0',
-            )
-          end
-
-          let :params do
-            base_params
-          end
-
+        context 'with eth0' do
           it { should compile.with_all_deps }
 
           it 'should include the dns class' do
@@ -67,39 +54,60 @@ describe 'foreman_proxy::proxydns' do
               .with_soa('foo.example.com')
               .with_reverse(true)
           end
-        end
 
-        context 'with dns_zone overridden' do
-          let :facts do
-            facts.merge(
-              :ipaddress_eth0 => '192.168.100.1',
-              :netmask_eth0   => '255.255.255.0',
-            )
+          context 'with dns_zone overridden' do
+            let(:params) { super().merge(forward_zone: 'something.example.com') }
+
+            it 'should include the forward zone' do
+              should contain_dns__zone('something.example.com')
+                .with_soa('foo.example.com')
+                .with_reverse(false)
+                .with_soaip('192.168.100.1')
+            end
           end
 
-          let :params do
-            base_params.merge(:forward_zone => 'something.example.com')
+          context "with dns_reverse value" do
+            let(:params) { super().merge(reverse_zone: ['168.192.in-addr.arpa']) }
+
+            it 'should include the reverse zone 168.192.in-addr.arpa' do
+              should contain_dns__zone('168.192.in-addr.arpa')
+                .with_soa('foo.example.com')
+                .with_reverse(true)
+            end
           end
 
-          it 'should include the forward zone' do
-            should contain_dns__zone('something.example.com')
-              .with_soa('foo.example.com')
-              .with_reverse(false)
-              .with_soaip('192.168.100.1')
+          context "with dns_reverse array" do
+            let(:params) { super().merge(reverse_zone: ['0.168.192.in-addr.arpa', '1.168.192.in-addr.arpa']) }
+
+            it 'should include the reverse zone 0.168.192.in-addr.arpa' do
+              should contain_dns__zone('0.168.192.in-addr.arpa')
+                .with_soa('foo.example.com')
+                .with_reverse(true)
+            end
+
+            it 'should include the reverse zone 1.168.192.in-addr.arpa' do
+              should contain_dns__zone('1.168.192.in-addr.arpa')
+                .with_soa('foo.example.com')
+                .with_reverse(true)
+            end
+          end
+
+          context 'invalid netmask fact' do
+            let(:facts) { super().merge(netmask_eth0: '0.0.0.0') }
+
+            it { should compile.and_raise_error(%r{subnets smaller than /8 are not supported}) }
           end
         end
 
         context "with vlan interface" do
           let :facts do
             facts.merge(
-              :ipaddress_eth0_0 => '192.168.100.1',
-              :netmask_eth0_0   => '255.255.255.0',
+              ipaddress_eth0_0: '192.168.100.1',
+              netmask_eth0_0: '255.255.255.0',
             )
           end
 
-          let :params do
-            base_params.merge(:interface => 'eth0:0')
-          end
+          let(:params) { super().merge(interface: 'eth0:0') }
 
           it 'should include the forward zone' do
             should contain_dns__zone('example.com')
@@ -118,14 +126,12 @@ describe 'foreman_proxy::proxydns' do
         context "with alias interface" do
           let :facts do
             facts.merge(
-              :ipaddress_eth0_0 => '192.168.100.1',
-              :netmask_eth0_0   => '255.255.255.0',
+              ipaddress_eth0_0: '192.168.100.1',
+              netmask_eth0_0: '255.255.255.0',
             )
           end
 
-          let :params do
-            base_params.merge(:interface => 'eth0:0')
-          end
+          let(:params) { super().merge(interface: 'eth0:0') }
 
           it 'should include the forward zone' do
             should contain_dns__zone('example.com')
@@ -142,87 +148,14 @@ describe 'foreman_proxy::proxydns' do
         end
 
         context 'with invalid interface' do
-          let :facts do
-            facts
-          end
+          let(:params) { super().merge(interface: 'invalid') }
 
-          let :params do
-            base_params.merge(:interface => 'invalid')
-          end
+          it { should compile.and_raise_error(/Could not get a valid IP address from fact ipaddress_invalid: '' \(Undef\)/) }
 
-          it { should raise_error(Puppet::Error, /Could not get a valid IP address from fact ipaddress_invalid: '' \(Undef\)/) }
-        end
-
-        context "with dns_reverse value" do
-          let :facts do
-            facts.merge(
-              :ipaddress_eth0 => '192.168.100.1',
-              :netmask_eth0   => '255.255.255.0',
-            )
-          end
-
-          let :params do
-            base_params.merge(:reverse_zone => ['168.192.in-addr.arpa'])
-          end
-
-          it 'should include the reverse zone 168.192.in-addr.arpa' do
-            should contain_dns__zone('168.192.in-addr.arpa')
-              .with_soa('foo.example.com')
-              .with_reverse(true)
-          end
-        end
-
-        context "with dns_reverse array" do
-          let :facts do
-            facts.merge(
-              :ipaddress_eth0 => '192.168.100.1',
-              :netmask_eth0   => '255.255.255.0',
-            )
-          end
-
-          let :params do
-            base_params.merge(:reverse_zone => ['0.168.192.in-addr.arpa', '1.168.192.in-addr.arpa'])
-          end
-
-          it 'should include the reverse zone 0.168.192.in-addr.arpa' do
-            should contain_dns__zone('0.168.192.in-addr.arpa')
-              .with_soa('foo.example.com')
-              .with_reverse(true)
-          end
-
-          it 'should include the reverse zone 1.168.192.in-addr.arpa' do
-            should contain_dns__zone('1.168.192.in-addr.arpa')
-              .with_soa('foo.example.com')
-              .with_reverse(true)
-          end
-        end
-
-        context 'with an invalid reverse' do
           context 'missing netmask fact' do
-            let :facts do
-              facts.merge(ipaddress_invalid: '192.0.2.1')
-            end
+            let(:facts) { facts.merge(ipaddress_invalid: '192.0.2.1') }
 
-            let :params do
-              base_params.merge(:interface => 'invalid')
-            end
-
-            it { should raise_error(Puppet::Error, /Could not get a valid netmask from fact netmask_invalid: '' \(Undef\)/) }
-          end
-
-          context 'invalid netmask fact' do
-            let :facts do
-              facts.merge(
-                :ipaddress_eth0 => '192.168.100.1',
-                :netmask_eth0   => '0.0.0.0',
-              )
-            end
-
-            let :params do
-              base_params.merge(:interface => 'eth0')
-            end
-
-            it { should raise_error(Puppet::Error) }
+            it { should compile.and_raise_error(/Could not get a valid netmask from fact netmask_invalid: '' \(Undef\)/) }
           end
         end
       end

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -16,15 +16,6 @@ describe 'foreman_proxy' do
         shell = '/usr/bin/false'
         usr_dir = '/usr/local'
         ssl_dir = '/var/puppet/ssl'
-      when 'Archlinux'
-        dns_group = 'named'
-        etc_dir = '/etc'
-        puppet_etc_dir = "#{etc_dir}/puppetlabs/puppet"
-        home_dir = '/usr/share/foreman-proxy'
-        proxy_user_name = 'foreman-proxy'
-        shell = '/usr/bin/false'
-        usr_dir = '/usr'
-        ssl_dir = "#{puppet_etc_dir}/ssl"
       else
         dns_group = facts[:osfamily] == 'RedHat' ? 'named' : 'bind'
         etc_dir = '/etc'
@@ -337,8 +328,6 @@ describe 'foreman_proxy' do
                       end
                     when 'FreeBSD', 'DragonFly'
                       '/tftpboot'
-                    when 'Archlinux'
-                      '/srv/tftp'
                     else
                       '/var/lib/tftpboot'
                     end
@@ -666,8 +655,6 @@ describe 'foreman_proxy' do
             'bind-utils'
           when 'FreeBSD', 'DragonFly'
             'bind910'
-          when 'Archlinux'
-            'bind-tools'
           else
             'dnsutils'
           end
@@ -948,9 +935,6 @@ describe 'foreman_proxy' do
           when 'Debian'
             dhcp_leases    = '/var/lib/dhcp/dhcpd.leases'
             dhcp_config    = "#{etc_dir}/dhcp/dhcpd.conf"
-          when 'Archlinux'
-            dhcp_leases    = '/var/lib/dhcp/dhcpd.leases'
-            dhcp_config    = "#{etc_dir}/dhcpd.conf"
           else
             dhcp_leases    = '/var/lib/dhcpd/dhcpd.leases'
             dhcp_config    = "#{etc_dir}/dhcp/dhcpd.conf"

--- a/spec/classes/foreman_proxy__tftp_spec.rb
+++ b/spec/classes/foreman_proxy__tftp_spec.rb
@@ -16,16 +16,6 @@ describe 'foreman_proxy::tftp' do
       it { is_expected.to contain_class('foreman_proxy::tftp::netboot') }
 
       case facts[:osfamily]
-      when 'Archlinux'
-        tftp_root = '/srv/tftp'
-        names = {
-          '/usr/lib/syslinux/bios/pxelinux.0'  => "#{tftp_root}/pxelinux.0",
-          '/usr/lib/syslinux/bios/memdisk'     => "#{tftp_root}/memdisk",
-          '/usr/lib/syslinux/bios/chain.c32'   => "#{tftp_root}/chain.c32",
-          '/usr/lib/syslinux/bios/ldlinux.c32' => "#{tftp_root}/ldlinux.c32",
-          '/usr/lib/syslinux/bios/libutil.c32' => "#{tftp_root}/libutil.c32",
-          '/usr/lib/syslinux/bios/menu.c32'    => "#{tftp_root}/menu.c32",
-        }
       when 'Debian'
         tftp_root = facts[:operatingsystem] == 'Ubuntu' ?  '/var/lib/tftpboot' : '/srv/tftp'
         names = {

--- a/spec/defines/foreman_proxy_plugin_spec.rb
+++ b/spec/defines/foreman_proxy_plugin_spec.rb
@@ -12,12 +12,7 @@ describe 'foreman_proxy::plugin' do
       end
 
       context 'no parameters' do
-        package = case facts[:osfamily]
-                  when 'Debian', 'Archlinux'
-                    'ruby-smart-proxy-myplugin'
-                  else
-                    'rubygem-smart_proxy_myplugin'
-                  end
+        package = facts[:osfamily] == 'Debian' ? 'ruby-smart-proxy-myplugin' : 'rubygem-smart_proxy_myplugin'
 
         it 'should install the correct package' do
           should contain_package(package).with_ensure('installed')


### PR DESCRIPTION
The package in AUR is version 1.13.0 and not supported by the module. The facts are also often causing failures.

Also cleans up the tests a bit to make sure they pass.