### PR TITLE
Fixes #30950 - Enable SmartProxy Registration module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Part of the Foreman installer: <https://github.com/theforeman/foreman-installer>
 | Module version | Proxy versions | Notes                                               |
 |----------------|----------------|-----------------------------------------------------|
 | 16.x           | 2.3 and newer  | See compatibility notes in its README for 2.0-2.2   |
-| 13.x           | 2.0 and newer  |                                                     |
+| 13.x           | 2.0 - 2.2      |                                                     |
 | 12.x           | 1.19 - 1.24    | See compatibility notes in its README for 1.19-1.22 |
 | 11.x           | 1.19 - 1.23    | See compatibility notes in its README for 1.19-1.21 |
 | 10.x           | 1.19 - 1.21    |                                                     |
@@ -23,6 +23,7 @@ Part of the Foreman installer: <https://github.com/theforeman/foreman-installer>
 | 2.x            | 1.5 - 1.10     |                                                     |
 | 1.x            | 1.4 and older  |                                                     |
 
+16.x added support for Smart Proxy Registration feature, available in Smart Proxy 2.3 and newer.
 12.x has dropped support for Puppet 3 which was officially unsupported for a while and Foreman Proxy 1.23 dropped altogether.
 
 ## Examples

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -92,6 +92,8 @@ class foreman_proxy::config {
 
   contain foreman_proxy::module::logs
 
+  contain foreman_proxy::module::registration
+
   if $foreman_proxy::puppetca or $foreman_proxy::puppet {
     $uses_sudo = $foreman_proxy::puppetca and versioncmp($facts['puppetversion'], '6.0') < 0
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,6 +94,10 @@
 #
 # $template_url::               URL a client should use for provisioning templates
 #
+# $registration::               Enable Registration feature
+#
+# $registration_listen_on::     Registration proxy to listen on https, http, or both
+#
 # $logs::                       Enable Logs (log buffer) feature
 #
 # $logs_listen_on::             Logs proxy to listen on https, http, or both
@@ -327,6 +331,8 @@ class foreman_proxy (
   Boolean $templates = $foreman_proxy::params::templates,
   Foreman_proxy::ListenOn $templates_listen_on = $foreman_proxy::params::templates_listen_on,
   Stdlib::HTTPUrl $template_url = $foreman_proxy::params::template_url,
+  Boolean $registration = $foreman_proxy::params::registration,
+  Foreman_proxy::ListenOn $registration_listen_on = $foreman_proxy::params::registration_listen_on,
   Boolean $logs = $foreman_proxy::params::logs,
   Foreman_proxy::ListenOn $logs_listen_on = $foreman_proxy::params::logs_listen_on,
   Optional[Boolean] $httpboot = $foreman_proxy::params::httpboot,

--- a/manifests/module/registration.pp
+++ b/manifests/module/registration.pp
@@ -1,0 +1,17 @@
+# @summary The built in Registration module
+#
+# @param enabled
+#  Whether the module is enabled or disabled.
+#
+# @param listen_on
+#   Where to listen on.
+class foreman_proxy::module::registration (
+  Boolean $enabled = $foreman_proxy::registration,
+  Foreman_proxy::ListenOn $listen_on = $foreman_proxy::registration_listen_on,
+) {
+  foreman_proxy::module { 'registration':
+    enabled   => $enabled,
+    feature   => 'Registration',
+    listen_on => $listen_on,
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -217,6 +217,10 @@ class foreman_proxy::params inherits foreman_proxy::globals {
   $templates_listen_on = 'both'
   $template_url        = "http://${facts['networking']['fqdn']}:${http_port}"
 
+  # Registration settings
+  $registration           = true
+  $registration_listen_on = 'https'
+
   # Logs settings
   $logs           = true
   $logs_listen_on = 'https'

--- a/spec/classes/foreman_proxy__register__spec.rb
+++ b/spec/classes/foreman_proxy__register__spec.rb
@@ -44,7 +44,7 @@ describe 'foreman_proxy::register' do
           before { subject.resource('Datacat_collector[foreman_proxy::enabled_features]').provider.exists? }
 
           it 'should populate features on foreman_smartproxy' do
-            expect(subject.resource("Foreman_smartproxy[#{facts[:fqdn]}]").parameters[:features].should.sort).to match_array(["Logs", "Puppet", "Puppet CA"])
+            expect(subject.resource("Foreman_smartproxy[#{facts[:fqdn]}]").parameters[:features].should.sort).to match_array(["Logs", "Puppet", "Puppet CA", "Registration"])
           end
         end
       end

--- a/templates/registration.yml.erb
+++ b/templates/registration.yml.erb
@@ -1,0 +1,3 @@
+---
+# Enable Registration module
+:enabled: <%= @module_enabled %>


### PR DESCRIPTION
Waiting for: https://github.com/theforeman/smart-proxy/pull/768

---

PR is part of **Simple & automatic host registration WF**, see:
* [RFC](https://community.theforeman.org/t/rfc-simple-automatic-host-registration-wf/19588)
* [Redmine (this PR)](https://projects.theforeman.org/issues/30950)
* [Redmine (Parent task)](https://projects.theforeman.org/issues/30440)
