### PR TITLE
Fixes #30449 - Do not require TFTP for HTTPBoot

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,6 +61,8 @@
 #
 # $ssldir::                     Puppet CA SSL directory
 #
+# $httpboot::                   Enable HTTPBoot feature. In most deployments this requires HTTP to be enabled as well.
+#
 # $puppetdir::                  Puppet var directory
 #
 # $puppetca_cmd::               Puppet CA command to be allowed in sudoers
@@ -272,8 +274,6 @@
 # $dhcp_load_balance::          Cutoff after which load balancing is disabled
 #
 # $dhcp_manage_acls::           Whether to manage DHCP directory ACLs. This allows the Foreman Proxy user to access even if the directory mode is 0750.
-#
-# $httpboot::                   Enable HTTPBoot feature
 #
 # $httpboot_listen_on::         HTTPBoot proxy to listen on https, http, or both
 #

--- a/manifests/module/httpboot.pp
+++ b/manifests/module/httpboot.pp
@@ -6,19 +6,11 @@
 # @param listen_on
 #   Where to listen on.
 class foreman_proxy::module::httpboot (
-  Optional[Boolean] $enabled = $foreman_proxy::httpboot,
+  Boolean $enabled = $foreman_proxy::httpboot,
   Foreman_proxy::ListenOn $listen_on = $foreman_proxy::httpboot_listen_on,
 ) {
-  $real_enabled = pick($enabled, $foreman_proxy::tftp)
-  if $real_enabled {
-    include foreman_proxy::module::tftp
-    unless $foreman_proxy::module::tftp::enabled {
-      fail('The HTTPBoot module depends on the TFTP module to be enabled')
-    }
-  }
-
   foreman_proxy::module { 'httpboot':
-    enabled   => $real_enabled,
+    enabled   => $enabled,
     feature   => 'HTTPBoot',
     listen_on => $listen_on,
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -225,8 +225,8 @@ class foreman_proxy::params inherits foreman_proxy::globals {
   $logs           = true
   $logs_listen_on = 'https'
 
-  # HTTPBoot settings - requires optional httpboot puppet module
-  $httpboot           = undef
+  # HTTPBoot settings
+  $httpboot           = false
   $httpboot_listen_on = 'both'
 
   # TFTP settings - requires optional TFTP puppet module

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -440,7 +440,7 @@ describe 'foreman_proxy' do
         it 'should generate correct httpboot.yml' do
           verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/httpboot.yml", [
             '---',
-            ':enabled: true',
+            ':enabled: false',
             ":root_dir: #{tftp_root}",
           ])
         end


### PR DESCRIPTION
Since Foreman Proxy 1.22 the hard requirement on TFTP is no longer present. This changes the default to always be off, rather than on. This makes sense since in the default deployment HTTP is off and most installations don't support booting over HTTPS.

To get the netboot files, the TFTP feature must still be enabled.

This is still a draft since I'm not sure if we should move the netboot file management to a higher level so you can run the HTTPBoot feature without the TFTP daemon.