### PR TITLE
Fixes #30072 - update grub default template

### DIFF
--- a/files/grub.cfg
+++ b/files/grub.cfg
@@ -1,35 +1,11 @@
-# This file was deployed by Puppet and is under Smart Proxy control. Click on
-# "Build PXE Default" button to overwrite it. Puppet is prevented from managing this
-# file by default, this can be enforced via --foreman-proxy-tftp-replace-grub2-cfg
-# foreman-installer option or Puppet parameter.
-
-insmod regexp
-
-# On Debian/Ubuntu grub2 does not have patch for loading MAC-based configs. Also, due to a bug
-# in RHEL 7.4, files are loaded with an extra ":" character at the end. This works around both
-# cases, and makes sure "regexp.mod" file is present on the TFTP server. For more info see:
-# https://bugzilla.redhat.com/show_bug.cgi?id=1370642#c70
-regexp --set=1:m1 --set=2:m2 --set=3:m3 --set=4:m4 --set=5:m5 --set=6:m6 '^([0-9a-f]{1,2})\:([0-9a-f]{1,2})\:([0-9a-f]{1,2})\:([0-9a-f]{1,2})\:([0-9a-f]{1,2})\:([0-9a-f]{1,2})' "$net_default_mac"
-mac=${m1}-${m2}-${m3}-${m4}-${m5}-${m6}
-configfile=/grub2/grub.cfg-01-$mac
-source "$configfile"
-
-# If MAC-specific config is not found, attempt to boot from local drive.
-
-default=local_chain_hd0
-timeout=20
-
-menuentry 'Chainload into BIOS bootloader on first disk' --id local_chain_hd0 {
-  set root=(hd0,0)
-  chainloader +1
-}
-
-menuentry 'Chainload into BIOS bootloader on second disk' --id local_chain_hd1 {
-  set root=(hd1,0)
-  chainloader +1
-}
-
-menuentry 'Third disk - for EFI or Discovery click on Build PXE Default'' --id local_chain_hd2 {
-  set root=(hd2,0)
-  chainloader +1
-}
+echo "This system was not recognized by Foreman."
+echo ""
+echo "Click on 'Build PXE Default' in the Foreman interface"
+echo "to create the default global grub.cfg configuration."
+echo ""
+echo "The system will attempt to chainload from first HDD"
+echo "in 10 minutes..."
+echo ""
+sleep 600
+set root=(hd0,0)
+chainloader +1

--- a/spec/acceptance/netboot_spec.rb
+++ b/spec/acceptance/netboot_spec.rb
@@ -22,6 +22,6 @@ describe 'Scenario: tftp' do
 
   describe file('/tmp/downloaded_file') do
     it { should be_file }
-    its(:content) { should match(/This file was deployed by Puppet and is under Smart Proxy control/) }
+    its(:content) { should match(/This system was not recognized by Foreman/) }
   end
 end


### PR DESCRIPTION
This happened now the third time and it took us to figure it out. Our installer deploys a copy of "PXEGrub2 global default" template which is susppoed to be overwirten after Build PXE default is clicked. However we never keep it up to date and we are getting feedback that "sometimes" the default template does not work well as we change it over the releases.

This is the definitive solution to this - users are asked to click on the button before they attempt to boot unknown hosts. This solves the issue (the template does not work for UEFI HTTP booted hosts) and prevents from this in the future.