### PR TITLE
Remove old Red Hat TFTP install methods

### DIFF
--- a/examples/tftp.pp
+++ b/examples/tftp.pp
@@ -1,0 +1,32 @@
+$directory = '/etc/foreman-proxy'
+$certificate = "${directory}/certificate.pem"
+$key = "${directory}/key.pem"
+
+# Install a proxy
+class { 'foreman_proxy':
+  tftp                => true,
+  puppet_group        => 'root',
+  register_in_foreman => false,
+  ssl_ca              => $certificate,
+  ssl_cert            => $certificate,
+  ssl_key             => $key,
+}
+
+# Create the certificates - this is after the proxy because we need the user variable
+exec { 'Create certificate directory':
+  command => "mkdir -p ${directory}",
+  path    => ['/bin', '/usr/bin'],
+  creates => $directory,
+}
+-> exec { 'Generate certificate':
+  command => "openssl req -nodes -x509 -newkey rsa:2048 -subj '/CN=${facts['networking']['fqdn']}' -keyout '${key}' -out '${certificate}' -days 365",
+  path    => ['/bin', '/usr/bin'],
+  creates => $certificate,
+  umask   => '0022',
+}
+-> file { [$key, $certificate]:
+  owner  => $foreman_proxy::user,
+  group  => $foreman_proxy::user,
+  mode   => '0640',
+  before => Class['foreman_proxy::service'],
+}

--- a/manifests/tftp.pp
+++ b/manifests/tftp.pp
@@ -44,7 +44,9 @@ class foreman_proxy::tftp (
     ensure_packages(['wget'], { ensure => $wget_version, })
   }
 
+  class { 'foreman_proxy::tftp::netboot':
+    root    => $root,
+    require => File[$directories],
+  }
   contain foreman_proxy::tftp::netboot
-
-  File[$directories] -> Class['foreman_proxy::tftp::netboot']
 }

