### PR TITLE
Use $f_p::plugin::dynflow::external_core

### DIFF
--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -73,7 +73,7 @@ class foreman_proxy::plugin::ansible (
     template_path => 'foreman_proxy/plugin/ansible.yml.erb',
   }
 
-  if $::osfamily == 'RedHat' and $::operatingsystem != 'Fedora' {
+  if $foreman_proxy::plugin::dynflow::external_core {
     Foreman_proxy::Settings_file['ansible'] ~> Service['smart_proxy_dynflow_core']
   }
 }

--- a/manifests/plugin/dynflow.pp
+++ b/manifests/plugin/dynflow.pp
@@ -52,8 +52,7 @@ class foreman_proxy::plugin::dynflow (
     template_path => 'foreman_proxy/plugin/dynflow.yml.erb',
   }
 
-  if $facts['osfamily'] == 'RedHat' {
-
+  if $external_core {
     foreman_proxy::plugin { 'dynflow_core':
     }
     ~> file { '/etc/smart_proxy_dynflow_core/settings.yml':

--- a/manifests/plugin/remote_execution/ssh.pp
+++ b/manifests/plugin/remote_execution/ssh.pp
@@ -102,7 +102,7 @@ class foreman_proxy::plugin::remote_execution::ssh (
     }
   }
 
-  if $::osfamily == 'RedHat' and $::operatingsystem != 'Fedora' {
+  if $foreman_proxy::plugin::dynflow::external_core {
     if $ssh_kerberos_auth {
       Package[$kerberos_pkg] ~> Service['smart_proxy_dynflow_core']
     }

--- a/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
@@ -7,7 +7,7 @@ describe 'foreman_proxy::plugin::dynflow' do
       let(:pre_condition) { 'include foreman_proxy' }
       let(:etc_dir) { ['FreeBSD', 'DragonFly'].include?(facts[:osfamily]) ? '/usr/local/etc' : '/etc' }
 
-      has_core = facts[:osfamily] == 'RedHat' && facts[:operatingsystem] != 'Fedora'
+      has_core = facts[:osfamily] == 'RedHat'
 
       describe 'with default settings' do
         it { should compile.with_all_deps }
@@ -69,55 +69,67 @@ describe 'foreman_proxy::plugin::dynflow' do
           :ssl_disabled_ciphers  => ['NULL-MD5', 'NULL-SHA'],
           :tls_disabled_versions => ['1.1'],
           :open_file_limit       => 8000,
-          :external_core         => false,
+          :external_core         => true,
         } end
 
         it { should compile.with_all_deps }
         it { should contain_foreman_proxy__plugin('dynflow') }
 
-        if has_core
-          it 'should create settings.d symlink' do
-            should contain_file("#{etc_dir}/smart_proxy_dynflow_core/settings.d").
-              with_ensure('link').with_target("#{etc_dir}/foreman-proxy/settings.d")
-          end
+        it 'should create settings.d symlink' do
+          should contain_file("#{etc_dir}/smart_proxy_dynflow_core/settings.d").
+            with_ensure('link').with_target("#{etc_dir}/foreman-proxy/settings.d")
+        end
 
-          it 'should create systemd service limits' do
-            should contain_systemd__service_limits('smart_proxy_dynflow_core.service').
-              with_limits({'LimitNOFILE' => 8000}).that_notifies('Service[smart_proxy_dynflow_core]')
-          end
+        it 'should create systemd service limits' do
+          should contain_systemd__service_limits('smart_proxy_dynflow_core.service').
+            with_limits({'LimitNOFILE' => 8000}).that_notifies('Service[smart_proxy_dynflow_core]')
+        end
 
-          it 'should generate correct dynflow core settings.yml' do
-            verify_exact_contents(catalogue, "#{etc_dir}/smart_proxy_dynflow_core/settings.yml", [
-              '---',
-              ':database: /var/lib/foreman-proxy/dynflow/dynflow.sqlite',
-              ':console_auth: true',
-              ':foreman_url: https://foo.example.com',
-              ':listen: "*"',
-              ':port: 8008',
-              ':use_https: true',
-              ':ssl_ca_file: /var/lib/puppet/ssl/certs/ca.pem',
-              ':ssl_certificate: /var/lib/puppet/ssl/certs/foo.example.com.pem',
-              ':ssl_private_key: /var/lib/puppet/ssl/private_keys/foo.example.com.pem',
-              ':ssl_disabled_ciphers: ["NULL-MD5", "NULL-SHA"]',
-              ':tls_disabled_versions: ["1.1"]',
-            ])
-          end
+        it 'should generate correct dynflow core settings.yml' do
+          verify_exact_contents(catalogue, "#{etc_dir}/smart_proxy_dynflow_core/settings.yml", [
+            '---',
+            ':database: /var/lib/foreman-proxy/dynflow/dynflow.sqlite',
+            ':console_auth: true',
+            ':foreman_url: https://foo.example.com',
+            ':listen: "*"',
+            ':port: 8008',
+            ':use_https: true',
+            ':ssl_ca_file: /var/lib/puppet/ssl/certs/ca.pem',
+            ':ssl_certificate: /var/lib/puppet/ssl/certs/foo.example.com.pem',
+            ':ssl_private_key: /var/lib/puppet/ssl/private_keys/foo.example.com.pem',
+            ':ssl_disabled_ciphers: ["NULL-MD5", "NULL-SHA"]',
+            ':tls_disabled_versions: ["1.1"]',
+          ])
+        end
 
-          it 'should generate correct dynflow.yml' do
-            verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/dynflow.yml", [
-              '---',
-              ':enabled: https',
-              ':database: /var/lib/foreman-proxy/dynflow/dynflow.sqlite',
-              ':core_url: https://foo.example.com:8008',
-              ':external_core: false',
-            ])
-          end
-        else
-          it { should_not contain_foreman_proxy__plugin('dynflow_core') }
-          it { should_not contain_file("#{etc_dir}/smart_proxy_dynflow_core/settings.d") }
-          it { should_not contain_file("#{etc_dir}/smart_proxy_dynflow_core/settings.yml") }
-          it { should_not contain_service('smart_proxy_dynflow_core') }
-          it { should_not contain_systemd__service_limits('smart_proxy_dynflow_core.service') }
+        it 'should generate correct dynflow.yml' do
+          verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/dynflow.yml", [
+            '---',
+            ':enabled: https',
+            ':database: /var/lib/foreman-proxy/dynflow/dynflow.sqlite',
+            ':core_url: https://foo.example.com:8008',
+            ':external_core: true',
+          ])
+        end
+      end
+
+      describe 'without external_core' do
+        let(:params) { { external_core: false } }
+
+        it { should_not contain_foreman_proxy__plugin('dynflow_core') }
+        it { should_not contain_file("#{etc_dir}/smart_proxy_dynflow_core/settings.d") }
+        it { should_not contain_file("#{etc_dir}/smart_proxy_dynflow_core/settings.yml") }
+        it { should_not contain_service('smart_proxy_dynflow_core') }
+        it { should_not contain_systemd__service_limits('smart_proxy_dynflow_core.service') }
+
+        it 'should generate correct dynflow.yml' do
+          verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/dynflow.yml", [
+            '---',
+            ':enabled: https',
+            ':database: ',
+            ':core_url: https://foo.example.com:8008',
+            ':external_core: false',
+          ])
         end
       end
     end


### PR DESCRIPTION
Since 5bde9c79ca05a7d30fd7ec7a85a109220b4950df there is a variable that explicitly sets the external core. Rather than copying the logic, this reuses the variable.

This should make https://github.com/theforeman/puppet-foreman_proxy/pull/516 easier.