### PR TITLE
Update the compatibility matrix in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Part of the Foreman installer: <https://github.com/theforeman/foreman-installer>
 
 | Module version | Proxy versions | Notes                                               |
 |----------------|----------------|-----------------------------------------------------|
-| 11.x           | 1.19 and newer | See compatibility notes in its README for 1.19-1.21 |
+| 13.x           | 2.0 and newer  |                                                     |
+| 12.x           | 1.19 - 1.24    | See compatibility notes in its README for 1.19-1.22 |
+| 11.x           | 1.19 - 1.23    | See compatibility notes in its README for 1.19-1.21 |
 | 10.x           | 1.19 - 1.21    |                                                     |
 | 5.x - 9.x      | 1.16 - 1.20    | See compatibility notes in its README for 1.16-1.18 |
 | 4.x            | 1.12 - 1.17    | See compatibility notes in its README for 1.15+     |
@@ -20,7 +22,7 @@ Part of the Foreman installer: <https://github.com/theforeman/foreman-installer>
 | 2.x            | 1.5 - 1.10     |                                                     |
 | 1.x            | 1.4 and older  |                                                     |
 
-Starting version 1.22 the Puppet CA configuration is split depending on the provider. When using the module with 1.19 - 1.21, set `puppetca_split_configs` to `false`.
+12.x has dropped support for Puppet 3 which was officially unsupported for a while and Foreman Proxy 1.23 dropped altogether.
 
 ## Examples
 


### PR DESCRIPTION
This makes it clear that 13.x is Foreman Proxy 2.0 only.