### PR TITLE
Drop unused listen_on param on remote_execution_ssh

### DIFF
--- a/manifests/plugin/remote_execution/ssh.pp
+++ b/manifests/plugin/remote_execution/ssh.pp
@@ -25,13 +25,10 @@
 #
 # $enabled::            Enables/disables the plugin
 #
-# $listen_on::          Proxy feature listens on https, http, or both
-#
 # $async_ssh::          Whether to run remote execution jobs asynchronously.
 #
 class foreman_proxy::plugin::remote_execution::ssh (
   Boolean $enabled = true,
-  Foreman_proxy::ListenOn $listen_on = 'https',
   Boolean $generate_keys = true,
   Boolean $install_key = false,
   Stdlib::Absolutepath $ssh_identity_dir = '/var/lib/foreman-proxy/ssh',
@@ -50,8 +47,7 @@ class foreman_proxy::plugin::remote_execution::ssh (
   foreman_proxy::plugin { 'remote_execution_ssh':
   }
   -> foreman_proxy::settings_file { 'remote_execution_ssh':
-    enabled       => $enabled,
-    listen_on     => $listen_on,
+    module        => false,
     template_path => 'foreman_proxy/plugin/remote_execution_ssh.yml.erb',
   }
 

--- a/spec/classes/foreman_proxy__plugin__remote_execution__ssh_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__remote_execution__ssh_spec.rb
@@ -35,7 +35,6 @@ describe 'foreman_proxy::plugin::remote_execution::ssh' do
       describe 'with override parameters' do
         let :params do {
           :enabled            => true,
-          :listen_on          => 'http',
           :local_working_dir  => '/tmp',
           :remote_working_dir => '/tmp',
           :generate_keys      => false,
@@ -72,7 +71,6 @@ describe 'foreman_proxy::plugin::remote_execution::ssh' do
       describe 'with ssh key generating and installation' do
         let :params do {
           :enabled            => true,
-          :listen_on          => 'http',
           :local_working_dir  => '/tmp',
           :remote_working_dir => '/tmp',
           :generate_keys      => true,

--- a/templates/plugin/remote_execution_ssh.yml.erb
+++ b/templates/plugin/remote_execution_ssh.yml.erb
@@ -1,5 +1,5 @@
 ---
-:enabled: <%= @module_enabled %>
+:enabled: <%= scope.lookupvar('::foreman_proxy::plugin::remote_execution::ssh::enabled') %>
 :ssh_identity_key_file: <%= scope.lookupvar('::foreman_proxy::plugin::remote_execution::ssh::ssh_identity_path') %>
 :local_working_dir: <%= scope.lookupvar('::foreman_proxy::plugin::remote_execution::ssh::local_working_dir') %>
 :remote_working_dir: <%= scope.lookupvar('::foreman_proxy::plugin::remote_execution::ssh::remote_working_dir') %>


### PR DESCRIPTION
This is a provider, not a module. That means the enabled and listen_on parameters can't be used. listen_on is unused and can be dropped safely.  enabled is, so the template is used to explicitly reference the correct variable.