### PR TITLE
Fixes #30962 - Correct DHCP file permissions

### DIFF
--- a/examples/isc_dhcp.pp
+++ b/examples/isc_dhcp.pp
@@ -1,0 +1,33 @@
+$directory = '/etc/foreman-proxy'
+$certificate = "${directory}/certificate.pem"
+$key = "${directory}/key.pem"
+
+# Install a proxy with ISC DHCP
+class { 'foreman_proxy':
+  dhcp                => true,
+  # Testing options
+  puppet_group        => 'root',
+  register_in_foreman => false,
+  ssl_ca              => $certificate,
+  ssl_cert            => $certificate,
+  ssl_key             => $key,
+}
+
+# Create the certificates - this is after the proxy because we need the user variable
+exec { 'Create certificate directory':
+  command => "mkdir -p ${directory}",
+  path    => ['/bin', '/usr/bin'],
+  creates => $directory,
+}
+-> exec { 'Generate certificate':
+  command => "openssl req -nodes -x509 -newkey rsa:2048 -subj '/CN=${facts['networking']['fqdn']}' -keyout '${key}' -out '${certificate}' -days 365",
+  path    => ['/bin', '/usr/bin'],
+  creates => $certificate,
+  umask   => '0022',
+}
+-> file { [$key, $certificate]:
+  owner  => $foreman_proxy::user,
+  group  => $foreman_proxy::user,
+  mode   => '0640',
+  before => Class['foreman_proxy::service'],
+}

--- a/examples/isc_dhcp_omapi.pp
+++ b/examples/isc_dhcp_omapi.pp
@@ -1,0 +1,35 @@
+$directory = '/etc/foreman-proxy'
+$certificate = "${directory}/certificate.pem"
+$key = "${directory}/key.pem"
+
+# Install a proxy with ISC DHCP
+class { 'foreman_proxy':
+  dhcp                => true,
+  dhcp_key_name       => 'mykey',
+  dhcp_key_secret     => 'Ofakekeyfakekeyfakekey==',
+  # Testing options
+  puppet_group        => 'root',
+  register_in_foreman => false,
+  ssl_ca              => $certificate,
+  ssl_cert            => $certificate,
+  ssl_key             => $key,
+}
+
+# Create the certificates - this is after the proxy because we need the user variable
+exec { 'Create certificate directory':
+  command => "mkdir -p ${directory}",
+  path    => ['/bin', '/usr/bin'],
+  creates => $directory,
+}
+-> exec { 'Generate certificate':
+  command => "openssl req -nodes -x509 -newkey rsa:2048 -subj '/CN=${facts['networking']['fqdn']}' -keyout '${key}' -out '${certificate}' -days 365",
+  path    => ['/bin', '/usr/bin'],
+  creates => $certificate,
+  umask   => '0022',
+}
+-> file { [$key, $certificate]:
+  owner  => $foreman_proxy::user,
+  group  => $foreman_proxy::user,
+  mode   => '0640',
+  before => Class['foreman_proxy::service'],
+}

