### PR TITLE
Remove redundant parameters

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,12 +1,8 @@
 # @summary Set up the foreman service
 # @api private
 class foreman_proxy::service {
-
   service { 'foreman-proxy':
-    ensure    => running,
-    enable    => true,
-    hasstatus => true,
-    require   => Class['foreman_proxy::config'],
+    ensure => running,
+    enable => true,
   }
-
 }


### PR DESCRIPTION
The parameter hasstatus has defaulted to true since Puppet 2.7.0 and that's long been the minimum supported version.

The require is already ensured in init.pp.