### PR TITLE
Fixes #28559 - keep default ssh args

### DIFF
--- a/manifests/plugin/ansible/params.pp
+++ b/manifests/plugin/ansible/params.pp
@@ -7,7 +7,7 @@ class foreman_proxy::plugin::ansible::params {
   $host_key_checking = false
   $stdout_callback = 'yaml'
   $roles_path = ['/etc/ansible/roles', '/usr/share/ansible/roles']
-  $ssh_args = '-o ProxyCommand=none'
+  $ssh_args = '-o ProxyCommand=none -C -o ControlMaster=auto -o ControlPersist=60s'
   $install_runner = true
   $manage_runner_repo = true
 }

--- a/spec/classes/foreman_proxy__plugin__ansible_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__ansible_spec.rb
@@ -58,7 +58,7 @@ describe 'foreman_proxy::plugin::ansible' do
             'verify_certs = /var/lib/puppet/ssl/certs/ca.pem',
             'roles_path = /etc/ansible/roles:/usr/share/ansible/roles',
             '[ssh_connection]',
-            'ssh_args = -o ProxyCommand=none',
+            'ssh_args = -o ProxyCommand=none -C -o ControlMaster=auto -o ControlPersist=60s',
           ])
         end
       end
@@ -106,7 +106,7 @@ describe 'foreman_proxy::plugin::ansible' do
             'verify_certs = /var/lib/puppet/ssl/certs/ca.pem',
             'roles_path = /etc/ansible/roles:/usr/share/ansible/roles',
             '[ssh_connection]',
-            'ssh_args = -o ProxyCommand=none',
+            'ssh_args = -o ProxyCommand=none -C -o ControlMaster=auto -o ControlPersist=60s',
           ])
         end
       end


### PR DESCRIPTION
Based on https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-ssh-args
the ssh args is by default se to "-C -o ControlMaster=auto -o ControlPersist=60s". In #25481, this
was overriden to "-o ProxyCommand=none" only. There seems to be no way to just append areguments,
so listing defaults here is probably the best option.