### PR TITLE
replace nsupdate dependency on FreeBSD

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -84,7 +84,7 @@ class foreman_proxy::params inherits foreman_proxy::globals {
       $dhcp_manage_acls = false
 
       $keyfile  = '/usr/local/etc/namedb/rndc.key'
-      $nsupdate = 'bind910'
+      $nsupdate = 'bind-tools'
 
       $tftp_root = '/tftpboot'
       $tftp_syslinux_filenames = [

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -624,7 +624,7 @@ describe 'foreman_proxy' do
           when 'RedHat'
             'bind-utils'
           when 'FreeBSD', 'DragonFly'
-            'bind910'
+            'bind-tools'
           else
             'dnsutils'
           end


### PR DESCRIPTION
The old FreeBSD port `bind910` is no longer available. The `nsupdate` tool is also available in the `bind-tools` port, which should be preferred over the full BIND distribution (which is available as `bind916`).