### PR TITLE
Fixes #30240 - compat with theforeman/dns 8.x

### DIFF
--- a/examples/dns.pp
+++ b/examples/dns.pp
@@ -1,0 +1,34 @@
+$directory = '/etc/foreman-proxy'
+$certificate = "${directory}/certificate.pem"
+$key = "${directory}/key.pem"
+
+# Install a proxy
+class { 'foreman_proxy':
+  puppet_group        => 'root',
+  register_in_foreman => false,
+  ssl_ca              => $certificate,
+  ssl_cert            => $certificate,
+  ssl_key             => $key,
+  dns                 => true,
+  dns_zone            => 'example.com',
+  dns_reverse         => '2.0.192.in-addr.arpa',
+}
+
+# Create the certificates - this is after the proxy because we need the user variable
+exec { 'Create certificate directory':
+  command => "mkdir -p ${directory}",
+  path    => ['/bin', '/usr/bin'],
+  creates => $directory,
+}
+-> exec { 'Generate certificate':
+  command => "openssl req -nodes -x509 -newkey rsa:2048 -subj '/CN=${facts['networking']['fqdn']}' -keyout '${key}' -out '${certificate}' -days 365",
+  path    => ['/bin', '/usr/bin'],
+  creates => $certificate,
+  umask   => '0022',
+}
+-> file { [$key, $certificate]:
+  owner  => $foreman_proxy::user,
+  group  => $foreman_proxy::user,
+  mode   => '0640',
+  before => Class['foreman_proxy::service'],
+}

--- a/manifests/proxydns.pp
+++ b/manifests/proxydns.pp
@@ -58,17 +58,27 @@ class foreman_proxy::proxydns(
     }
   }
 
+  $update_policy = {
+    'rndc-key' => {
+      'action'    => 'grant',
+      'matchtype' => 'zonesub',
+      'rr'        => 'ANY',
+    },
+  }
+
   dns::zone { $forward_zone:
-    soa     => $soa,
-    reverse => false,
-    soaip   => $ip,
-    soaipv6 => $ip6,
+    soa           => $soa,
+    reverse       => false,
+    soaip         => $ip,
+    soaipv6       => $ip6,
+    update_policy => $update_policy,
   }
 
   if $reverse {
     dns::zone { $reverse:
-      soa     => $soa,
-      reverse => true,
+      soa           => $soa,
+      reverse       => true,
+      update_policy => $update_policy,
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
   "dependencies": [
     {
       "name": "theforeman/dns",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     },
     {
       "name": "theforeman/dhcp",

--- a/spec/acceptance/dns_spec.rb
+++ b/spec/acceptance/dns_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper_acceptance'
+
+# On EL bind runs using PIDFile in systemd which is broken under docker
+broken_pid_file = ENV['BEAKER_HYPERVISOR'] == 'docker' && host_inventory['facter']['os']['family'] == 'RedHat'
+describe 'Scenario: install foreman-proxy', unless: broken_pid_file do
+  before(:context) { purge_installed_packages }
+
+  include_examples 'the example', 'dns.pp'
+
+  it_behaves_like 'the default foreman proxy application'
+
+  describe port(53) do
+    it { is_expected.to be_listening }
+  end
+
+  cert_dir = '/etc/foreman-proxy'
+
+  context 'forward dns' do
+    describe command('dig +short SOA example.com @localhost') do
+      its(:stdout) { is_expected.to match(/#{host_inventory['fqdn']}\. root\.example\.com\. \d+ 86400 3600 604800 3600\n/) }
+    end
+
+    describe command("curl --cacert #{cert_dir}/certificate.pem --cert #{cert_dir}/certificate.pem --key #{cert_dir}/key.pem https://$(hostname -f):8443/dns -X POST -d fqdn=integration.example.com -d value=192.0.2.100 -d type=A -s -w '%{http_code}'") do
+      its(:stdout) { should eq('200') }
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe command('dig +short A integration.example.com @localhost') do
+      its(:stdout) { is_expected.to eq("192.0.2.100\n") }
+    end
+
+    describe command("curl --cacert #{cert_dir}/certificate.pem --cert #{cert_dir}/certificate.pem --key #{cert_dir}/key.pem https://$(hostname -f):8443/dns/integration.example.com/A -X DELETE -s -w \'%{http_code}\'") do
+      its(:stdout) { should eq('200') }
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe command('dig +short A integration.example.com @localhost') do
+      its(:stdout) { is_expected.to eq('') }
+    end
+  end
+
+  context 'reverse dns' do
+    describe command('dig +short SOA 2.0.192.in-addr.arpa @localhost') do
+      its(:stdout) { is_expected.to match(/#{host_inventory['fqdn']}\. root\.2\.0\.192\.in-addr\.arpa\. \d+ 86400 3600 604800 3600\n/) }
+    end
+
+    describe command("curl --cacert #{cert_dir}/certificate.pem --cert #{cert_dir}/certificate.pem --key #{cert_dir}/key.pem https://$(hostname -f):8443/dns -X POST -d fqdn=integration.example.com -d value=100.2.0.192.in-addr.arpa -d type=PTR -s -w '%{http_code}'") do
+      its(:stdout) { should eq('200') }
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe command('dig +short -x 192.0.2.100 @localhost') do
+      its(:stdout) { is_expected.to eq("integration.example.com.\n") }
+    end
+
+    describe command("curl --cacert #{cert_dir}/certificate.pem --cert #{cert_dir}/certificate.pem --key #{cert_dir}/key.pem https://$(hostname -f):8443/dns/100.2.0.192.in-addr.arpa/PTR -X DELETE -s -w \'%{http_code}\'") do
+      its(:stdout) { should eq('200') }
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe command('dig +short -x 192.0.2.100 @localhost') do
+      its(:stdout) { is_expected.to eq('') }
+    end
+  end
+end

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,3 +1,13 @@
 class { 'foreman::repo':
   repo => 'nightly',
 }
+
+# This provides dig which we use in our tests
+$dig_package = $facts['os']['family'] ? {
+  'Debian' => 'dnsutils',
+  default  => 'bind-utils',
+}
+
+package { $dig_package:
+  ensure => installed,
+}


### PR DESCRIPTION
dda99d908f38c3e752928a9a2d570280477d581c marked the module as compatible with theforeman/dns 8.x. However, 8.x was a breaking change and no longer automatically grants access to the rndc-key by default. This restores compatibility.

I haven't had a chance to actually test this myself, but pushing this so this can be verified.