### PR TITLE
Drop unused MySQL module fixture

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -13,7 +13,6 @@ fixtures:
     dns:      'https://github.com/theforeman/puppet-dns'
     extlib:   'https://github.com/voxpupuli/puppet-extlib'
     foreman:  'https://github.com/theforeman/puppet-foreman'
-    mysql:    'https://github.com/puppetlabs/puppetlabs-mysql'
     puppet:   'https://github.com/theforeman/puppet-puppet'
     redis:    'https://github.com/voxpupuli/puppet-redis'
     stdlib:   'https://github.com/puppetlabs/puppetlabs-stdlib'


### PR DESCRIPTION
c57d7fc64f2fa5a506f8531e482b081491dc7ff0 and possible Foreman itself used this in the past, but is no longer needed.