### PR TITLE
Fixes #28877 - Dynamically determine Pulp Puppet dir

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -15,6 +15,7 @@ fixtures:
     foreman:  'https://github.com/theforeman/puppet-foreman'
     mysql:    'https://github.com/puppetlabs/puppetlabs-mysql'
     puppet:   'https://github.com/theforeman/puppet-puppet'
+    redis:    'https://github.com/voxpupuli/puppet-redis'
     stdlib:   'https://github.com/puppetlabs/puppetlabs-stdlib'
     sudo:     'https://github.com/saz/puppet-sudo'
     systemd:  'https://github.com/camptocamp/puppet-systemd'

--- a/manifests/plugin/pulp.pp
+++ b/manifests/plugin/pulp.pp
@@ -29,7 +29,7 @@
 #
 # $pulpcore_content_url::  The URL to the Pulp 3 content
 #
-# $puppet_content_dir:: directory for puppet content
+# $puppet_content_dir:: Directory for puppet content. Automatically determined if empty.
 #
 # $mongodb_dir::        directory for Mongo DB
 #
@@ -46,9 +46,11 @@ class foreman_proxy::plugin::pulp (
   Stdlib::HTTPUrl $pulp_url = $::foreman_proxy::plugin::pulp::params::pulp_url,
   Stdlib::Absolutepath $pulp_dir = $::foreman_proxy::plugin::pulp::params::pulp_dir,
   Stdlib::Absolutepath $pulp_content_dir = $::foreman_proxy::plugin::pulp::params::pulp_content_dir,
-  Stdlib::Absolutepath $puppet_content_dir = $::foreman_proxy::plugin::pulp::params::puppet_content_dir,
+  Optional[Stdlib::Absolutepath] $puppet_content_dir = $::foreman_proxy::plugin::pulp::params::puppet_content_dir,
   Stdlib::Absolutepath $mongodb_dir = $::foreman_proxy::plugin::pulp::params::mongodb_dir,
 ) inherits foreman_proxy::plugin::pulp::params {
+  $real_puppet_content_dir = pick($puppet_content_dir, lookup('puppet::server_envs_dir') |$key| { undef }, $facts['puppet_environmentpath'], "${foreman_proxy::puppetdir}/environments")
+
   foreman_proxy::plugin {'pulp':
     version => $version,
   }

--- a/manifests/plugin/pulp/params.pp
+++ b/manifests/plugin/pulp/params.pp
@@ -1,8 +1,6 @@
 # Default parameters for the Pulp smart proxy plugin
 # @api private
 class foreman_proxy::plugin::pulp::params {
-  include ::foreman_proxy::params
-
   $enabled              = true
   $listen_on            = 'https'
   $version              = undef
@@ -15,6 +13,6 @@ class foreman_proxy::plugin::pulp::params {
   $pulpcore_content_url = "${pulp_url}/content"
   $pulp_dir             = '/var/lib/pulp'
   $pulp_content_dir     = '/var/lib/pulp/content'
-  $puppet_content_dir   = pick($::puppet_environmentpath, "${::foreman_proxy::params::puppetdir}/environments")
+  $puppet_content_dir   = undef
   $mongodb_dir          = '/var/lib/mongodb'
 }

--- a/templates/plugin/pulp.yml.erb
+++ b/templates/plugin/pulp.yml.erb
@@ -5,5 +5,5 @@
 # Path to pulp, pulp content and mongodb directories
 :pulp_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::pulp_dir") %>
 :pulp_content_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::pulp_content_dir") %>
-:puppet_content_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::puppet_content_dir") %>
+:puppet_content_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::real_puppet_content_dir") %>
 :mongodb_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::mongodb_dir") %>

--- a/templates/plugin/pulpnode.yml.erb
+++ b/templates/plugin/pulpnode.yml.erb
@@ -5,5 +5,5 @@
 # Path to pulp, pulp content and mongodb directories
 :pulp_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::pulp_dir") %>
 :pulp_content_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::pulp_content_dir") %>
-:puppet_content_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::puppet_content_dir") %>
+:puppet_content_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::real_puppet_content_dir") %>
 :mongodb_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::mongodb_dir") %>


### PR DESCRIPTION
This change removes the default value and looks it up at runtime. The benefit is that we can use the lookup method to get the answer for the puppet module.

The main driver for this is that the puppet_environmentpath fact has become unreliable with Kafo due to more isolation.

Also includes a fix to make the tests pass again.