### PR TITLE
Refs #31118 - Remove daemon option from settings.yaml

### DIFF
--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -133,7 +133,6 @@ describe 'foreman_proxy' do
               ':trusted_hosts:',
               "  - #{facts[:fqdn]}",
               ":foreman_url: https://#{facts[:fqdn]}",
-              ':daemon: true',
               ":bind_host: '#{bind_host}'",
               ':https_port: 8443',
               ':log_file: /var/log/foreman-proxy/proxy.log',

--- a/templates/settings.yml.erb
+++ b/templates/settings.yml.erb
@@ -87,12 +87,6 @@
 #:foreman_ssl_key: ssl/private_keys/fqdn.pem
 <% end -%>
 
-# by default smart_proxy runs in the foreground. To enable running as a daemon, uncomment 'daemon' setting
-:daemon: true
-# Only used when 'daemon' is set to true.
-# Uncomment and modify if you want to change the default pid file '/var/run/foreman-proxy/foreman-proxy.pid'
-#:daemon_pid: /var/run/foreman-proxy/foreman-proxy.pid
-
 # host and ports configuration
 <%# Write bind_host as a string if given a single-element array for 1.14 compatibility -%>
 <% if scope.lookupvar("foreman_proxy::bind_host").is_a?(String) -%>


### PR DESCRIPTION
This option is being removed from the Smart Proxy and should no longer be present.

It is likely to break BSD deployments which relied on this. However, no init scripts are shipped for BSD. Those would need to be modified by the user. For older versions they can use the --daemonize command line option. For versions which have dropped daemonize support it is recommended to use a separate tool to daemonize.

On systemd based deployments this option already had no effect since the service file included the --no-daemonize option. The config was misleading there.