### PR TITLE
Introduce foreman_proxy::globals

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,7 +47,7 @@ class foreman_proxy::config {
   }
 
   foreman_proxy::settings_file { 'settings':
-    path   => "${::foreman_proxy::etc}/foreman-proxy/settings.yml",
+    path   => "${foreman_proxy::config_dir}/settings.yml",
     module => false,
   }
 

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -1,0 +1,17 @@
+# @summary Global overrides on parameters that hardly ever change
+#
+# @param user
+#   The user under which Foreman Proxy runs
+#
+# @param dir
+#   The directory where Foreman Proxy is deployed
+#
+# @param plugin_version
+#   The default plugin package state to ensure
+#
+class foreman_proxy::globals (
+  Optional[String] $user = undef,
+  Optional[Stdlib::Absolutepath] $dir = undef,
+  Enum['latest', 'present', 'installed', 'absent'] $plugin_version = 'installed',
+) {
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,8 +7,6 @@
 #
 # $ensure_packages_version::    control extra packages version, it's passed to ensure parameter of package resource
 #
-# $plugin_version::             foreman plugins version, it's passed to ensure parameter of plugins package resource
-#
 # $bind_host::                  Host to bind ports to, e.g. *, localhost, 0.0.0.0
 #
 # $http::                       Enable HTTP
@@ -18,10 +16,6 @@
 # $ssl::                        Enable SSL, ensure feature is added with "https://" protocol if true
 #
 # $ssl_port::                   HTTPS port to listen on (if ssl is enabled)
-#
-# $dir::                        Foreman proxy install directory
-#
-# $user::                       User under which foreman proxy will run
 #
 # $groups::                     Array of additional groups for the foreman proxy user
 #
@@ -314,12 +308,9 @@ class foreman_proxy (
   Boolean $gpgcheck = $::foreman_proxy::params::gpgcheck,
   String $version = $::foreman_proxy::params::version,
   Enum['latest', 'present', 'installed', 'absent'] $ensure_packages_version = $::foreman_proxy::params::ensure_packages_version,
-  Enum['latest', 'present', 'installed', 'absent'] $plugin_version = $::foreman_proxy::params::plugin_version,
   Variant[Array[String], String] $bind_host = $::foreman_proxy::params::bind_host,
   Integer[0, 65535] $http_port = $::foreman_proxy::params::http_port,
   Integer[0, 65535] $ssl_port = $::foreman_proxy::params::ssl_port,
-  Stdlib::Absolutepath $dir = $::foreman_proxy::params::dir,
-  String $user = $::foreman_proxy::params::user,
   Array[String] $groups = $::foreman_proxy::params::groups,
   Variant[Enum['STDOUT', 'SYSLOG', 'JOURNAL'], Stdlib::Absolutepath] $log = $::foreman_proxy::params::log,
   Enum['WARN', 'DEBUG', 'ERROR', 'FATAL', 'INFO', 'UNKNOWN'] $log_level = $::foreman_proxy::params::log_level,
@@ -474,5 +465,7 @@ class foreman_proxy (
   ~> Foreman_proxy::Plugin <| |>
   ~> Class['foreman_proxy::service']
   ~> Class['foreman_proxy::register']
+
+  Class['foreman_proxy::install'] -> Foreman_proxy::Settings_file <| |> ~> Class['foreman_proxy::service']
   # lint:endignore
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 # @summary The default parameters for the foreman proxy
 # @api private
-class foreman_proxy::params {
+class foreman_proxy::params inherits foreman_proxy::globals {
 
   $lower_fqdn = downcase($::fqdn)
 
@@ -12,10 +12,10 @@ class foreman_proxy::params {
         $plugin_prefix = 'rubygem-smart_proxy_'
       }
 
-      $dir   = '/usr/share/foreman-proxy'
+      $dir   = pick($foreman_proxy::globals::dir, '/usr/share/foreman-proxy')
       $etc   = '/etc'
       $shell = '/bin/false'
-      $user  = 'foreman-proxy'
+      $user  = pick($foreman_proxy::globals::user, 'foreman-proxy')
 
       $dhcp_config = '/etc/dhcp/dhcpd.conf'
       $dhcp_leases = '/var/lib/dhcpd/dhcpd.leases'
@@ -36,10 +36,10 @@ class foreman_proxy::params {
     'Debian': {
       $plugin_prefix = 'ruby-smart-proxy-'
 
-      $dir   = '/usr/share/foreman-proxy'
+      $dir   = pick($foreman_proxy::globals::dir, '/usr/share/foreman-proxy')
       $etc   = '/etc'
       $shell = '/bin/false'
-      $user  = 'foreman-proxy'
+      $user  = pick($foreman_proxy::globals::user, 'foreman-proxy')
 
       $dhcp_config = '/etc/dhcp/dhcpd.conf'
       $dhcp_leases = '/var/lib/dhcp/dhcpd.leases'
@@ -67,10 +67,10 @@ class foreman_proxy::params {
     /^(FreeBSD|DragonFly)$/: {
       $plugin_prefix = 'rubygem-smart_proxy_'
 
-      $dir   = '/usr/local/share/foreman-proxy'
+      $dir   = pick($foreman_proxy::globals::dir, '/usr/local/share/foreman-proxy')
       $etc   = '/usr/local/etc'
       $shell = '/usr/bin/false'
-      $user  = 'foreman_proxy'
+      $user  = pick($foreman_proxy::globals::user, 'foreman_proxy')
 
       $puppet_bindir = '/usr/local/bin'
       $puppetdir     = '/usr/local/etc/puppet'
@@ -112,6 +112,8 @@ class foreman_proxy::params {
     }
   }
 
+  $config_dir = "${etc}/foreman-proxy"
+
   $puppet_cmd = "${puppet_bindir}/puppet"
 
   $groups = []
@@ -121,7 +123,6 @@ class foreman_proxy::params {
   $gpgcheck                = true
   $version                 = 'present'
   $ensure_packages_version = 'present'
-  $plugin_version          = 'installed'
 
   # Enable listening on http
   $bind_host = ['*']
@@ -197,7 +198,7 @@ class foreman_proxy::params {
   $puppetssh_command   = "${puppet_cmd} agent --onetime --no-usecacheonfailure"
   $puppetssh_sudo      = false
   $puppetssh_user      = 'root'
-  $puppetssh_keyfile   = "${etc}/foreman-proxy/id_rsa"
+  $puppetssh_keyfile   = "${config_dir}/id_rsa"
   $puppetssh_wait      = false
   $puppet_user         = 'root'
   $salt_puppetrun_cmd  = 'puppet.run'
@@ -271,7 +272,7 @@ class foreman_proxy::params {
   # localhost can resolve to ipv6 which ruby doesn't handle well
   $dns_server             = '127.0.0.1'
   $dns_ttl                = 86400
-  $dns_tsig_keytab        = "${etc}/foreman-proxy/dns.keytab"
+  $dns_tsig_keytab        = "${config_dir}/dns.keytab"
   $dns_tsig_principal     = "foremanproxy/${::fqdn}@${dns_realm}"
 
   $dns_forwarders = []
@@ -297,7 +298,7 @@ class foreman_proxy::params {
   $realm              = false
   $realm_listen_on    = 'https'
   $realm_provider     = 'freeipa'
-  $realm_keytab       = "${etc}/foreman-proxy/freeipa.keytab"
+  $realm_keytab       = "${config_dir}/freeipa.keytab"
   $realm_principal    = 'realm-proxy@EXAMPLE.COM'
   $freeipa_config     = '/etc/ipa/default.conf'
   $freeipa_remove_dns = true

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -7,8 +7,8 @@
 #   The package to install. Underscores are replaced with dashes on Debian
 #
 define foreman_proxy::plugin(
-  $version = $foreman_proxy::plugin_version,
-  $package = "${foreman_proxy::plugin_prefix}${title}",
+  $version = $foreman_proxy::params::plugin_version,
+  $package = "${foreman_proxy::params::plugin_prefix}${title}",
 ) {
   # Debian gem2deb converts underscores to hyphens
   case $::osfamily {

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -47,7 +47,7 @@ class foreman_proxy::plugin::ansible (
   $foreman_ssl_key = pick($::foreman_proxy::foreman_ssl_key, $::foreman_proxy::ssl_key)
   $foreman_ssl_ca = pick($::foreman_proxy::foreman_ssl_ca, $::foreman_proxy::ssl_ca)
 
-  file {"${::foreman_proxy::etc}/foreman-proxy/ansible.cfg":
+  file {"${foreman_proxy::config_dir}/ansible.cfg":
     ensure  => file,
     content => template('foreman_proxy/plugin/ansible.cfg.erb'),
     owner   => 'root',
@@ -56,7 +56,7 @@ class foreman_proxy::plugin::ansible (
   }
   ~> file { "${::foreman_proxy::dir}/.ansible.cfg":
     ensure => link,
-    target => "${::foreman_proxy::etc}/foreman-proxy/ansible.cfg",
+    target => "${foreman_proxy::config_dir}/ansible.cfg",
   }
 
   include ::foreman_proxy::plugin::dynflow

--- a/manifests/plugin/ansible/params.pp
+++ b/manifests/plugin/ansible/params.pp
@@ -1,9 +1,11 @@
 # @summary Ansible proxy default parameters
 # @api private
 class foreman_proxy::plugin::ansible::params {
+  include foreman_proxy::params
+
   $enabled     = true
   $listen_on   = 'https'
-  $ansible_dir = '/usr/share/foreman-proxy'
+  $ansible_dir = $foreman_proxy::params::dir
   $working_dir = '/tmp'
   $host_key_checking = false
   $stdout_callback = 'yaml'

--- a/manifests/plugin/dynflow.pp
+++ b/manifests/plugin/dynflow.pp
@@ -62,7 +62,7 @@ class foreman_proxy::plugin::dynflow (
     }
     ~> file { '/etc/smart_proxy_dynflow_core/settings.d':
       ensure => link,
-      target => '/etc/foreman-proxy/settings.d',
+      target => "${foreman_proxy::config_dir}/settings.d",
     }
     ~> systemd::service_limits { 'smart_proxy_dynflow_core.service':
       limits          => {

--- a/manifests/plugin/monitoring/icingadirector/params.pp
+++ b/manifests/plugin/monitoring/icingadirector/params.pp
@@ -1,9 +1,11 @@
 # @summary Defaults for the icingadirector provider to the monitoring plugin
 # @api private
 class foreman_proxy::plugin::monitoring::icingadirector::params {
+  include foreman_proxy::params
+
   $enabled = true
   $director_url = "https://${::fqdn}/icingaweb2/director"
-  $director_cacert = '/etc/foreman-proxy/monitoring/ca.crt'
+  $director_cacert = "${foreman_proxy::params::config_dir}/monitoring/ca.crt"
   $director_user = undef
   $director_password = undef
   $verify_ssl = true

--- a/manifests/settings_file.pp
+++ b/manifests/settings_file.pp
@@ -36,9 +36,9 @@ define foreman_proxy::settings_file (
   Boolean $module = true,
   Boolean $enabled = true,
   Foreman_proxy::ListenOn $listen_on = 'https',
-  Stdlib::Absolutepath $path = "${foreman_proxy::etc}/foreman-proxy/settings.d/${title}.yml",
+  Stdlib::Absolutepath $path = "${foreman_proxy::params::config_dir}/settings.d/${title}.yml",
   String $owner = 'root',
-  String $group = $foreman_proxy::user,
+  String $group = $foreman_proxy::params::user,
   Stdlib::Filemode $mode = '0640',
   String $template_path = "foreman_proxy/${title}.yml.erb",
   Optional[String] $feature = undef,
@@ -76,7 +76,5 @@ define foreman_proxy::settings_file (
     owner   => $owner,
     group   => $group,
     mode    => $mode,
-    require => Class['foreman_proxy::install'],
-    notify  => Class['foreman_proxy::service'],
   }
 }

--- a/spec/defines/foreman_proxy_plugin_spec.rb
+++ b/spec/defines/foreman_proxy_plugin_spec.rb
@@ -5,7 +5,7 @@ describe 'foreman_proxy::plugin' do
     context "on #{os}" do
       let(:facts) { facts }
       let(:title) { 'myplugin' }
-      let(:pre_condition) { 'include foreman_proxy' }
+      let(:pre_condition) { 'include foreman_proxy::params' }
 
       context 'no parameters' do
         package = if facts[:osfamily] == 'Debian'

--- a/spec/defines/foreman_proxy_settings_file_spec.rb
+++ b/spec/defines/foreman_proxy_settings_file_spec.rb
@@ -11,59 +11,67 @@ describe 'foreman_proxy::settings_file' do
           'foreman-proxy', 'settings.d', "#{title}.yml"
         )
       end
-      let(:pre_condition) { 'include foreman_proxy' }
 
-      context 'defaults, module enabled' do
-        it do
-          is_expected.to contain_file(config_path).with(
-            ensure: 'file',
-            owner: 'root',
-            group: ['FreeBSD', 'DragonFly'].include?(facts[:osfamily]) ? 'foreman_proxy' : 'foreman-proxy',
-            mode: '0640',
-          )
-        end
-        it { is_expected.to contain_file(config_path).that_requires('Class[foreman_proxy::install]') }
-        it { is_expected.to contain_file(config_path).that_notifies('Class[foreman_proxy::service]') }
+      context 'standalone' do
+        let(:pre_condition) { 'include foreman_proxy::params' }
 
-        it 'should set :enabled in config' do
-          verify_exact_contents(catalogue, config_path, ['---', ':enabled: https'])
-        end
+        context 'defaults, module enabled' do
+          it do
+            is_expected.to contain_file(config_path).with(
+              ensure: 'file',
+              owner: 'root',
+              group: ['FreeBSD', 'DragonFly'].include?(facts[:osfamily]) ? 'foreman_proxy' : 'foreman-proxy',
+              mode: '0640',
+            )
+          end
 
-        it { is_expected.not_to contain_foreman_proxy__feature('Test') }
-      end
+          it 'should set :enabled in config' do
+            verify_exact_contents(catalogue, config_path, ['---', ':enabled: https'])
+          end
 
-      context 'with feature' do
-        let(:params) { { feature: 'Test' } }
-        it { is_expected.to contain_foreman_proxy__feature('Test') }
-      end
-
-      context 'with listen_on => both' do
-        let(:params) { { listen_on: 'both' } }
-
-        it 'should set :enabled to true in config' do
-          verify_exact_contents(catalogue, config_path, ['---', ':enabled: true'])
-        end
-      end
-
-      context 'with listen_on => http' do
-        let(:params) { { listen_on: 'http' } }
-
-        it 'should set :enabled to http in config' do
-          verify_exact_contents(catalogue, config_path, ['---', ':enabled: http'])
-        end
-      end
-
-      context 'with enabled => false' do
-        let(:params) { { enabled: false } }
-
-        it 'should set :enabled to false in config' do
-          verify_exact_contents(catalogue, config_path, ['---', ':enabled: false'])
+          it { is_expected.not_to contain_foreman_proxy__feature('Test') }
         end
 
         context 'with feature' do
-          let(:params) { { enabled: false, feature: 'Test' } }
-          it { is_expected.not_to contain_foreman_proxy__feature('Test') }
+          let(:params) { { feature: 'Test' } }
+          it { is_expected.to contain_foreman_proxy__feature('Test') }
         end
+
+        context 'with listen_on => both' do
+          let(:params) { { listen_on: 'both' } }
+
+          it 'should set :enabled to true in config' do
+            verify_exact_contents(catalogue, config_path, ['---', ':enabled: true'])
+          end
+        end
+
+        context 'with listen_on => http' do
+          let(:params) { { listen_on: 'http' } }
+
+          it 'should set :enabled to http in config' do
+            verify_exact_contents(catalogue, config_path, ['---', ':enabled: http'])
+          end
+        end
+
+        context 'with enabled => false' do
+          let(:params) { { enabled: false } }
+
+          it 'should set :enabled to false in config' do
+            verify_exact_contents(catalogue, config_path, ['---', ':enabled: false'])
+          end
+
+          context 'with feature' do
+            let(:params) { { enabled: false, feature: 'Test' } }
+            it { is_expected.not_to contain_foreman_proxy__feature('Test') }
+          end
+        end
+      end
+
+      context 'with foreman_proxy included' do
+        let(:pre_condition) { 'include foreman_proxy' }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file(config_path).that_requires('Class[foreman_proxy::install]').that_notifies('Class[foreman_proxy::service]') }
       end
     end
   end


### PR DESCRIPTION
This class is intended to allow overriding some parameters that basically never change. This makes the parameters of init.pp slightly easier to digest. It also allows testing of some modules by just including params without the entire foreman_proxy class. This makes tests faster but also more focused.