### PR TITLE
Do not set ACLs on DHCP leases directory

### DIFF
--- a/manifests/proxydhcp.pp
+++ b/manifests/proxydhcp.pp
@@ -72,15 +72,12 @@ class foreman_proxy::proxydhcp {
 
     ensure_packages(['grep', 'acl'])
 
-    [$dhcp::dhcp_dir, dirname($foreman_proxy::dhcp_leases)].each |$path| {
-      exec { "Allow ${foreman_proxy::user} to read ${path}":
-        command => "setfacl -m u:${foreman_proxy::user}:rx ${path}",
-        path    => ['/bin', '/usr/bin'],
-        unless  => "getfacl -p ${path} | grep user:${foreman_proxy::user}:r-x",
-        require => [Class['dhcp'], Package['acl']],
-      }
+    exec { "Allow ${foreman_proxy::user} to read ${dhcp::dhcp_dir}":
+      command => "setfacl -m u:${foreman_proxy::user}:rx ${dhcp::dhcp_dir}",
+      path    => ['/bin', '/usr/bin'],
+      unless  => "getfacl -p ${dhcp::dhcp_dir} | grep user:${foreman_proxy::user}:r-x",
+      require => [Class['dhcp'], Package['acl']],
     }
-
   }
 
   if $failover {

--- a/spec/classes/foreman_proxy__proxydhcp__spec.rb
+++ b/spec/classes/foreman_proxy__proxydhcp__spec.rb
@@ -18,17 +18,6 @@ describe 'foreman_proxy' do
         }
       end
 
-      let(:leases_dir) {
-        case facts[:osfamily]
-        when 'RedHat'
-          '/var/lib/dhcpd'
-        when 'Debian'
-          '/var/lib/dhcp'
-        else
-          '/var/db/dhcpd'
-        end
-      }
-
       context "on physical interface" do
         let :facts do
           facts.merge(
@@ -69,10 +58,6 @@ describe 'foreman_proxy' do
           it do should contain_exec('Allow foreman-proxy to read /etc/dhcp').
             with_command("setfacl -m u:foreman-proxy:rx /etc/dhcp")
           end
-
-          it do should contain_exec("Allow foreman-proxy to read #{leases_dir}").
-            with_command("setfacl -m u:foreman-proxy:rx #{leases_dir}")
-          end
         end
 
         context "as manager of ACLs for dhcp for RedHat and Debian by default" do
@@ -84,16 +69,6 @@ describe 'foreman_proxy' do
             end
           else
             it { should_not contain_exec('Allow foreman-proxy to read /etc/dhcp') }
-          end
-
-          case facts[:osfamily]
-          when 'RedHat', 'Debian'
-            it do should contain_exec("Allow foreman-proxy to read #{leases_dir}").
-              with_command("setfacl -m u:foreman-proxy:rx #{leases_dir}").
-              with_unless("getfacl -p #{leases_dir} | grep user:foreman-proxy:r-x")
-            end
-          else
-            it { should_not contain_exec("Allow foreman-proxy to read #{leases_dir}") }
           end
         end
 


### PR DESCRIPTION
By default this directory is set to mode 0755 on EL7, EL8, Debian 10 and Ubuntu 18.04. Those are all the platforms we set ACLs so there's no need to do this.

The result is that rpm -qV dhcp (on EL7) doesn't complain about /var/lib/dhcpd being modified.