### PR TITLE
Refactor modules, plugins and providers design

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -54,52 +54,39 @@ class foreman_proxy::config {
   contain foreman_proxy::module::bmc
 
   contain foreman_proxy::module::dhcp
-  foreman_proxy::settings_file { ['dhcp_isc', 'dhcp_libvirt']:
-    module => false,
+  foreman_proxy::provider { ['dhcp_isc', 'dhcp_libvirt']:
   }
 
   contain foreman_proxy::module::dns
-  foreman_proxy::settings_file { ['dns_nsupdate', 'dns_nsupdate_gss', 'dns_libvirt']:
-    module => false,
+  foreman_proxy::provider { ['dns_nsupdate', 'dns_nsupdate_gss', 'dns_libvirt']:
   }
 
   contain foreman_proxy::module::httpboot
 
   contain foreman_proxy::module::puppet
-  foreman_proxy::settings_file { [
+  foreman_proxy::provider { [
       'puppet_proxy_customrun',
       'puppet_proxy_mcollective',
       'puppet_proxy_puppet_api',
       'puppet_proxy_salt',
       'puppet_proxy_ssh',
     ]:
-      module => false,
   }
-  foreman_proxy::settings_file { [
-      'puppet_proxy_legacy',
-      'puppet_proxy_puppetrun',
-    ]:
-      ensure => 'absent',
-      module => false,
+  foreman_proxy::provider { ['puppet_proxy_legacy', 'puppet_proxy_puppetrun']:
+    ensure => 'absent',
   }
 
   contain foreman_proxy::module::puppetca
-  foreman_proxy::settings_file { ['puppetca_hostname_whitelisting', 'puppetca_token_whitelisting']:
-    module => false,
+  foreman_proxy::provider { ['puppetca_hostname_whitelisting', 'puppetca_token_whitelisting']:
   }
 
   if $foreman_proxy::puppetca_split_configs {
-    foreman_proxy::settings_file { [
-        'puppetca_http_api',
-        'puppetca_puppet_cert',
-      ]:
-        module => false,
+    foreman_proxy::provider { ['puppetca_http_api', 'puppetca_puppet_cert']:
     }
   }
 
   contain foreman_proxy::module::realm
-  foreman_proxy::settings_file { 'realm_freeipa':
-    module => false,
+  foreman_proxy::provider { 'realm_freeipa':
   }
 
   contain foreman_proxy::module::tftp

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -51,48 +51,27 @@ class foreman_proxy::config {
     module => false,
   }
 
-  foreman_proxy::settings_file { 'bmc':
-    enabled   => $::foreman_proxy::bmc,
-    feature   => 'BMC',
-    listen_on => $::foreman_proxy::bmc_listen_on,
-  }
-  foreman_proxy::settings_file { 'dhcp':
-    enabled   => $::foreman_proxy::dhcp,
-    feature   => 'DHCP',
-    listen_on => $::foreman_proxy::dhcp_listen_on,
-  }
-  foreman_proxy::settings_file { 'dhcp_isc':
+  contain foreman_proxy::module::bmc
+
+  contain foreman_proxy::module::dhcp
+  foreman_proxy::settings_file { ['dhcp_isc', 'dhcp_libvirt']:
     module => false,
   }
-  foreman_proxy::settings_file { 'dns':
-    enabled   => $::foreman_proxy::dns,
-    feature   => 'DNS',
-    listen_on => $::foreman_proxy::dns_listen_on,
-  }
-  foreman_proxy::settings_file { ['dns_nsupdate', 'dns_nsupdate_gss']:
+
+  contain foreman_proxy::module::dns
+  foreman_proxy::settings_file { ['dns_nsupdate', 'dns_nsupdate_gss', 'dns_libvirt']:
     module => false,
   }
-  foreman_proxy::settings_file { ['dns_libvirt', 'dhcp_libvirt']:
-    module => false,
-  }
-  foreman_proxy::settings_file { 'httpboot':
-    enabled   => pick($::foreman_proxy::httpboot, $::foreman_proxy::tftp),
-    feature   => 'HTTPBoot',
-    listen_on => $::foreman_proxy::httpboot_listen_on,
-  }
-  foreman_proxy::settings_file { 'puppet':
-    enabled   => $::foreman_proxy::puppet,
-    feature   => 'Puppet',
-    listen_on => $::foreman_proxy::puppet_listen_on,
-  }
+
+  contain foreman_proxy::module::httpboot
+
+  contain foreman_proxy::module::puppet
   foreman_proxy::settings_file { [
       'puppet_proxy_customrun',
       'puppet_proxy_mcollective',
       'puppet_proxy_puppet_api',
       'puppet_proxy_salt',
       'puppet_proxy_ssh',
-      'puppetca_hostname_whitelisting',
-      'puppetca_token_whitelisting',
     ]:
       module => false,
   }
@@ -103,33 +82,10 @@ class foreman_proxy::config {
       ensure => 'absent',
       module => false,
   }
-  foreman_proxy::settings_file { 'puppetca':
-    enabled   => $::foreman_proxy::puppetca,
-    feature   => 'Puppet CA',
-    listen_on => $::foreman_proxy::puppetca_listen_on,
-  }
-  foreman_proxy::settings_file { 'realm':
-    enabled   => $::foreman_proxy::realm,
-    feature   => 'Realm',
-    listen_on => $::foreman_proxy::realm_listen_on,
-  }
-  foreman_proxy::settings_file { 'realm_freeipa':
+
+  contain foreman_proxy::module::puppetca
+  foreman_proxy::settings_file { ['puppetca_hostname_whitelisting', 'puppetca_token_whitelisting']:
     module => false,
-  }
-  foreman_proxy::settings_file { 'tftp':
-    enabled   => $::foreman_proxy::tftp,
-    feature   => 'TFTP',
-    listen_on => $::foreman_proxy::tftp_listen_on,
-  }
-  foreman_proxy::settings_file { 'templates':
-    enabled   => $::foreman_proxy::templates,
-    feature   => 'Templates',
-    listen_on => $::foreman_proxy::templates_listen_on,
-  }
-  foreman_proxy::settings_file { 'logs':
-    enabled   => $::foreman_proxy::logs,
-    feature   => 'Logs',
-    listen_on => $::foreman_proxy::logs_listen_on,
   }
 
   if $foreman_proxy::puppetca_split_configs {
@@ -140,6 +96,17 @@ class foreman_proxy::config {
         module => false,
     }
   }
+
+  contain foreman_proxy::module::realm
+  foreman_proxy::settings_file { 'realm_freeipa':
+    module => false,
+  }
+
+  contain foreman_proxy::module::tftp
+
+  contain foreman_proxy::module::templates
+
+  contain foreman_proxy::module::logs
 
   if $foreman_proxy::puppetca or $foreman_proxy::puppet {
     $uses_sudo = $foreman_proxy::puppetca and versioncmp($facts['puppetversion'], '6.0') < 0

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,8 +47,7 @@ class foreman_proxy::config {
   }
 
   foreman_proxy::settings_file { 'settings':
-    path   => "${foreman_proxy::config_dir}/settings.yml",
-    module => false,
+    path => "${foreman_proxy::config_dir}/settings.yml",
   }
 
   contain foreman_proxy::module::bmc

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -25,11 +25,21 @@ define foreman_proxy::module (
   Optional[String] $template_path = undef,
   String $feature = upcase($title),
 ) {
+  if $enabled {
+    $module_enabled = $listen_on ? {
+      'both'  => 'true',
+      'https' => 'https',
+      'http'  => 'http',
+      default => 'false',
+    }
+
+    foreman_proxy::feature { $feature: }
+  } else {
+    $module_enabled = 'false'
+  }
+
   foreman_proxy::settings_file { $name:
-    module        => true,
-    enabled       => $enabled,
-    feature       => $feature,
-    listen_on     => $listen_on,
-    template_path => $template_path,
+    module_enabled => $module_enabled,
+    template_path  => $template_path,
   }
 }

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -1,0 +1,30 @@
+# @summary Low level abstraction of Foreman Proxy modules
+#
+# Foreman Proxy internally has the concept of modules. Some modules have
+# providers or even multiple ones. That's not part of this definition.
+#
+# @param enabled
+#  Whether the module is enabled or disabled.
+#
+# @param listen_on
+#   When enabled, it's configured to listen on HTTPS (default), HTTP or both.
+#   Unless the module explicitly needs HTTP (usually because clients needs it),
+#   HTTPS should be chosen.
+#
+# @param feature
+#   Each module is exposed as a feature to Foreman on registration.
+#   foreman_proxy::register will validate the feature name is loaded and
+#   advertised.
+#
+define foreman_proxy::module (
+  Boolean $enabled = false,
+  Foreman_proxy::ListenOn $listen_on = 'https',
+  String $feature = upcase($title),
+) {
+  foreman_proxy::settings_file { $name:
+    module    => true,
+    enabled   => $enabled,
+    feature   => $feature,
+    listen_on => $listen_on,
+  }
+}

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -16,15 +16,20 @@
 #   foreman_proxy::register will validate the feature name is loaded and
 #   advertised.
 #
+# @param template_path
+#   An optional template path
+#
 define foreman_proxy::module (
   Boolean $enabled = false,
   Foreman_proxy::ListenOn $listen_on = 'https',
+  Optional[String] $template_path = undef,
   String $feature = upcase($title),
 ) {
   foreman_proxy::settings_file { $name:
-    module    => true,
-    enabled   => $enabled,
-    feature   => $feature,
-    listen_on => $listen_on,
+    module        => true,
+    enabled       => $enabled,
+    feature       => $feature,
+    listen_on     => $listen_on,
+    template_path => $template_path,
   }
 }

--- a/manifests/module/bmc.pp
+++ b/manifests/module/bmc.pp
@@ -1,0 +1,16 @@
+# @summary The built in BMC module
+#
+# @param enabled
+#  Whether the module is enabled or disabled.
+#
+# @param listen_on
+#   Where to listen on.
+class foreman_proxy::module::bmc (
+  Boolean $enabled = $foreman_proxy::bmc,
+  Foreman_proxy::ListenOn $listen_on = $foreman_proxy::bmc_listen_on,
+) {
+  foreman_proxy::module { 'bmc':
+    enabled   => $enabled,
+    listen_on => $listen_on,
+  }
+}

--- a/manifests/module/dhcp.pp
+++ b/manifests/module/dhcp.pp
@@ -1,0 +1,16 @@
+# @summary The built in DHCP module
+#
+# @param enabled
+#  Whether the module is enabled or disabled.
+#
+# @param listen_on
+#   Where to listen on.
+class foreman_proxy::module::dhcp (
+  Boolean $enabled = $foreman_proxy::dhcp,
+  Foreman_proxy::ListenOn $listen_on = $foreman_proxy::dhcp_listen_on,
+) {
+  foreman_proxy::module { 'dhcp':
+    enabled   => $enabled,
+    listen_on => $listen_on,
+  }
+}

--- a/manifests/module/dns.pp
+++ b/manifests/module/dns.pp
@@ -1,0 +1,16 @@
+# @summary The built in DNS module
+#
+# @param enabled
+#  Whether the module is enabled or disabled.
+#
+# @param listen_on
+#   Where to listen on.
+class foreman_proxy::module::dns (
+  Boolean $enabled = $foreman_proxy::dns,
+  Foreman_proxy::ListenOn $listen_on = $foreman_proxy::dns_listen_on,
+) {
+  foreman_proxy::module { 'dns':
+    enabled   => $enabled,
+    listen_on => $listen_on,
+  }
+}

--- a/manifests/module/httpboot.pp
+++ b/manifests/module/httpboot.pp
@@ -1,0 +1,25 @@
+# @summary The built in HTTPBoot module
+#
+# @param enabled
+#  Whether the module is enabled or disabled.
+#
+# @param listen_on
+#   Where to listen on.
+class foreman_proxy::module::httpboot (
+  Optional[Boolean] $enabled = $foreman_proxy::httpboot,
+  Foreman_proxy::ListenOn $listen_on = $foreman_proxy::httpboot_listen_on,
+) {
+  $real_enabled = pick($enabled, $foreman_proxy::tftp)
+  if $real_enabled {
+    include foreman_proxy::module::tftp
+    unless $foreman_proxy::module::tftp::enabled {
+      fail('The HTTPBoot module depends on the TFTP module to be enabled')
+    }
+  }
+
+  foreman_proxy::module { 'httpboot':
+    enabled   => $real_enabled,
+    feature   => 'HTTPBoot',
+    listen_on => $listen_on,
+  }
+}

--- a/manifests/module/logs.pp
+++ b/manifests/module/logs.pp
@@ -1,0 +1,17 @@
+# @summary The built in Logs module
+#
+# @param enabled
+#  Whether the module is enabled or disabled.
+#
+# @param listen_on
+#   Where to listen on.
+class foreman_proxy::module::logs (
+  Boolean $enabled = $foreman_proxy::logs,
+  Foreman_proxy::ListenOn $listen_on = $foreman_proxy::logs_listen_on,
+) {
+  foreman_proxy::module { 'logs':
+    enabled   => $enabled,
+    feature   => 'Logs',
+    listen_on => $listen_on,
+  }
+}

--- a/manifests/module/puppet.pp
+++ b/manifests/module/puppet.pp
@@ -1,0 +1,17 @@
+# @summary The built in Puppet module
+#
+# @param enabled
+#  Whether the module is enabled or disabled.
+#
+# @param listen_on
+#   Where to listen on.
+class foreman_proxy::module::puppet (
+  Boolean $enabled = $foreman_proxy::puppet,
+  Foreman_proxy::ListenOn $listen_on = $foreman_proxy::puppet_listen_on,
+) {
+  foreman_proxy::module { 'puppet':
+    enabled   => $enabled,
+    feature   => 'Puppet',
+    listen_on => $listen_on,
+  }
+}

--- a/manifests/module/puppetca.pp
+++ b/manifests/module/puppetca.pp
@@ -1,0 +1,17 @@
+# @summary The built in Puppet CA module
+#
+# @param enabled
+#  Whether the module is enabled or disabled.
+#
+# @param listen_on
+#   Where to listen on.
+class foreman_proxy::module::puppetca (
+  Boolean $enabled = $foreman_proxy::puppetca,
+  Foreman_proxy::ListenOn $listen_on = $foreman_proxy::puppetca_listen_on,
+) {
+  foreman_proxy::module { 'puppetca':
+    enabled   => $enabled,
+    feature   => 'Puppet CA',
+    listen_on => $listen_on,
+  }
+}

--- a/manifests/module/realm.pp
+++ b/manifests/module/realm.pp
@@ -1,0 +1,17 @@
+# @summary The built in Realm module
+#
+# @param enabled
+#  Whether the module is enabled or disabled.
+#
+# @param listen_on
+#   Where to listen on.
+class foreman_proxy::module::realm (
+  Boolean $enabled = $foreman_proxy::realm,
+  Foreman_proxy::ListenOn $listen_on = $foreman_proxy::realm_listen_on,
+) {
+  foreman_proxy::module { 'realm':
+    enabled   => $enabled,
+    feature   => 'Realm',
+    listen_on => $listen_on,
+  }
+}

--- a/manifests/module/templates.pp
+++ b/manifests/module/templates.pp
@@ -1,0 +1,17 @@
+# @summary The built in Templates module
+#
+# @param enabled
+#  Whether the module is enabled or disabled.
+#
+# @param listen_on
+#   Where to listen on.
+class foreman_proxy::module::templates (
+  Boolean $enabled = $foreman_proxy::templates,
+  Foreman_proxy::ListenOn $listen_on = $foreman_proxy::templates_listen_on,
+) {
+  foreman_proxy::module { 'templates':
+    enabled   => $enabled,
+    feature   => 'Templates',
+    listen_on => $listen_on,
+  }
+}

--- a/manifests/module/tftp.pp
+++ b/manifests/module/tftp.pp
@@ -1,0 +1,16 @@
+# @summary The built in TFTP module
+#
+# @param enabled
+#  Whether the module is enabled or disabled.
+#
+# @param listen_on
+#   Where to listen on.
+class foreman_proxy::module::tftp (
+  Boolean $enabled = $foreman_proxy::tftp,
+  Foreman_proxy::ListenOn $listen_on = $foreman_proxy::tftp_listen_on,
+) {
+  foreman_proxy::module { 'tftp':
+    enabled   => $enabled,
+    listen_on => $listen_on,
+  }
+}

--- a/manifests/plugin/abrt.pp
+++ b/manifests/plugin/abrt.pp
@@ -43,13 +43,9 @@ class foreman_proxy::plugin::abrt (
   Optional[Stdlib::Absolutepath] $faf_server_ssl_cert = undef,
   Optional[Stdlib::Absolutepath] $faf_server_ssl_key = undef,
 ) {
-  foreman_proxy::plugin { 'abrt':
-    version => $version,
-  }
-  -> foreman_proxy::settings_file { 'abrt':
-    template_path => 'foreman_proxy/plugin/abrt.yml.erb',
-    feature       => 'Abrt',
-    listen_on     => $listen_on,
-    enabled       => $enabled,
+  foreman_proxy::plugin::module { 'abrt':
+    version   => $version,
+    listen_on => $listen_on,
+    enabled   => $enabled,
   }
 }

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -64,13 +64,9 @@ class foreman_proxy::plugin::ansible (
     include ::foreman_proxy::plugin::ansible::runner
   }
 
-  foreman_proxy::plugin { 'ansible':
-  }
-  -> foreman_proxy::settings_file { 'ansible':
-    enabled       => $enabled,
-    feature       => 'Ansible',
-    listen_on     => $listen_on,
-    template_path => 'foreman_proxy/plugin/ansible.yml.erb',
+  foreman_proxy::plugin::module { 'ansible':
+    enabled   => $enabled,
+    listen_on => $listen_on,
   }
 
   if $foreman_proxy::plugin::dynflow::external_core {

--- a/manifests/plugin/chef.pp
+++ b/manifests/plugin/chef.pp
@@ -36,13 +36,8 @@ class foreman_proxy::plugin::chef (
   Boolean $ssl_verify = $::foreman_proxy::plugin::chef::params::ssl_verify,
   Optional[Stdlib::Absolutepath] $ssl_pem_file = $::foreman_proxy::plugin::chef::params::ssl_pem_file,
 ) inherits foreman_proxy::plugin::chef::params {
-  foreman_proxy::plugin {'chef':
-    version => $version,
-  }
-  -> foreman_proxy::settings_file { 'chef':
-    listen_on     => $listen_on,
-    enabled       => $enabled,
-    feature       => 'Chef',
-    template_path => 'foreman_proxy/plugin/chef.yml.erb',
+  foreman_proxy::plugin::module { 'chef':
+    enabled   => $enabled,
+    listen_on => $listen_on,
   }
 }

--- a/manifests/plugin/dhcp/infoblox.pp
+++ b/manifests/plugin/dhcp/infoblox.pp
@@ -21,10 +21,6 @@ class foreman_proxy::plugin::dhcp::infoblox (
   String $dns_view = 'default',
   String $network_view = 'default',
 ) {
-  foreman_proxy::plugin { 'dhcp_infoblox':
-  }
-  -> foreman_proxy::settings_file { 'dhcp_infoblox':
-    module        => false,
-    template_path => 'foreman_proxy/plugin/dhcp_infoblox.yml.erb',
+  foreman_proxy::plugin::provider { 'dhcp_infoblox':
   }
 }

--- a/manifests/plugin/dhcp/remote_isc.pp
+++ b/manifests/plugin/dhcp/remote_isc.pp
@@ -21,10 +21,6 @@ class foreman_proxy::plugin::dhcp::remote_isc (
   Optional[String] $key_secret = undef,
   Stdlib::Port $omapi_port = 7911,
 ) {
-  foreman_proxy::plugin { 'dhcp_remote_isc':
-  }
-  -> foreman_proxy::settings_file { 'dhcp_remote_isc':
-    module        => false,
-    template_path => 'foreman_proxy/plugin/dhcp_remote_isc.yml.erb',
+  foreman_proxy::plugin::provider { 'dhcp_remote_isc':
   }
 }

--- a/manifests/plugin/dns/infoblox.pp
+++ b/manifests/plugin/dns/infoblox.pp
@@ -18,10 +18,6 @@ class foreman_proxy::plugin::dns::infoblox (
   String $password = undef,
   String $dns_view = 'default',
 ) {
-  foreman_proxy::plugin { 'dns_infoblox':
-  }
-  -> foreman_proxy::settings_file { 'dns_infoblox':
-    module        => false,
-    template_path => 'foreman_proxy/plugin/dns_infoblox.yml.erb',
+  foreman_proxy::plugin::provider { 'dns_infoblox':
   }
 }

--- a/manifests/plugin/dns/powerdns.pp
+++ b/manifests/plugin/dns/powerdns.pp
@@ -10,10 +10,6 @@ class foreman_proxy::plugin::dns::powerdns (
   Stdlib::HTTPUrl $rest_url = 'http://localhost:8081/api/v1/servers/localhost',
   String $rest_api_key = '', # lint:ignore:empty_string_assignment
 ) {
-  foreman_proxy::plugin { 'dns_powerdns':
-  }
-  -> foreman_proxy::settings_file { 'dns_powerdns':
-    module        => false,
-    template_path => 'foreman_proxy/plugin/dns_powerdns.yml.erb',
+  foreman_proxy::plugin::provider { 'dns_powerdns':
   }
 }

--- a/manifests/plugin/dynflow.pp
+++ b/manifests/plugin/dynflow.pp
@@ -43,13 +43,9 @@ class foreman_proxy::plugin::dynflow (
     $core_url = "http://${::fqdn}:${core_port}"
   }
 
-  foreman_proxy::plugin { 'dynflow':
-  }
-  -> foreman_proxy::settings_file { 'dynflow':
-    enabled       => $enabled,
-    feature       => 'Dynflow',
-    listen_on     => $listen_on,
-    template_path => 'foreman_proxy/plugin/dynflow.yml.erb',
+  foreman_proxy::plugin::module { 'dynflow':
+    enabled   => $enabled,
+    listen_on => $listen_on,
   }
 
   if $external_core {

--- a/manifests/plugin/module.pp
+++ b/manifests/plugin/module.pp
@@ -1,0 +1,43 @@
+# @summary Install a Foreman Proxy plugin that's a module
+#
+# @param version
+#   The version to ensure
+#
+# @param package
+#   The package to install
+#
+# @param enabled
+#  Whether the module is enabled or disabled.
+#
+# @param feature
+#   Each module is exposed as a feature to Foreman on registration. When using
+#   `foreman_proxy::register`, these features are checked to verify it works
+#   end to end.
+#
+# @param listen_on
+#   When enabled, it's configured to listen on HTTPS (default), HTTP or both.
+#   Unless the module explicitly needs HTTP (usually because clients needs it),
+#   HTTPS should be chosen.
+#
+# @param template_path
+#   An optional template path
+#
+define foreman_proxy::plugin::module (
+  Optional[String] $version = undef,
+  Optional[String] $package = undef,
+  Boolean $enabled = false,
+  Optional[Foreman_proxy::ListenOn] $listen_on = undef,
+  String $template_path = "foreman_proxy/plugin/${title}.yml.erb",
+  String $feature = $title.capitalize(),
+) {
+  foreman_proxy::plugin { $title:
+    version => $version,
+    package => $package,
+  }
+  -> foreman_proxy::module { $name:
+    enabled       => $enabled,
+    feature       => $feature,
+    listen_on     => $listen_on,
+    template_path => $template_path,
+  }
+}

--- a/manifests/plugin/monitoring.pp
+++ b/manifests/plugin/monitoring.pp
@@ -24,13 +24,9 @@ class foreman_proxy::plugin::monitoring (
   Optional[String] $version = undef,
   Boolean $collect_status = true,
 ) {
-  foreman_proxy::plugin { 'monitoring':
-    version => $version,
-  }
-  -> foreman_proxy::settings_file { 'monitoring':
-    template_path => 'foreman_proxy/plugin/monitoring.yml.erb',
-    enabled       => $enabled,
-    feature       => 'Monitoring',
-    listen_on     => $listen_on,
+  foreman_proxy::plugin::module { 'monitoring':
+    version   => $version,
+    enabled   => $enabled,
+    listen_on => $listen_on,
   }
 }

--- a/manifests/plugin/monitoring/icinga2.pp
+++ b/manifests/plugin/monitoring/icinga2.pp
@@ -40,7 +40,6 @@ class foreman_proxy::plugin::monitoring::icinga2 (
   include ::foreman_proxy::plugin::monitoring
 
   foreman_proxy::settings_file { 'monitoring_icinga2':
-    module        => false,
     template_path => 'foreman_proxy/plugin/monitoring_icinga2.yml.erb',
   }
 }

--- a/manifests/plugin/monitoring/icingadirector.pp
+++ b/manifests/plugin/monitoring/icingadirector.pp
@@ -30,7 +30,6 @@ class foreman_proxy::plugin::monitoring::icingadirector (
   include ::foreman_proxy::plugin::monitoring
 
   foreman_proxy::settings_file { 'monitoring_icingadirector':
-    module        => false,
     template_path => 'foreman_proxy/plugin/monitoring_icingadirector.yml.erb',
   }
 }

--- a/manifests/plugin/omaha.pp
+++ b/manifests/plugin/omaha.pp
@@ -27,14 +27,10 @@ class foreman_proxy::plugin::omaha (
   Optional[Stdlib::HTTPUrl] $http_proxy = undef,
   Optional[String] $version = undef,
 ) {
-  foreman_proxy::plugin { 'omaha':
-    version => $version,
-  }
-  -> foreman_proxy::settings_file { 'omaha':
-    template_path => 'foreman_proxy/plugin/omaha.yml.erb',
-    enabled       => $enabled,
-    feature       => 'Omaha',
-    listen_on     => $listen_on,
+  foreman_proxy::plugin::module { 'omaha':
+    version   => $version,
+    listen_on => $listen_on,
+    enabled   => $enabled,
   }
 
   exec { "mkdir_p-${contentpath}":

--- a/manifests/plugin/openscap.pp
+++ b/manifests/plugin/openscap.pp
@@ -48,13 +48,9 @@ class foreman_proxy::plugin::openscap (
   Integer[0] $timeout = 60,
 ) {
   $registered_proxy_name = pick($proxy_name, $foreman_proxy::registered_name)
-  foreman_proxy::plugin { 'openscap':
-    version => $version,
-  }
-  -> foreman_proxy::settings_file { 'openscap':
-    template_path => 'foreman_proxy/plugin/openscap.yml.erb',
-    listen_on     => $listen_on,
-    enabled       => $enabled,
-    feature       => 'Openscap',
+  foreman_proxy::plugin::module { 'openscap':
+    version   => $version,
+    listen_on => $listen_on,
+    enabled   => $enabled,
   }
 }

--- a/manifests/plugin/provider.pp
+++ b/manifests/plugin/provider.pp
@@ -1,0 +1,31 @@
+# @summary Install a Foreman Proxy plugin that's a provider
+#
+# @param version
+#   The version to ensure. When absent, the config file will be removed as well.
+#
+# @param package
+#   The package to install. Automatically determined by default.
+#
+# @param template_path
+#   An optional template path
+#
+define foreman_proxy::plugin::provider (
+  Optional[String] $version = undef,
+  Optional[String] $package = undef,
+  String $template_path = "foreman_proxy/plugin/${title}.yml.erb",
+) {
+  if $version == 'absent' {
+    $provider_ensure = 'absent'
+  } else {
+    $provider_ensure = 'file'
+  }
+
+  foreman_proxy::plugin { $title:
+    version => $version,
+    package => $package,
+  }
+  -> foreman_proxy::provider { $title:
+    ensure        => $provider_ensure,
+    template_path => $template_path,
+  }
+}

--- a/manifests/plugin/pulp.pp
+++ b/manifests/plugin/pulp.pp
@@ -52,19 +52,19 @@ class foreman_proxy::plugin::pulp (
     version => $version,
   }
   -> [
-    foreman_proxy::settings_file { 'pulp':
+    foreman_proxy::module { 'pulp':
       template_path => 'foreman_proxy/plugin/pulp.yml.erb',
       enabled       => $enabled,
       feature       => 'Pulp',
       listen_on     => $listen_on,
     },
-    foreman_proxy::settings_file { 'pulpnode':
+    foreman_proxy::module { 'pulpnode':
       template_path => 'foreman_proxy/plugin/pulpnode.yml.erb',
       enabled       => $pulpnode_enabled,
       feature       => 'Pulp Node',
       listen_on     => $listen_on,
     },
-    foreman_proxy::settings_file { 'pulpcore':
+    foreman_proxy::module { 'pulpcore':
       template_path => 'foreman_proxy/plugin/pulpcore.yml.erb',
       enabled       => $pulpcore_enabled,
       feature       => 'Pulpcore',

--- a/manifests/plugin/realm/ad.pp
+++ b/manifests/plugin/realm/ad.pp
@@ -30,11 +30,10 @@ class foreman_proxy::plugin::realm::ad (
   Optional[Boolean] $computername_use_fqdn = undef,
   Optional[String] $version = undef,
 ) {
-  foreman_proxy::plugin { 'realm_ad_plugin':
+  include foreman_proxy::params
+
+  foreman_proxy::plugin::provider { 'realm_ad':
+    package => "${foreman_proxy::params::plugin_prefix}realm_ad_plugin",
     version => $version,
-  }
-  -> foreman_proxy::settings_file { 'realm_ad':
-    module        => false,
-    template_path => 'foreman_proxy/plugin/realm_ad.yml.erb',
   }
 }

--- a/manifests/plugin/remote_execution/ssh.pp
+++ b/manifests/plugin/remote_execution/ssh.pp
@@ -48,13 +48,10 @@ class foreman_proxy::plugin::remote_execution::ssh (
   include foreman_proxy::params
   include ::foreman_proxy::plugin::dynflow
 
-  foreman_proxy::plugin { 'remote_execution_ssh':
-  }
-  -> foreman_proxy::settings_file { 'remote_execution_ssh':
-    enabled       => $enabled,
-    feature       => 'SSH',
-    listen_on     => $listen_on,
-    template_path => 'foreman_proxy/plugin/remote_execution_ssh.yml.erb',
+  foreman_proxy::plugin::module { 'remote_execution_ssh':
+    enabled   => $enabled,
+    feature   => 'SSH',
+    listen_on => $listen_on,
   }
 
   if $ssh_kerberos_auth {

--- a/manifests/plugin/salt.pp
+++ b/manifests/plugin/salt.pp
@@ -38,12 +38,8 @@ class foreman_proxy::plugin::salt (
   String $api_password = $::foreman_proxy::plugin::salt::params::api_password,
   Optional[Stdlib::Absolutepath] $saltfile = $::foreman_proxy::plugin::salt::params::saltfile,
 ) inherits foreman_proxy::plugin::salt::params {
-  foreman_proxy::plugin { 'salt':
-  }
-  -> foreman_proxy::settings_file { 'salt':
-    enabled       => $enabled,
-    listen_on     => $listen_on,
-    template_path => 'foreman_proxy/plugin/salt.yml.erb',
-    feature       => 'Salt',
+  foreman_proxy::plugin::module { 'salt':
+    enabled   => $enabled,
+    listen_on => $listen_on,
   }
 }

--- a/manifests/provider.pp
+++ b/manifests/provider.pp
@@ -1,0 +1,12 @@
+# @summary Configure a provider
+#
+# @param ensure
+#   Whether the config file should be a file or absent
+#
+define foreman_proxy::provider (
+  Enum['file', 'absent'] $ensure = 'file',
+) {
+  foreman_proxy::settings_file { $title:
+    ensure        => $ensure,
+  }
+}

--- a/manifests/provider.pp
+++ b/manifests/provider.pp
@@ -3,10 +3,15 @@
 # @param ensure
 #   Whether the config file should be a file or absent
 #
+# @param template_path
+#   An optional template path
+#
 define foreman_proxy::provider (
   Enum['file', 'absent'] $ensure = 'file',
+  Optional[String] $template_path = undef,
 ) {
   foreman_proxy::settings_file { $title:
     ensure        => $ensure,
+    template_path => $template_path,
   }
 }

--- a/manifests/settings_file.pp
+++ b/manifests/settings_file.pp
@@ -3,14 +3,8 @@
 # @param ensure
 #   Whether the config file should be a file or absent
 #
-# @param module
-#   Whether the config file is a proxy module or not
-#
-# @param enabled
-#   If module is enabled or not
-#
-# @param listen_on
-#   Whether the module listens on https, http, or both
+# @param module_enabled
+#   If module is enabled or not. Only relevant when it's a module.
 #
 # @param path
 #   Path to module's settings file
@@ -27,43 +21,15 @@
 # @param mode
 #   Settings file's mode
 #
-# @param feature
-#   Feature name advertised by proxy module. If set, foreman_proxy::register
-#   will validate the feature name is loaded and advertised.
-#
 define foreman_proxy::settings_file (
   Enum['file', 'absent'] $ensure = 'file',
-  Boolean $module = true,
-  Boolean $enabled = true,
-  Foreman_proxy::ListenOn $listen_on = 'https',
+  String $module_enabled = 'false',
   Stdlib::Absolutepath $path = "${foreman_proxy::params::config_dir}/settings.d/${title}.yml",
   String $owner = 'root',
   String $group = $foreman_proxy::params::user,
   Stdlib::Filemode $mode = '0640',
   String $template_path = "foreman_proxy/${title}.yml.erb",
-  Optional[String] $feature = undef,
 ) {
-  # If the config file is for a proxy module, then we need to know
-  # whether it's enabled, and if so, where to listen (https, http, or both).
-  # If undefined here, look up the values from the foreman_proxy class.
-
-  if $module {
-    if $enabled {
-      $module_enabled = $listen_on ? {
-        'both'  => true,
-        'https' => 'https',
-        'http'  => 'http',
-        default => false,
-      }
-
-      if $feature and $ensure != 'absent' {
-        foreman_proxy::feature { $feature: }
-      }
-    } else {
-      $module_enabled = false
-    }
-  }
-
   if $ensure == 'absent' {
     $content = undef
   } else {

--- a/spec/classes/foreman_proxy__plugin__abrt_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__abrt_spec.rb
@@ -7,7 +7,7 @@ describe 'foreman_proxy::plugin::abrt' do
       let(:pre_condition) { 'include foreman_proxy' }
 
       describe 'with default settings' do
-        it { should contain_foreman_proxy__plugin('abrt') }
+        it { should contain_foreman_proxy__plugin__module('abrt') }
         it 'should configure abrt.yml' do
           should contain_file('/etc/foreman-proxy/settings.d/abrt.yml').
             with({

--- a/spec/classes/foreman_proxy__plugin__ansible_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__ansible_spec.rb
@@ -7,7 +7,8 @@ describe 'foreman_proxy::plugin::ansible' do
       let(:pre_condition) { 'include foreman_proxy' }
 
       describe 'with default settings' do
-        it { should contain_foreman_proxy__plugin('dynflow') }
+        it { should contain_class('foreman_proxy::plugin::dynflow') }
+        it { should contain_foreman_proxy__plugin__module('ansible') }
 
         case os
         when 'debian-10-x86_64'
@@ -69,7 +70,7 @@ describe 'foreman_proxy::plugin::ansible' do
           }
         end
 
-        it { should contain_foreman_proxy__plugin('dynflow') }
+        it { should contain_class('foreman_proxy::plugin::dynflow') }
 
         case os
         when 'debian-10-x86_64'

--- a/spec/classes/foreman_proxy__plugin__chef__spec.rb
+++ b/spec/classes/foreman_proxy__plugin__chef__spec.rb
@@ -16,11 +16,11 @@ describe 'foreman_proxy::plugin::chef' do
         it { should compile.with_all_deps }
 
         it 'should call the plugin' do
-          should contain_foreman_proxy__plugin('chef')
+          should contain_foreman_proxy__plugin__module('chef').with_enabled(true).with_listen_on('https')
         end
 
         it 'should install configuration file' do
-          should contain_foreman_proxy__settings_file('chef').with_enabled(true).with_listen_on('https')
+          should contain_foreman_proxy__settings_file('chef')
           verify_exact_contents(catalogue, '/etc/foreman-proxy/settings.d/chef.yml', [
             '---',
             ':enabled: https',
@@ -43,11 +43,10 @@ describe 'foreman_proxy::plugin::chef' do
         it { should compile.with_all_deps }
 
         it 'should call the plugin' do
-          should contain_foreman_proxy__plugin('chef')
+          should contain_foreman_proxy__plugin__module('chef').with_enabled(false)
         end
 
         it 'should install configuration file' do
-          should contain_foreman_proxy__settings_file('chef').with_enabled(false)
           should contain_file('/etc/foreman-proxy/settings.d/chef.yml').with_content(/:enabled: false/)
         end
       end

--- a/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
@@ -11,7 +11,7 @@ describe 'foreman_proxy::plugin::dynflow' do
 
       describe 'with default settings' do
         it { should compile.with_all_deps }
-        it { should contain_foreman_proxy__plugin('dynflow') }
+        it { should contain_foreman_proxy__plugin__module('dynflow') }
 
         it 'should generate correct dynflow.yml' do
           lines = [
@@ -73,7 +73,7 @@ describe 'foreman_proxy::plugin::dynflow' do
         } end
 
         it { should compile.with_all_deps }
-        it { should contain_foreman_proxy__plugin('dynflow') }
+        it { should contain_foreman_proxy__plugin__module('dynflow') }
 
         it 'should create settings.d symlink' do
           should contain_file("#{etc_dir}/smart_proxy_dynflow_core/settings.d").

--- a/spec/classes/foreman_proxy__plugin__monitoring_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__monitoring_spec.rb
@@ -7,7 +7,7 @@ describe 'foreman_proxy::plugin::monitoring' do
       let(:pre_condition) { 'include foreman_proxy' }
 
       describe 'with default settings' do
-        it { should contain_foreman_proxy__plugin('monitoring') }
+        it { should contain_foreman_proxy__plugin__module('monitoring') }
         it 'should configure monitoring.yml' do
           should contain_file('/etc/foreman-proxy/settings.d/monitoring.yml').
             with({

--- a/spec/classes/foreman_proxy__plugin__omaha_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__omaha_spec.rb
@@ -7,7 +7,7 @@ describe 'foreman_proxy::plugin::omaha' do
       let(:pre_condition) { 'include foreman_proxy' }
 
       describe 'with default settings' do
-        it { should contain_foreman_proxy__plugin('omaha') }
+        it { should contain_foreman_proxy__plugin__module('omaha') }
         it 'omaha.yml should contain the correct configuration' do
           verify_exact_contents(catalogue, '/etc/foreman-proxy/settings.d/omaha.yml', [
             '---',

--- a/spec/classes/foreman_proxy__plugin__openscap_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__openscap_spec.rb
@@ -14,7 +14,7 @@ describe 'foreman_proxy::plugin::openscap' do
         end
 
         it 'should call the plugin' do
-          should contain_foreman_proxy__plugin('openscap')
+          should contain_foreman_proxy__plugin__module('openscap')
         end
 
         it 'should install configuration file' do
@@ -43,7 +43,7 @@ describe 'foreman_proxy::plugin::openscap' do
         end
 
         it 'should call the plugin' do
-          should contain_foreman_proxy__plugin('openscap')
+          should contain_foreman_proxy__plugin__module('openscap')
         end
 
         it 'should install configuration file' do

--- a/spec/classes/foreman_proxy__plugin__realm__ad_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__realm__ad_spec.rb
@@ -12,7 +12,7 @@ describe 'foreman_proxy::plugin::realm::ad' do
           :domain_controller => 'dc.example.com'
         } end
 
-        it { should contain_foreman_proxy__plugin('realm_ad_plugin') }
+        it { should contain_foreman_proxy__plugin__provider('realm_ad').with_package(/^(tfm-)?ruby(gem)?-smart[_-]proxy[-_]realm[_-]ad[_-]plugin$/) }
         it 'realm_ad.yml should contain the correct configuration' do
           verify_exact_contents(catalogue, '/etc/foreman-proxy/settings.d/realm_ad.yml', [
             '---',

--- a/spec/classes/foreman_proxy__plugin__remote_execution__ssh_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__remote_execution__ssh_spec.rb
@@ -8,8 +8,8 @@ describe 'foreman_proxy::plugin::remote_execution::ssh' do
       let(:package_name) { os.start_with?('debian') ? 'ruby-net-ssh-krb' : 'tfm-rubygem-net-ssh-krb' }
 
       describe 'with default settings' do
-        it { should contain_foreman_proxy__plugin('dynflow') }
-        it { should contain_foreman_proxy__plugin('remote_execution_ssh') }
+        it { should contain_class('foreman_proxy::plugin::dynflow') }
+        it { should contain_foreman_proxy__plugin__module('remote_execution_ssh') }
 
         it 'should configure remote_execution_ssh.yml' do
           should contain_file('/etc/foreman-proxy/settings.d/remote_execution_ssh.yml').
@@ -46,8 +46,8 @@ describe 'foreman_proxy::plugin::remote_execution::ssh' do
           :async_ssh          => true,
         } end
 
-        it { should contain_foreman_proxy__plugin('dynflow') }
-        it { should contain_foreman_proxy__plugin('remote_execution_ssh') }
+        it { should contain_class('foreman_proxy::plugin::dynflow') }
+        it { should contain_foreman_proxy__plugin__module('remote_execution_ssh') }
 
         it 'should configure remote_execution_ssh.yml' do
           should contain_file('/etc/foreman-proxy/settings.d/remote_execution_ssh.yml').

--- a/spec/classes/foreman_proxy__plugin__salt_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__salt_spec.rb
@@ -7,7 +7,7 @@ describe 'foreman_proxy::plugin::salt' do
       let(:pre_condition) { 'include foreman_proxy' }
 
       describe 'with default settings' do
-        it { should contain_foreman_proxy__plugin('salt') }
+        it { should contain_foreman_proxy__plugin__module('salt') }
         it 'should configure salt.yml' do
           should contain_file('/etc/foreman-proxy/settings.d/salt.yml').
             with({

--- a/spec/defines/foreman_proxy_module_spec.rb
+++ b/spec/defines/foreman_proxy_module_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe 'foreman_proxy::module' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:title) { 'test' }
+      let(:pre_condition) { 'include foreman_proxy::params' }
+
+      context 'with defaults' do
+        it { is_expected.to compile.with_all_deps }
+        it do
+          is_expected.to contain_foreman_proxy__settings_file('test')
+            .with_enabled(false)
+            .with_feature('TEST')
+            .with_listen_on('https')
+        end
+
+        it { is_expected.not_to contain_foreman_proxy__feature('TEST') }
+      end
+
+      context 'with enabled => true' do
+        let(:params) { { enabled: true } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_foreman_proxy__settings_file('test').with_enabled(true) }
+        it { is_expected.to contain_foreman_proxy__feature('TEST') }
+      end
+
+      context 'with feature' do
+        let(:params) { { feature: 'Test' } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_foreman_proxy__settings_file('test').with_feature('Test') }
+        it { is_expected.not_to contain_foreman_proxy__feature('Test') }
+
+        context 'with enabled => true' do
+          let(:params) { super().merge(enabled: true) }
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_foreman_proxy__settings_file('test').with_enabled(true).with_feature('Test') }
+          it { is_expected.to contain_foreman_proxy__feature('Test') }
+        end
+      end
+
+      context 'with listen_on => both' do
+        let(:params) { { listen_on: 'both' } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_foreman_proxy__settings_file('test').with_listen_on('both') }
+      end
+
+      context 'with listen_on => http' do
+        let(:params) { { listen_on: 'http' } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_foreman_proxy__settings_file('test').with_listen_on('http') }
+      end
+    end
+  end
+end

--- a/spec/defines/foreman_proxy_module_spec.rb
+++ b/spec/defines/foreman_proxy_module_spec.rb
@@ -9,13 +9,7 @@ describe 'foreman_proxy::module' do
 
       context 'with defaults' do
         it { is_expected.to compile.with_all_deps }
-        it do
-          is_expected.to contain_foreman_proxy__settings_file('test')
-            .with_enabled(false)
-            .with_feature('TEST')
-            .with_listen_on('https')
-        end
-
+        it { is_expected.to contain_foreman_proxy__settings_file('test').with_module_enabled('false') }
         it { is_expected.not_to contain_foreman_proxy__feature('TEST') }
       end
 
@@ -23,38 +17,36 @@ describe 'foreman_proxy::module' do
         let(:params) { { enabled: true } }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_foreman_proxy__settings_file('test').with_enabled(true) }
+        it { is_expected.to contain_foreman_proxy__settings_file('test').with_module_enabled('https') }
         it { is_expected.to contain_foreman_proxy__feature('TEST') }
+
+        context 'with listen_on => both' do
+          let(:params) { super().merge(listen_on: 'both') }
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_foreman_proxy__settings_file('test').with_module_enabled('true') }
+        end
+
+        context 'with listen_on => http' do
+          let(:params) { super().merge(listen_on: 'http') }
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_foreman_proxy__settings_file('test').with_module_enabled('http') }
+        end
       end
 
       context 'with feature' do
         let(:params) { { feature: 'Test' } }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_foreman_proxy__settings_file('test').with_feature('Test') }
         it { is_expected.not_to contain_foreman_proxy__feature('Test') }
 
         context 'with enabled => true' do
           let(:params) { super().merge(enabled: true) }
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_foreman_proxy__settings_file('test').with_enabled(true).with_feature('Test') }
           it { is_expected.to contain_foreman_proxy__feature('Test') }
         end
-      end
-
-      context 'with listen_on => both' do
-        let(:params) { { listen_on: 'both' } }
-
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_foreman_proxy__settings_file('test').with_listen_on('both') }
-      end
-
-      context 'with listen_on => http' do
-        let(:params) { { listen_on: 'http' } }
-
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_foreman_proxy__settings_file('test').with_listen_on('http') }
       end
     end
   end

--- a/spec/defines/foreman_proxy_plugin_module_spec.rb
+++ b/spec/defines/foreman_proxy_plugin_module_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'foreman_proxy::plugin::module' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:title) { 'test' }
+      let(:pre_condition) { 'include foreman_proxy::params' }
+
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_foreman_proxy__plugin('test').with_version('installed').with_package(/[-_]test$/) }
+      it do
+        is_expected.to contain_foreman_proxy__module('test')
+          .with_enabled(false)
+          .with_feature('Test')
+          .with_listen_on('https')
+          .with_template_path('foreman_proxy/plugin/test.yml.erb')
+      end
+    end
+  end
+end

--- a/spec/defines/foreman_proxy_plugin_provider_spec.rb
+++ b/spec/defines/foreman_proxy_plugin_provider_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'foreman_proxy::plugin::provider' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:title) { 'test' }
+      let(:pre_condition) { 'include foreman_proxy::params' }
+
+      context 'with defaults' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_foreman_proxy__plugin('test').with_version('installed').with_package(/[-_]test$/) }
+        it { is_expected.to contain_foreman_proxy__provider('test').with_ensure('file').with_template_path('foreman_proxy/plugin/test.yml.erb') }
+      end
+
+      context 'with version => absent' do
+        let(:params) { { version: 'absent' } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_foreman_proxy__plugin('test').with_version('absent') }
+        it { is_expected.to contain_foreman_proxy__provider('test').with_ensure('absent') }
+      end
+    end
+  end
+end

--- a/spec/defines/foreman_proxy_provider_spec.rb
+++ b/spec/defines/foreman_proxy_provider_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'foreman_proxy::provider' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:title) { 'test' }
+      let(:pre_condition) { 'include foreman_proxy::params' }
+
+      context 'with defaults' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_foreman_proxy__settings_file('test').with_ensure('file') }
+      end
+
+      context 'with ensure => absent' do
+        let(:params) { { ensure: 'absent' } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_foreman_proxy__settings_file('test').with_ensure('absent') }
+      end
+    end
+  end
+end

--- a/spec/defines/foreman_proxy_settings_file_spec.rb
+++ b/spec/defines/foreman_proxy_settings_file_spec.rb
@@ -5,6 +5,7 @@ describe 'foreman_proxy::settings_file' do
     context "on #{os}" do
       let(:facts) { facts }
       let(:title) { 'test' }
+      let(:group) { ['FreeBSD', 'DragonFly'].include?(facts[:osfamily]) ? 'foreman_proxy' : 'foreman-proxy' }
       let(:config_path) do
         File.join(
           ['FreeBSD', 'DragonFly'].include?(facts[:osfamily]) ? '/usr/local/etc' : '/etc',
@@ -15,55 +16,14 @@ describe 'foreman_proxy::settings_file' do
       context 'standalone' do
         let(:pre_condition) { 'include foreman_proxy::params' }
 
-        context 'defaults, module enabled' do
-          it do
-            is_expected.to contain_file(config_path).with(
-              ensure: 'file',
-              owner: 'root',
-              group: ['FreeBSD', 'DragonFly'].include?(facts[:osfamily]) ? 'foreman_proxy' : 'foreman-proxy',
-              mode: '0640',
-            )
-          end
-
-          it 'should set :enabled in config' do
-            verify_exact_contents(catalogue, config_path, ['---', ':enabled: https'])
-          end
-
-          it { is_expected.not_to contain_foreman_proxy__feature('Test') }
-        end
-
-        context 'with feature' do
-          let(:params) { { feature: 'Test' } }
-          it { is_expected.to contain_foreman_proxy__feature('Test') }
-        end
-
-        context 'with listen_on => both' do
-          let(:params) { { listen_on: 'both' } }
-
-          it 'should set :enabled to true in config' do
-            verify_exact_contents(catalogue, config_path, ['---', ':enabled: true'])
-          end
-        end
-
-        context 'with listen_on => http' do
-          let(:params) { { listen_on: 'http' } }
-
-          it 'should set :enabled to http in config' do
-            verify_exact_contents(catalogue, config_path, ['---', ':enabled: http'])
-          end
-        end
-
-        context 'with enabled => false' do
-          let(:params) { { enabled: false } }
-
-          it 'should set :enabled to false in config' do
-            verify_exact_contents(catalogue, config_path, ['---', ':enabled: false'])
-          end
-
-          context 'with feature' do
-            let(:params) { { enabled: false, feature: 'Test' } }
-            it { is_expected.not_to contain_foreman_proxy__feature('Test') }
-          end
+        it do
+          is_expected.to compile.with_all_deps
+          is_expected.to contain_file(config_path)
+            .with_ensure('file')
+            .with_owner('root')
+            .with_group(group)
+            .with_mode('0640')
+            .with_content("---\n# Test file only\n# Can be true, false, or http/https to enable just one of the protocols\n:enabled: false\n")
         end
       end
 

--- a/templates/plugin/test.yml.erb
+++ b/templates/plugin/test.yml.erb
@@ -1,0 +1,4 @@
+---
+# Test file only
+# Can be true, false, or http/https to enable just one of the protocols
+:enabled: <%= @module_enabled %>


### PR DESCRIPTION
This introduces defines to provide abstractions at a higher level. There are modules and providers in Foreman proxy. Both can either be built in, in which case a package is not needed, or a plugin. The Puppet module now knows about them.

Not all plugins properly follow this and I want to dive into to see what can be done around this. I also want to look into taking it a step further and moving variables to their correct classes. I also think the globals introduction should be done before this entire PR to prevent changing those specs again. That's why this is a draft for now. There's preparation PRs for code that can already be merged:
* [x] https://github.com/theforeman/puppet-foreman_proxy/pull/567
* [x] https://github.com/theforeman/puppet-foreman_proxy/pull/568
* [x] https://github.com/theforeman/puppet-foreman_proxy/pull/569
* [x] https://github.com/theforeman/puppet-foreman_proxy/pull/570
* [x] https://github.com/theforeman/puppet-foreman_proxy/pull/571
* [x] https://github.com/theforeman/puppet-foreman_proxy/pull/572
* [x] https://github.com/theforeman/puppet-foreman_proxy/pull/573