### PR TITLE
Fixes #29690 - install shimx64.efi and shim.efi

### DIFF
--- a/manifests/tftp/netboot.pp
+++ b/manifests/tftp/netboot.pp
@@ -28,11 +28,6 @@ class foreman_proxy::tftp::netboot (
 
   case $grub_installation_type {
     'redhat': {
-      $shim_file = $facts['os']['release']['major'] ? {
-        '7'     => 'shim.efi',
-        default => 'shimx64.efi'
-      }
-
       $grub_efi_path = $facts['os']['name'] ? {
         /Fedora|CentOS/ => downcase($facts['os']['name']),
         default         => 'redhat',
@@ -43,11 +38,16 @@ class foreman_proxy::tftp::netboot (
         source => "/boot/efi/EFI/${grub_efi_path}/grubx64.efi",
       }
 
-      file { "${root}/grub2/${shim_file}":
+      file { "${root}/grub2/shimx64.efi":
         ensure => file,
-        source => "/boot/efi/EFI/${grub_efi_path}/${shim_file}",
+        source => "/boot/efi/EFI/${grub_efi_path}/shimx64.efi",
         mode   => '0644',
         owner  => 'root',
+      }
+
+      file { "${root}/grub2/shim.efi":
+        ensure => 'link',
+        target => 'shimx64.efi',
       }
     }
     'debian': {
@@ -62,7 +62,12 @@ class foreman_proxy::tftp::netboot (
         owner => 'root',
       }
 
-      file {"${root}/grub2/shim.efi":
+      file { "${root}/grub2/shim.efi":
+        ensure => 'link',
+        target => 'grubx64.efi',
+      }
+
+      file { "${root}/grub2/shimx64.efi":
         ensure => 'link',
         target => 'grubx64.efi',
       }

--- a/spec/classes/foreman_proxy__tftp__netboot_spec.rb
+++ b/spec/classes/foreman_proxy__tftp__netboot_spec.rb
@@ -50,7 +50,7 @@ describe 'foreman_proxy::tftp::netboot' do
           it { should contain_file("/tftproot/grub2/grubx64.efi").with_source('/boot/efi/EFI/centos/grubx64.efi') }
           it { should contain_file("/tftproot/grub2/shimx64.efi").with_source('/boot/efi/EFI/centos/shimx64.efi').with_owner('root').with_mode('0644') }
         end
-        it { should contain_file("/tftproot/grub2/shimx64.efi").with_ensure('link') }
+        it { should contain_file("/tftproot/grub2/shim.efi").with_ensure('link') }
       else
         it { is_expected.to contain_class('foreman_proxy::tftp::netboot').with_grub_installation_type('none') }
         # TODO: check if a warning is emited

--- a/spec/classes/foreman_proxy__tftp__netboot_spec.rb
+++ b/spec/classes/foreman_proxy__tftp__netboot_spec.rb
@@ -30,6 +30,7 @@ describe 'foreman_proxy::tftp::netboot' do
             .with_owner('root')
             .that_requires('Exec[build-grub2-efi-image]')
         end
+        it { should contain_file("/tftproot/grub2/shimx64.efi").with_ensure('link') }
         it { should contain_file("/tftproot/grub2/shim.efi").with_ensure('link') }
       elsif facts[:osfamily] == 'RedHat'
         it { is_expected.to contain_class('foreman_proxy::tftp::netboot').with_grub_installation_type('redhat') }
@@ -41,14 +42,15 @@ describe 'foreman_proxy::tftp::netboot' do
         case facts[:operatingsystem]
         when /^(RedHat|Scientific|OracleLinux)$/
           it { should contain_file("/tftproot/grub2/grubx64.efi").with_source('/boot/efi/EFI/redhat/grubx64.efi') }
-          it { should contain_file("/tftproot/grub2/shim.efi").with_source('/boot/efi/EFI/redhat/shim.efi').with_owner('root').with_mode('0644') }
+          it { should contain_file("/tftproot/grub2/shimx64.efi").with_source('/boot/efi/EFI/redhat/shimx64.efi').with_owner('root').with_mode('0644') }
         when 'Fedora'
           it { should contain_file("/tftproot/grub2/grubx64.efi").with_source('/boot/efi/EFI/fedora/grubx64.efi') }
-          it { should contain_file("/tftproot/grub2/shim.efi").with_source('/boot/efi/EFI/fedora/shim.efi').with_owner('root').with_mode('0644') }
+          it { should contain_file("/tftproot/grub2/shimx64.efi").with_source('/boot/efi/EFI/fedora/shimx64.efi').with_owner('root').with_mode('0644') }
         when 'CentOS'
           it { should contain_file("/tftproot/grub2/grubx64.efi").with_source('/boot/efi/EFI/centos/grubx64.efi') }
-          it { should contain_file("/tftproot/grub2/shim.efi").with_source('/boot/efi/EFI/centos/shim.efi').with_owner('root').with_mode('0644') }
+          it { should contain_file("/tftproot/grub2/shimx64.efi").with_source('/boot/efi/EFI/centos/shimx64.efi').with_owner('root').with_mode('0644') }
         end
+        it { should contain_file("/tftproot/grub2/shimx64.efi").with_ensure('link') }
       else
         it { is_expected.to contain_class('foreman_proxy::tftp::netboot').with_grub_installation_type('none') }
         # TODO: check if a warning is emited


### PR DESCRIPTION
More info in the ticket. I am unable to run tests locally it fails with missing random_password method. Doing a blind test change.