### PR TITLE
Refs #29005 - Require theforeman/dns 7.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
   "dependencies": [
     {
       "name": "theforeman/dns",
-      "version_requirement": ">= 1.3.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 8.0.0"
     },
     {
       "name": "theforeman/dhcp",


### PR DESCRIPTION
fecf9c8b8bc3a50bdc0ace5e96840fae90c9d240 started to depend on parameters only present in 7.0.0, but was merged before it could be added.