### PR TITLE
don't fail on upcase() when domain fact is undefined

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -411,7 +411,7 @@ class foreman_proxy (
   Boolean $dns_managed = $foreman_proxy::params::dns_managed,
   String $dns_provider = $foreman_proxy::params::dns_provider,
   String $dns_interface = $foreman_proxy::params::dns_interface,
-  String $dns_zone = $foreman_proxy::params::dns_zone,
+  Optional[Stdlib::Fqdn] $dns_zone = $foreman_proxy::params::dns_zone,
   Optional[Variant[String, Array[String]]] $dns_reverse = $foreman_proxy::params::dns_reverse,
   String $dns_server = $foreman_proxy::params::dns_server,
   Integer[0] $dns_ttl = $foreman_proxy::params::dns_ttl,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -275,7 +275,11 @@ class foreman_proxy::params inherits foreman_proxy::globals {
   $dns_provider           = 'nsupdate'
   $dns_interface          = pick(fact('networking.primary'), 'eth0')
   $dns_zone               = $facts['networking']['domain']
-  $dns_realm              = upcase($dns_zone)
+  if $dns_zone {
+    $dns_realm            = upcase($dns_zone)
+  } else {
+    $dns_realm            = undef
+  }
   $dns_reverse            = undef
   # localhost can resolve to ipv6 which ruby doesn't handle well
   $dns_server             = '127.0.0.1'

--- a/manifests/proxydns.pp
+++ b/manifests/proxydns.pp
@@ -21,7 +21,7 @@
 class foreman_proxy::proxydns(
   $forwarders = $foreman_proxy::dns_forwarders,
   $interface = $foreman_proxy::dns_interface,
-  $forward_zone = $foreman_proxy::dns_zone,
+  Stdlib::Fqdn $forward_zone = $foreman_proxy::dns_zone,
   $reverse_zone = $foreman_proxy::dns_reverse,
   String $soa = $facts['networking']['fqdn'],
 ) {


### PR DESCRIPTION
I chose an empty string in case the fact is absent because `upcase()` should be able to handle it. I think this is a valid use because loading default parameters from this module (as in foreman-installer) should not fail, particularly when that parameter should not be used when the relevant feature is disabled.