--- a/manifests/tftp/netboot.pp
+++ b/manifests/tftp/netboot.pp
@@ -13,10 +13,10 @@
 #   The root directory to use for grub
 #
 class foreman_proxy::tftp::netboot (
+  Stdlib::Absolutepath $root,
   Array[String] $packages = $foreman_proxy::tftp::netboot::params::packages,
   Enum['redhat', 'debian', 'none'] $grub_installation_type = $foreman_proxy::tftp::netboot::params::grub_installation_type,
   String $grub_modules = $foreman_proxy::tftp::netboot::params::grub_modules,
-  Stdlib::Absolutepath $root = $foreman_proxy::tftp::root,
 ) inherits foreman_proxy::tftp::netboot::params {
   ensure_packages($packages, { ensure => 'present', })
 

--- a/manifests/tftp/netboot/params.pp
+++ b/manifests/tftp/netboot/params.pp
@@ -6,26 +6,8 @@ class foreman_proxy::tftp::netboot::params {
 
   case $facts['os']['family'] {
     'RedHat': {
-      if versioncmp($facts['os']['release']['major'], '6') <= 0 {
-        $grub_installation_type = 'redhat_old'
-        $packages = ['grub']
-      } elsif versioncmp($facts['os']['release']['full'], '7.4') == 0 and $facts['os']['name'] != 'Fedora' {
-        # RHEL 7.4 renamed packages and introduced a regression in the MAC
-        # loading of configs, it was fixed in 7.5
-        # https://bugzilla.redhat.com/show_bug.cgi?id=1483740
-        $grub_installation_type = 'redhat_exec'
-        $packages = ['grub2-efi-x64','grub2-efi-x64-modules','grub2-tools','shim-x64']
-      } elsif versioncmp($facts['os']['release']['full'], '7.4') > 0 and $facts['os']['name'] != 'Fedora' {
-        $grub_installation_type = 'redhat'
-        $packages = ['grub2-efi-x64','grub2-efi-x64-modules','grub2-tools','shim-x64']
-      } elsif versioncmp($facts['os']['release']['full'], '27') >= 0 and $facts['os']['name'] == 'Fedora' {
-        # Fedora 27 started using RHEL7.4 naming scheme for grub2* packages 
-        $grub_installation_type = 'redhat'
-        $packages = ['grub2-efi-x64','grub2-efi-x64-modules','grub2-tools','shim-x64']
-      } else {
-        $grub_installation_type = 'redhat'
-        $packages = ['grub2-efi','grub2-efi-modules','grub2-tools','shim']
-      }
+      $grub_installation_type = 'redhat'
+      $packages = ['grub2-efi-x64','grub2-efi-x64-modules','grub2-tools','shim-x64']
     }
     'Debian': {
       $grub_installation_type = 'debian'

--- a/spec/acceptance/netboot_spec.rb
+++ b/spec/acceptance/netboot_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper_acceptance'
+
+describe 'Scenario: tftp' do
+  before(:context) { purge_installed_packages }
+
+  include_examples 'the example', 'tftp.pp'
+
+  root = fact('os.name') == 'Debian' ? '/srv/tftp' : '/var/lib/tftpboot'
+
+  describe file("#{root}/grub2/boot") do
+    it { should be_symlink }
+    it { should be_linked_to '../boot' }
+  end
+
+  describe 'ensure tftp client is installed' do
+    on hosts, puppet('resource', 'package', 'tftp', 'ensure=installed')
+  end
+
+  describe command("echo get /grub2/grub.cfg /tmp/downloaded_file | tftp #{fact('fqdn')}") do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe file('/tmp/downloaded_file') do
+    it { should be_file }
+    its(:content) { should match(/This file was deployed by Puppet and is under Smart Proxy control/) }
+  end
+end

--- a/spec/classes/foreman_proxy__tftp__netboot_spec.rb
+++ b/spec/classes/foreman_proxy__tftp__netboot_spec.rb
@@ -32,34 +32,22 @@ describe 'foreman_proxy::tftp::netboot' do
         end
         it { should contain_file("/tftproot/grub2/shim.efi").with_ensure('link') }
       elsif facts[:osfamily] == 'RedHat'
-        if facts[:operatingsystemmajrelease].to_i > 6
-          it { is_expected.to contain_class('foreman_proxy::tftp::netboot').with_grub_installation_type('redhat') }
-          it { should contain_package('grub2-efi-x64').with_ensure('present') }
-          it { should contain_package('grub2-efi-x64-modules').with_ensure('present') }
-          it { should contain_package('grub2-tools').with_ensure('present') }
-          it { should contain_package('shim-x64').with_ensure('present') }
+        it { is_expected.to contain_class('foreman_proxy::tftp::netboot').with_grub_installation_type('redhat') }
+        it { should contain_package('grub2-efi-x64').with_ensure('present') }
+        it { should contain_package('grub2-efi-x64-modules').with_ensure('present') }
+        it { should contain_package('grub2-tools').with_ensure('present') }
+        it { should contain_package('shim-x64').with_ensure('present') }
 
-          case facts[:operatingsystem]
-          when /^(RedHat|Scientific|OracleLinux)$/
-            it { should contain_file("/tftproot/grub2/grubx64.efi").with_source('/boot/efi/EFI/redhat/grubx64.efi') }
-            it { should contain_file("/tftproot/grub2/shim.efi").with_source('/boot/efi/EFI/redhat/shim.efi').with_owner('root').with_mode('0644') }
-          when 'Fedora'
-            it { should contain_file("/tftproot/grub2/grubx64.efi").with_source('/boot/efi/EFI/fedora/grubx64.efi') }
-            it { should contain_file("/tftproot/grub2/shim.efi").with_source('/boot/efi/EFI/fedora/shim.efi').with_owner('root').with_mode('0644') }
-          when 'CentOS'
-            it { should contain_file("/tftproot/grub2/grubx64.efi").with_source('/boot/efi/EFI/centos/grubx64.efi') }
-            it { should contain_file("/tftproot/grub2/shim.efi").with_source('/boot/efi/EFI/centos/shim.efi').with_owner('root').with_mode('0644') }
-          end
-        else
-          it { is_expected.to contain_class('foreman_proxy::tftp::netboot').with_grub_installation_type('redhat_old') }
-          it { should contain_package('grub').with_ensure('present') }
-          it { should contain_file('/var/lib/tftpboot/grub/grubx64.efi').with_ensure('file').with_owner('root').with_mode('0644').with_source('/boot/efi/EFI/redhat/grub.efi') }
-
-          if facts[:operatingsystemmajrelease].to_i == 8
-            it { should contain_file('/var/lib/tftpboot/grub/shimx64.efi').with_ensure('link') }
-          else
-            it { should contain_file('/var/lib/tftpboot/grub/shim.efi').with_ensure('link') }
-          end
+        case facts[:operatingsystem]
+        when /^(RedHat|Scientific|OracleLinux)$/
+          it { should contain_file("/tftproot/grub2/grubx64.efi").with_source('/boot/efi/EFI/redhat/grubx64.efi') }
+          it { should contain_file("/tftproot/grub2/shim.efi").with_source('/boot/efi/EFI/redhat/shim.efi').with_owner('root').with_mode('0644') }
+        when 'Fedora'
+          it { should contain_file("/tftproot/grub2/grubx64.efi").with_source('/boot/efi/EFI/fedora/grubx64.efi') }
+          it { should contain_file("/tftproot/grub2/shim.efi").with_source('/boot/efi/EFI/fedora/shim.efi').with_owner('root').with_mode('0644') }
+        when 'CentOS'
+          it { should contain_file("/tftproot/grub2/grubx64.efi").with_source('/boot/efi/EFI/centos/grubx64.efi') }
+          it { should contain_file("/tftproot/grub2/shim.efi").with_source('/boot/efi/EFI/centos/shim.efi').with_owner('root').with_mode('0644') }
         end
       else
         it { is_expected.to contain_class('foreman_proxy::tftp::netboot').with_grub_installation_type('none') }


### PR DESCRIPTION
This module doesn't support EL 6 or < EL 7.5. To verify it does work, an acceptance test is added.

Also explicitly passes in the tftp root since it makes it easier to follow the variable flow.