### PR TITLE
Fixes #30962 - fix dhcpd.conf acl

### DIFF
--- a/manifests/proxydhcp.pp
+++ b/manifests/proxydhcp.pp
@@ -76,8 +76,10 @@ class foreman_proxy::proxydhcp {
       exec { "Allow ${foreman_proxy::user} to read ${path}":
         command => "setfacl -R -m u:${foreman_proxy::user}:rx ${path}",
         path    => ['/bin', '/usr/bin'],
-        unless  => "getfacl -p ${path} | grep user:${foreman_proxy::user}:r-x",
-        require => Package['acl'],
+        require => [
+          Package['acl'],
+          Class['dhcp'],
+        ],
       }
     }
 

--- a/spec/classes/foreman_proxy__proxydhcp__spec.rb
+++ b/spec/classes/foreman_proxy__proxydhcp__spec.rb
@@ -79,8 +79,7 @@ describe 'foreman_proxy' do
           case facts[:osfamily]
           when 'RedHat', 'Debian'
             it do should contain_exec('Allow foreman-proxy to read /etc/dhcp').
-              with_command('setfacl -R -m u:foreman-proxy:rx /etc/dhcp').
-              with_unless('getfacl -p /etc/dhcp | grep user:foreman-proxy:r-x')
+              with_command('setfacl -R -m u:foreman-proxy:rx /etc/dhcp')
             end
           else
             it { should_not contain_exec('Allow foreman-proxy to read /etc/dhcp') }
@@ -89,8 +88,7 @@ describe 'foreman_proxy' do
           case facts[:osfamily]
           when 'RedHat', 'Debian'
             it do should contain_exec("Allow foreman-proxy to read #{leases_dir}").
-              with_command("setfacl -R -m u:foreman-proxy:rx #{leases_dir}").
-              with_unless("getfacl -p #{leases_dir} | grep user:foreman-proxy:r-x")
+              with_command("setfacl -R -m u:foreman-proxy:rx #{leases_dir}")
             end
           else
             it { should_not contain_exec("Allow foreman-proxy to read #{leases_dir}") }


### PR DESCRIPTION
1. Make sure that we explicitly check ACLs for `dhcpd.conf`, because the ACLs are not refreshed, if the `/etc/dhcp/`-directory already has the correct permissions. The most secure way would be to remove the `unless`-statement, so the ACLs are always (re)set recursively :thinking: .
1. Make sure the ACLs are set **after** `dhcp` puppet-module has finished configuration, before setting the ACLs

Probably needs to be cherry-picked into `1.4-stable`-branch.