--- a/spec/acceptance/isc_dhcp_spec.rb
+++ b/spec/acceptance/isc_dhcp_spec.rb
@@ -1,0 +1,138 @@
+require 'spec_helper_acceptance'
+
+describe 'Scenario: install foreman-proxy with ISC DHCP', order: :defined do
+  case fact('os.family')
+  when 'Debian'
+    service_name = 'isc-dhcp-server'
+    leases_file = '/var/lib/dhcp/dhcpd.leases'
+  else
+    service_name = 'dhcpd'
+    leases_file = '/var/lib/dhcpd/dhcpd.leases'
+  end
+
+  context 'default options' do
+    include_examples 'the example', 'isc_dhcp.pp'
+
+    it_behaves_like 'the default foreman proxy application'
+
+    describe file('/etc/dhcp/dhcpd.conf') do
+      it { should be_file }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      it { should be_mode 644 }
+      it { should_not contain(/secret/) }
+    end
+
+    describe service(service_name) do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
+    omshell = <<~COMMAND
+    omshell <<EOF
+    server localhost
+    port 7911
+    connect
+    new host
+    set name = "host.example.com"
+    set hardware-address = "00:11:22:33:44:55"
+    set hardware-type = 1
+    create
+    remove
+    EOF
+    COMMAND
+
+    describe command(omshell) do
+      its(:stdout) { should match(/^name = "host\.example\.com"/) }
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe file(leases_file) do
+      it { should contain(/host host\.example\.com/) }
+    end
+
+    describe file(leases_file) do
+      before do
+        # Lease updates are appended, so there's a create lease and delete
+        # lease. Restarting the service rewrites the leases file to a short
+        # version.
+        on hosts, "systemctl restart #{service_name}"
+      end
+
+      it { should_not contain(/host host\.example\.com/) }
+    end
+  end
+
+  context 'with omapi key' do
+    include_examples 'the example', 'isc_dhcp_omapi.pp'
+
+    it_behaves_like 'the default foreman proxy application'
+
+    describe file('/etc/dhcp/dhcpd.conf') do
+      it { should be_file }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'foreman-proxy' }
+      it { should be_mode 640 }
+      it { should contain(/secret "Ofakekeyfakekeyfakekey=="/) }
+    end
+
+    describe service(service_name) do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
+    omshell_without_key = <<~COMMAND
+    omshell <<EOF
+    server localhost
+    port 7911
+    connect
+    new host
+    set name = "host-key.example.com"
+    set hardware-address = "00:11:22:33:44:66"
+    set hardware-type = 1
+    create
+    remove
+    EOF
+    COMMAND
+
+    describe file(leases_file) do
+      it { should_not contain(/host host-key\.example\.com/) }
+    end
+
+    describe command(omshell_without_key) do
+      its(:stdout) { should match(/can't open object: no key specified/) }
+    end
+
+    omshell_with_key = <<~COMMAND
+    omshell <<EOF
+    key mykey "Ofakekeyfakekeyfakekey=="
+    server localhost
+    port 7911
+    connect
+    new host
+    set name = "host-key.example.com"
+    set hardware-address = "00:11:22:33:44:66"
+    set hardware-type = 1
+    create
+    remove
+    EOF
+    COMMAND
+
+    describe command(omshell_with_key) do
+      its(:stdout) { should_not match(/can't open object: no key specified/) }
+      its(:stdout) { should match(/^name = "host-key\.example\.com"/) }
+    end
+
+    describe file(leases_file) do
+      it { should contain(/host host-key\.example\.com/) }
+    end
+
+    describe file(leases_file) do
+      before do
+        on hosts, "systemctl restart #{service_name}"
+      end
+
+      it { should_not contain(/host host-key\.example\.com/) }
+    end
+  end
+end

--- a/spec/classes/foreman_proxy__proxydhcp__spec.rb
+++ b/spec/classes/foreman_proxy__proxydhcp__spec.rb
@@ -54,11 +54,11 @@ describe 'foreman_proxy' do
           let(:params) { super().merge(dhcp_manage_acls: true) }
 
           it do should contain_exec('Allow foreman-proxy to read /etc/dhcp').
-            with_command("setfacl -R -m u:foreman-proxy:rx /etc/dhcp")
+            with_command("setfacl -m u:foreman-proxy:rx /etc/dhcp")
           end
 
           it do should contain_exec('Allow foreman-proxy to read /var/lib/dhcpd').
-            with_command("setfacl -R -m u:foreman-proxy:rx /var/lib/dhcpd")
+            with_command("setfacl -m u:foreman-proxy:rx /var/lib/dhcpd")
           end
         end
 
@@ -66,7 +66,7 @@ describe 'foreman_proxy' do
           case facts[:osfamily]
           when 'RedHat'
             it do should contain_exec('Allow foreman-proxy to read /etc/dhcp').
-              with_command('setfacl -R -m u:foreman-proxy:rx /etc/dhcp').
+              with_command('setfacl -m u:foreman-proxy:rx /etc/dhcp').
               with_unless('getfacl -p /etc/dhcp | grep user:foreman-proxy:r-x')
             end
           else
@@ -76,7 +76,7 @@ describe 'foreman_proxy' do
           case facts[:osfamily]
           when 'RedHat'
             it do should contain_exec('Allow foreman-proxy to read /var/lib/dhcpd').
-              with_command("setfacl -R -m u:foreman-proxy:rx /var/lib/dhcpd").
+              with_command("setfacl -m u:foreman-proxy:rx /var/lib/dhcpd").
               with_unless('getfacl -p /var/lib/dhcpd | grep user:foreman-proxy:r-x')
             end
           else


### PR DESCRIPTION
The Proxy needs to read dhcpd.conf. Normally that's guaranteed to be mode 0644 by theforeman/dhcp. In case there is an omapi key, there is a secret that needs to be hidden (CVE-2020-14335). The previous patch relied on the recursive ACL and then setting the mode to 0640.

The cause for this change is the correct chaining. Previously there was no guarantee when the ACL was applied. In practice it was often done as: File[/etc/dhcp] -> Exec[setfacl] -> File[/etc/dhcp/dhcpd.conf]

This meant the dhcpd.conf file didn't receive the ACL. Since there was no group set, this means foreman-proxy couldn't read the DHCP config.  After chaining to Class['dhcp'] (to guarantee all files existed) it turns out that /etc/dhcp/dhcpd.conf would become executable. That resulted in idempotency problems.

Only the DHCP dir itself can have mode 0750 (owned by root:root) which is why the ACL is needed. By making it non-recursive and done after Class[dhcp] these problems are avoided.

The security problem is avoided by setting an explicit group on the dhcpd.conf if there is a key. Otherwise it's default to reduce the impact on a system. This means tools like rpm -qV dhcp will not flag the permissions as different.