### PR TITLE
Drop puppetca_split_configs parameter

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -78,10 +78,7 @@ class foreman_proxy::config {
   contain foreman_proxy::module::puppetca
   foreman_proxy::provider { ['puppetca_hostname_whitelisting', 'puppetca_token_whitelisting']:
   }
-
-  if $foreman_proxy::puppetca_split_configs {
-    foreman_proxy::provider { ['puppetca_http_api', 'puppetca_puppet_cert']:
-    }
+  foreman_proxy::provider { ['puppetca_http_api', 'puppetca_puppet_cert']:
   }
 
   contain foreman_proxy::module::realm

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -292,9 +292,6 @@
 #
 # $httpboot_listen_on::         HTTPBoot proxy to listen on https, http, or both
 #
-# $puppetca_split_configs::     Whether to split the puppetca configs. This is only supported on 1.22+.
-#                               Set to false for older versions.
-#
 # $puppetca_provider::          Whether to use puppetca_hostname_whitelisting or puppetca_token_whitelisting
 #
 # $puppetca_sign_all::          Token-whitelisting only: Whether to sign all CSRs without checking their token
@@ -331,7 +328,6 @@ class foreman_proxy (
   Boolean $use_sudoersd = $foreman_proxy::params::use_sudoersd,
   Boolean $use_sudoers = $foreman_proxy::params::use_sudoers,
   Boolean $puppetca = $foreman_proxy::params::puppetca,
-  Boolean $puppetca_split_configs = $foreman_proxy::params::puppetca_split_configs,
   Foreman_proxy::ListenOn $puppetca_listen_on = $foreman_proxy::params::puppetca_listen_on,
   Stdlib::Absolutepath $ssldir = $foreman_proxy::params::ssldir,
   Stdlib::Absolutepath $puppetdir = $foreman_proxy::params::puppetdir,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -182,7 +182,6 @@ class foreman_proxy::params inherits foreman_proxy::globals {
 
   # puppetca settings
   $puppetca              = true
-  $puppetca_split_configs = true
   $puppetca_provider     = 'puppetca_hostname_whitelisting'
   $puppetca_listen_on    = 'https'
   $puppetca_cmd          = "${puppet_cmd} cert"

--- a/templates/puppetca.yml.erb
+++ b/templates/puppetca.yml.erb
@@ -2,16 +2,11 @@
 # PuppetCA management
 # Can be true, false, or http/https to enable just one of the protocols
 :enabled: <%= @module_enabled %>
-<% unless scope.lookupvar("foreman_proxy::puppetca_split_configs") -%>
-:ssldir: <%= scope.lookupvar("foreman_proxy::ssldir") %>
-<% end -%>
 
 # valid providers:
 #   - puppetca_hostname_whitelisting (verify CSRs based on a hostname whitelist)
 #   - puppetca_token_whitelisting (verify CSRs based on a token whitelist)
 :use_provider: <%= scope.lookupvar("foreman_proxy::puppetca_provider") %>
-<% if scope.lookupvar("foreman_proxy::puppetca_split_configs") -%>
 
 # Puppet version used
 :puppet_version: <%= @puppetversion %>
-<% end -%>


### PR DESCRIPTION
Since module version 13 this module is Foreman 2.0+ which means we must always use split configs. That makes this parameter redundant.