### PR TITLE
Drop EPEL in acceptance tests

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -16,5 +16,3 @@ spec/spec_helper.rb:
     - name: sudoversion
       value: 1.8.23
       source: saz-sudo
-spec/spec_helper_acceptance.rb:
-  install_epel: true

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -28,8 +28,6 @@ RSpec.configure do |c|
         on host, 'sed -i "s/keepcache=.*/keepcache=1/" /etc/yum.conf'
         # refresh check if cache needs refresh on next yum command
         on host, 'yum clean expire-cache'
-        # We always need EPEL
-        host.install_package('epel-release')
         # We need SCL as well for dynflow
         if fact_on(host, 'operatingsystem') == 'CentOS'
           host.install_package('centos-release-scl-rh')


### PR DESCRIPTION
With the SCL build of foreman-proxy, I believe this is no longer needed.