### PR TITLE
Fixes #30198 - Disable TFTP by default

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -226,7 +226,7 @@ class foreman_proxy::params inherits foreman_proxy::globals {
   $httpboot_listen_on = 'both'
 
   # TFTP settings - requires optional TFTP puppet module
-  $tftp                   = true
+  $tftp                   = false
   $tftp_listen_on         = 'https'
   $tftp_managed           = true
   $tftp_manage_wget       = true

--- a/spec/classes/foreman_proxy__register__spec.rb
+++ b/spec/classes/foreman_proxy__register__spec.rb
@@ -44,7 +44,7 @@ describe 'foreman_proxy::register' do
           before { subject.resource('Datacat_collector[foreman_proxy::enabled_features]').provider.exists? }
 
           it 'should populate features on foreman_smartproxy' do
-            expect(subject.resource("Foreman_smartproxy[#{facts[:fqdn]}]").parameters[:features].should.sort).to match_array(["HTTPBoot", "Logs", "Puppet", "Puppet CA", "TFTP"])
+            expect(subject.resource("Foreman_smartproxy[#{facts[:fqdn]}]").parameters[:features].should.sort).to match_array(["Logs", "Puppet", "Puppet CA"])
           end
         end
       end


### PR DESCRIPTION
Not all installations require TFTP. This is only needed when doing kickstart/preseed/... installations. Typically that's bare metal but can be used on virtual machines as well. Doing those kind of installations also requires DHCP so disabling it is not a huge extra step.