### PR TITLE
Move Ruby package prefix to params

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,10 +7,11 @@ class foreman_proxy::params inherits foreman_proxy::globals {
   case $::osfamily {
     'RedHat': {
       if versioncmp($facts['os']['release']['major'], '7') <= 0 {
-        $plugin_prefix = 'tfm-rubygem-smart_proxy_'
+        $ruby_package_prefix = 'tfm-rubygem-'
       } else {
-        $plugin_prefix = 'rubygem-smart_proxy_'
+        $ruby_package_prefix = 'rubygem-'
       }
+      $plugin_prefix = "${ruby_package_prefix}smart_proxy_"
 
       $dir   = pick($foreman_proxy::globals::dir, '/usr/share/foreman-proxy')
       $etc   = '/etc'
@@ -34,7 +35,8 @@ class foreman_proxy::params inherits foreman_proxy::globals {
       ]
     }
     'Debian': {
-      $plugin_prefix = 'ruby-smart-proxy-'
+      $ruby_package_prefix = 'ruby-'
+      $plugin_prefix = "${ruby_package_prefix}smart-proxy-"
 
       $dir   = pick($foreman_proxy::globals::dir, '/usr/share/foreman-proxy')
       $etc   = '/etc'
@@ -65,7 +67,8 @@ class foreman_proxy::params inherits foreman_proxy::globals {
       ]
     }
     /^(FreeBSD|DragonFly)$/: {
-      $plugin_prefix = 'rubygem-smart_proxy_'
+      $ruby_package_prefix = 'rubygem-'
+      $plugin_prefix = "${ruby_package_prefix}smart_proxy_"
 
       $dir   = pick($foreman_proxy::globals::dir, '/usr/local/share/foreman-proxy')
       $etc   = '/usr/local/etc'

--- a/manifests/plugin/remote_execution/ssh.pp
+++ b/manifests/plugin/remote_execution/ssh.pp
@@ -45,6 +45,7 @@ class foreman_proxy::plugin::remote_execution::ssh (
 
   $ssh_identity_path = "${ssh_identity_dir}/${ssh_identity_file}"
 
+  include foreman_proxy::params
   include ::foreman_proxy::plugin::dynflow
 
   foreman_proxy::plugin { 'remote_execution_ssh':
@@ -56,17 +57,7 @@ class foreman_proxy::plugin::remote_execution::ssh (
   }
 
   if $ssh_kerberos_auth {
-    if $::osfamily == 'RedHat' {
-      if versioncmp($facts['operatingsystemmajrelease'], '8') >= 0 {
-        $ruby_prefix = 'rubygem'
-      } else {
-        $ruby_prefix = 'tfm-rubygem'
-      }
-    } else {
-      $ruby_prefix = 'ruby'
-    }
-
-    $kerberos_pkg = "${ruby_prefix}-net-ssh-krb"
+    $kerberos_pkg = "${foreman_proxy::params::ruby_package_prefix}net-ssh-krb"
     package { $kerberos_pkg:
       ensure => present,
     }


### PR DESCRIPTION
Rather than redefining the package prefix, this introduces the variable in params.pp.