### PR TITLE
Fixes #30121 - Generate SSH keys in PEM format

### DIFF
--- a/manifests/plugin/remote_execution/ssh.pp
+++ b/manifests/plugin/remote_execution/ssh.pp
@@ -69,7 +69,7 @@ class foreman_proxy::plugin::remote_execution::ssh (
       mode   => '0700',
     }
     -> exec { 'generate_ssh_key':
-      command => "${ssh_keygen} -f ${ssh_identity_path} -N ''",
+      command => "${ssh_keygen} -f ${ssh_identity_path} -N '' -m pem",
       user    => $foreman_proxy::user,
       cwd     => $ssh_identity_dir,
       creates => $ssh_identity_path,

--- a/spec/classes/foreman_proxy__plugin__remote_execution__ssh_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__remote_execution__ssh_spec.rb
@@ -25,7 +25,7 @@ describe 'foreman_proxy::plugin::remote_execution::ssh' do
 
         it 'should configure ssh key' do
           should contain_exec('generate_ssh_key').
-            with_command("/usr/bin/ssh-keygen -f /var/lib/foreman-proxy/ssh/id_rsa_foreman_proxy -N ''")
+            with_command("/usr/bin/ssh-keygen -f /var/lib/foreman-proxy/ssh/id_rsa_foreman_proxy -N '' -m pem")
         end
 
         it { should_not contain_file('/root/.ssh') }


### PR DESCRIPTION
On EL8 the keys get generated in RFC4716 format which doesn't play well with the version of net-ssh we currently ship.