### PR TITLE
Drop group parameter on plugins

### DIFF
--- a/manifests/plugin/abrt.pp
+++ b/manifests/plugin/abrt.pp
@@ -25,8 +25,6 @@
 #
 # $enabled::                    Enables/disables the abrt plugin
 #
-# $group::                      group owner of the configuration file
-#
 # $listen_on::                  Proxy feature listens on http, https, or both
 #
 # $version::                    plugin package version, it's passed to ensure parameter of package resource
@@ -36,7 +34,6 @@ class foreman_proxy::plugin::abrt (
   Boolean $enabled = true,
   Foreman_proxy::ListenOn $listen_on = 'https',
   Optional[String] $version = undef,
-  Optional[String] $group = undef,
   Stdlib::Absolutepath $abrt_send_log_file = '/var/log/foreman-proxy/abrt-send.log',
   Stdlib::Absolutepath $spooldir = '/var/spool/foreman-proxy-abrt',
   Boolean $aggregate_reports = true,
@@ -52,7 +49,6 @@ class foreman_proxy::plugin::abrt (
   -> foreman_proxy::settings_file { 'abrt':
     template_path => 'foreman_proxy/plugin/abrt.yml.erb',
     feature       => 'Abrt',
-    group         => $group,
     listen_on     => $listen_on,
     enabled       => $enabled,
   }

--- a/manifests/plugin/chef.pp
+++ b/manifests/plugin/chef.pp
@@ -21,8 +21,6 @@
 #
 # $enabled::      enables/disables the chef plugin
 #
-# $group::        group owner of the configuration file
-#
 # $listen_on::    Proxy feature listens on http, https, or both
 #
 # $version::      plugin package version, it's passed to ensure parameter of package resource
@@ -32,7 +30,6 @@ class foreman_proxy::plugin::chef (
   Boolean $enabled = $::foreman_proxy::plugin::chef::params::enabled,
   Foreman_proxy::ListenOn $listen_on = $::foreman_proxy::plugin::chef::params::listen_on,
   Optional[String] $version = $::foreman_proxy::plugin::chef::params::version,
-  Optional[String] $group = $::foreman_proxy::plugin::chef::params::group,
   Stdlib::HTTPUrl $server_url = $::foreman_proxy::plugin::chef::params::server_url,
   String $client_name = $::foreman_proxy::plugin::chef::params::client_name,
   Stdlib::Absolutepath $private_key = $::foreman_proxy::plugin::chef::params::private_key,
@@ -46,7 +43,6 @@ class foreman_proxy::plugin::chef (
     listen_on     => $listen_on,
     enabled       => $enabled,
     feature       => 'Chef',
-    group         => $group,
     template_path => 'foreman_proxy/plugin/chef.yml.erb',
   }
 }

--- a/manifests/plugin/chef/params.pp
+++ b/manifests/plugin/chef/params.pp
@@ -4,7 +4,6 @@ class foreman_proxy::plugin::chef::params {
   include ::foreman_proxy::params
 
   $enabled      = true
-  $group        = undef
   $listen_on    = 'https'
   $version      = undef
   $server_url   = "https://${::fqdn}"

--- a/manifests/plugin/monitoring.pp
+++ b/manifests/plugin/monitoring.pp
@@ -12,8 +12,6 @@
 #
 # $enabled::            enables/disables the monitoring plugin
 #
-# $group::              owner of plugin configuration
-#
 # $listen_on::          proxy feature listens on http, https, or both
 #
 # $version::            plugin package version, it's passed to ensure parameter of package resource
@@ -21,7 +19,6 @@
 #
 class foreman_proxy::plugin::monitoring (
   Boolean $enabled = true,
-  Optional[String] $group = undef,
   Foreman_proxy::ListenOn $listen_on = 'https',
   Array[String] $providers = ['icinga2'],
   Optional[String] $version = undef,
@@ -32,7 +29,6 @@ class foreman_proxy::plugin::monitoring (
   }
   -> foreman_proxy::settings_file { 'monitoring':
     template_path => 'foreman_proxy/plugin/monitoring.yml.erb',
-    group         => $group,
     enabled       => $enabled,
     feature       => 'Monitoring',
     listen_on     => $listen_on,

--- a/manifests/plugin/omaha.pp
+++ b/manifests/plugin/omaha.pp
@@ -14,8 +14,6 @@
 #
 # $enabled::            enables/disables the omaha plugin
 #
-# $group::              owner of plugin configuration
-#
 # $listen_on::          proxy feature listens on http, https, or both
 #
 # $version::            plugin package version, it's passed to ensure parameter of package resource
@@ -23,7 +21,6 @@
 #
 class foreman_proxy::plugin::omaha (
   Boolean $enabled = true,
-  Optional[String] $group = undef,
   Foreman_proxy::ListenOn $listen_on = 'https',
   Stdlib::Absolutepath $contentpath = '/var/lib/foreman-proxy/omaha/content',
   Integer[0] $sync_releases = 2,
@@ -35,7 +32,6 @@ class foreman_proxy::plugin::omaha (
   }
   -> foreman_proxy::settings_file { 'omaha':
     template_path => 'foreman_proxy/plugin/omaha.yml.erb',
-    group         => $group,
     enabled       => $enabled,
     feature       => 'Omaha',
     listen_on     => $listen_on,

--- a/manifests/plugin/pulp.pp
+++ b/manifests/plugin/pulp.pp
@@ -6,8 +6,6 @@
 #
 # $enabled::            enables/disables the pulp plugin
 #
-# $group::              group owner of the configuration file
-#
 # $listen_on::          proxy feature listens on http, https, or both
 #
 # $version::            plugin package version, it's passed to ensure parameter of package resource
@@ -42,7 +40,6 @@ class foreman_proxy::plugin::pulp (
   Stdlib::HTTPUrl $pulpcore_content_url = $::foreman_proxy::plugin::pulp::params::pulpcore_content_url,
   Boolean $pulpcore_mirror = $::foreman_proxy::plugin::pulp::params::pulpcore_mirror,
   Optional[String] $version = $::foreman_proxy::plugin::pulp::params::version,
-  Optional[String] $group = $::foreman_proxy::plugin::pulp::params::group,
   Stdlib::HTTPUrl $pulp_url = $::foreman_proxy::plugin::pulp::params::pulp_url,
   Stdlib::Absolutepath $pulp_dir = $::foreman_proxy::plugin::pulp::params::pulp_dir,
   Stdlib::Absolutepath $pulp_content_dir = $::foreman_proxy::plugin::pulp::params::pulp_content_dir,
@@ -57,19 +54,16 @@ class foreman_proxy::plugin::pulp (
   -> [
     foreman_proxy::settings_file { 'pulp':
       template_path => 'foreman_proxy/plugin/pulp.yml.erb',
-      group         => $group,
       enabled       => $enabled,
       listen_on     => $listen_on,
     },
     foreman_proxy::settings_file { 'pulpnode':
       template_path => 'foreman_proxy/plugin/pulpnode.yml.erb',
-      group         => $group,
       enabled       => $pulpnode_enabled,
       listen_on     => $listen_on,
     },
     foreman_proxy::settings_file { 'pulpcore':
       template_path => 'foreman_proxy/plugin/pulpcore.yml.erb',
-      group         => $group,
       enabled       => $pulpcore_enabled,
       listen_on     => $listen_on,
     },

--- a/manifests/plugin/pulp/params.pp
+++ b/manifests/plugin/pulp/params.pp
@@ -4,7 +4,6 @@ class foreman_proxy::plugin::pulp::params {
   $enabled              = true
   $listen_on            = 'https'
   $version              = undef
-  $group                = undef
   $pulpnode_enabled     = false
   $pulpcore_enabled     = false
   $pulpcore_mirror      = false

--- a/manifests/plugin/realm/ad.pp
+++ b/manifests/plugin/realm/ad.pp
@@ -18,8 +18,6 @@
 #
 # === Advanced parameters:
 #
-# $group::                  owner of plugin configuration
-#
 # $version::                 plugin package version, it's passed to ensure parameter of package resource
 #                            can be set to specific version number, 'latest', 'present' etc.
 #
@@ -30,7 +28,6 @@ class foreman_proxy::plugin::realm::ad (
   Optional[String] $computername_prefix = undef,
   Optional[Boolean] $computername_hash = undef,
   Optional[Boolean] $computername_use_fqdn = undef,
-  Optional[String] $group = undef,
   Optional[String] $version = undef,
 ) {
   foreman_proxy::plugin { 'realm_ad_plugin':
@@ -39,6 +36,5 @@ class foreman_proxy::plugin::realm::ad (
   -> foreman_proxy::settings_file { 'realm_ad':
     module        => false,
     template_path => 'foreman_proxy/plugin/realm_ad.yml.erb',
-    group         => $group,
   }
 }

--- a/manifests/plugin/salt.pp
+++ b/manifests/plugin/salt.pp
@@ -24,8 +24,6 @@
 #
 # $enabled::         Enables/disables the salt plugin
 #
-# $group::           Owner of plugin configuration
-#
 # $listen_on::       Proxy feature listens on https, http, or both
 #
 class foreman_proxy::plugin::salt (
@@ -33,7 +31,6 @@ class foreman_proxy::plugin::salt (
   Boolean $enabled = $::foreman_proxy::plugin::salt::params::enabled,
   Foreman_proxy::ListenOn $listen_on = $::foreman_proxy::plugin::salt::params::listen_on,
   String $user = $::foreman_proxy::plugin::salt::params::user,
-  Optional[String] $group = $::foreman_proxy::plugin::salt::params::group,
   Boolean $api = $::foreman_proxy::plugin::salt::params::api,
   Stdlib::HTTPUrl $api_url = $::foreman_proxy::plugin::salt::params::api_url,
   String $api_auth = $::foreman_proxy::plugin::salt::params::api_auth,
@@ -47,7 +44,6 @@ class foreman_proxy::plugin::salt (
     enabled       => $enabled,
     listen_on     => $listen_on,
     template_path => 'foreman_proxy/plugin/salt.yml.erb',
-    group         => $group,
     feature       => 'Salt',
   }
 }

--- a/manifests/plugin/salt/params.pp
+++ b/manifests/plugin/salt/params.pp
@@ -7,7 +7,6 @@ class foreman_proxy::plugin::salt::params {
   $listen_on     = 'https'
   $autosign_file = "${foreman_proxy::params::etc}/salt/autosign.conf"
   $user          = 'root'
-  $group         = undef
 
   $api           = false
   $api_url       = 'https://localhost:8080'

--- a/spec/classes/foreman_proxy__plugin__abrt_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__abrt_spec.rb
@@ -20,20 +20,6 @@ describe 'foreman_proxy::plugin::abrt' do
         end
       end
 
-      describe 'with group overridden' do
-        let :params do {
-          :group => 'example',
-        } end
-
-        it 'should change abrt.yml group' do
-          should contain_file('/etc/foreman-proxy/settings.d/abrt.yml').
-            with({
-              :owner   => 'root',
-              :group   => 'example'
-            })
-        end
-      end
-
       describe 'with faf_ssl_* set' do
         let :params do {
           :faf_server_ssl_cert => '/faf_cert.pem',

--- a/spec/classes/foreman_proxy__plugin__monitoring_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__monitoring_spec.rb
@@ -32,23 +32,6 @@ describe 'foreman_proxy::plugin::monitoring' do
             with_content(/collect_status: false/)
         end
       end
-
-      describe 'with group overridden' do
-        let :pre_condition do
-          "include foreman_proxy"
-        end
-        let :params do {
-          :group => 'example',
-        } end
-
-        it 'should change monitoring.yml group' do
-          should contain_file('/etc/foreman-proxy/settings.d/monitoring.yml').
-            with({
-              :owner   => 'root',
-              :group   => 'example'
-            })
-        end
-      end
     end
   end
 end

--- a/spec/classes/foreman_proxy__plugin__omaha_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__omaha_spec.rb
@@ -35,20 +35,6 @@ describe 'foreman_proxy::plugin::omaha' do
           ])
         end
       end
-
-      describe 'with group overridden' do
-        let :params do {
-          :group => 'example',
-        } end
-
-        it 'should change omaha.yml group' do
-          should contain_file('/etc/foreman-proxy/settings.d/omaha.yml').
-            with({
-              :owner   => 'root',
-              :group   => 'example'
-            })
-        end
-      end
     end
   end
 end

--- a/spec/classes/foreman_proxy__plugin__pulp_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__pulp_spec.rb
@@ -69,7 +69,6 @@ describe 'foreman_proxy::plugin::pulp' do
       describe 'with overrides' do
         let :params do
           {
-            group: 'example',
             pulpnode_enabled: true,
             pulpcore_enabled: true,
             pulpcore_mirror: true,
@@ -87,10 +86,6 @@ describe 'foreman_proxy::plugin::pulp' do
         it { is_expected.to contain_foreman_proxy__plugin('pulp') }
 
         it 'should configure pulp.yml' do
-          is_expected.to contain_file("#{etc_dir}/foreman-proxy/settings.d/pulp.yml")
-            .with_owner('root')
-            .with_group('example')
-
           verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/pulp.yml", [
                                   '---',
                                   ':enabled: https',
@@ -103,11 +98,6 @@ describe 'foreman_proxy::plugin::pulp' do
         end
 
         it 'should configure pulpnode.yml' do
-          is_expected.to contain_file("#{etc_dir}/foreman-proxy/settings.d/pulpnode.yml")
-            .with_ensure('file')
-            .with_owner('root')
-            .with_group('example')
-
           verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/pulpnode.yml", [
                                   '---',
                                   ':enabled: https',
@@ -120,11 +110,6 @@ describe 'foreman_proxy::plugin::pulp' do
         end
 
         it 'should configure pulpcore.yml' do
-          is_expected.to contain_file("#{etc_dir}/foreman-proxy/settings.d/pulpcore.yml")
-            .with_ensure('file')
-            .with_owner('root')
-            .with_group('example')
-
           verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/pulpcore.yml", [
                                   '---',
                                   ':enabled: https',

--- a/spec/classes/foreman_proxy__plugin__realm__ad_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__realm__ad_spec.rb
@@ -51,22 +51,6 @@ describe 'foreman_proxy::plugin::realm::ad' do
           ])
         end
       end
-
-      describe 'with group overridden' do
-        let :params do {
-          :group => 'example',
-          :realm => 'EXAMPLE.COM',
-          :domain_controller => 'dc.example.com'
-        } end
-
-        it 'should change realm_ad.yml group' do
-          should contain_file('/etc/foreman-proxy/settings.d/realm_ad.yml').
-            with({
-              :owner   => 'root',
-              :group   => 'example'
-            })
-        end
-      end
     end
   end
 end

--- a/spec/classes/foreman_proxy__plugin__salt_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__salt_spec.rb
@@ -44,20 +44,6 @@ describe 'foreman_proxy::plugin::salt' do
             with_content(/:saltfile: \/etc\/salt\/Saltfile/)
         end
       end
-
-      describe 'with group overridden' do
-        let :params do {
-          :group => 'example',
-        } end
-
-        it 'should change salt.yml group' do
-          should contain_file('/etc/foreman-proxy/settings.d/salt.yml').
-            with({
-              :owner   => 'root',
-              :group   => 'example'
-            })
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
Setting the group can be useful if other processes need to read the file, but for foreman-proxy this is not the case.