### PR TITLE
add support for flatcar

### DIFF
--- a/manifests/plugin/omaha.pp
+++ b/manifests/plugin/omaha.pp
@@ -19,6 +19,9 @@
 # $version::            plugin package version, it's passed to ensure parameter of package resource
 #                       can be set to specific version number, 'latest', 'present' etc.
 #
+# $distribution::       distribution type, it's passed to specify the distribution type.
+#                       can be set to one of 'coreos' (default), 'flatcar'
+#
 class foreman_proxy::plugin::omaha (
   Boolean $enabled = true,
   Foreman_proxy::ListenOn $listen_on = 'https',
@@ -26,6 +29,7 @@ class foreman_proxy::plugin::omaha (
   Integer[0] $sync_releases = 2,
   Optional[Stdlib::HTTPUrl] $http_proxy = undef,
   Optional[String] $version = undef,
+  Optional[Enum['coreos','flatcar']] $distribution = undef,
 ) {
   foreman_proxy::plugin::module { 'omaha':
     version   => $version,

--- a/templates/plugin/omaha.yml.erb
+++ b/templates/plugin/omaha.yml.erb
@@ -8,3 +8,7 @@
 <%- else -%>
 :proxy: '<%= http_proxy %>'
 <%- end -%>
+<%- distribution = scope.lookupvar('::foreman_proxy::plugin::omaha::distribution') -%>
+<%- unless [nil, :undefined, :undef].include?(distribution) || distribution.empty? -%>
+:distribution: '<%= distribution %>'
+<%- end -%>


### PR DESCRIPTION
The following PR adds support for flatcar linux on the omaha smart proxy:
https://github.com/theforeman/smart_proxy_omaha/pull/21
We should add this as an option to the puppet module too.