### PR TITLE
Fixes #31415 - Expose DHCP's ping_free_ip option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -130,6 +130,10 @@
 #
 # $dhcp_subnets::               Subnets list to restrict DHCP management to
 #
+# $dhcp_ping_free_ip::          Perform ICMP and TCP ping when searching free IPs from the pool. This makes
+#                               sure that active IP address is not suggested as free, however in locked down
+#                               network environments this can cause no free IPs.
+#
 # $dhcp_option_domain::         DHCP use the dhcpd config option domain-name
 #
 # $dhcp_search_domains::        DHCP search domains option
@@ -351,6 +355,7 @@ class foreman_proxy (
   Boolean $dhcp_managed = $foreman_proxy::params::dhcp_managed,
   String $dhcp_provider = $foreman_proxy::params::dhcp_provider,
   Array[String] $dhcp_subnets = $foreman_proxy::params::dhcp_subnets,
+  Boolean $dhcp_ping_free_ip = $foreman_proxy::params::dhcp_ping_free_ip,
   Array[String] $dhcp_option_domain = $foreman_proxy::params::dhcp_option_domain,
   Optional[Array[String]] $dhcp_search_domains = $foreman_proxy::params::dhcp_search_domains,
   String $dhcp_interface = $foreman_proxy::params::dhcp_interface,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -244,6 +244,7 @@ class foreman_proxy::params inherits foreman_proxy::globals {
   $dhcp_managed            = true
   $dhcp_provider           = 'isc'
   $dhcp_subnets            = []
+  $dhcp_ping_free_ip       = true
   $dhcp_interface          = pick(fact('networking.primary'), 'eth0')
   $dhcp_additional_interfaces = []
   $dhcp_gateway            = undef

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -163,6 +163,7 @@ describe 'foreman_proxy' do
             ':enabled: false',
             ':use_provider: dhcp_isc',
             ':server: 127.0.0.1',
+            ':ping_free_ip: true',
           ])
         end
 
@@ -856,6 +857,7 @@ describe 'foreman_proxy' do
               ':enabled: https',
               ':use_provider: dhcp_isc',
               ':server: 127.0.0.1',
+              ':ping_free_ip: true',
             ])
           end
 
@@ -903,6 +905,7 @@ describe 'foreman_proxy' do
               ':enabled: https',
               ':use_provider: dhcp_libvirt',
               ':server: 127.0.0.1',
+              ':ping_free_ip: true',
             ])
 
             verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/dhcp_libvirt.yml", [

--- a/templates/dhcp.yml.erb
+++ b/templates/dhcp.yml.erb
@@ -20,3 +20,8 @@
 #  - 192.168.205.0/255.255.255.128
 #  - 192.168.205.128/255.255.255.128
 <% end -%>
+
+# Perform ICMP and TCP ping when searching free IPs from the pool. This makes
+# sure that active IP address is not suggested as free, however in locked down
+# network environments this can cause no free IPs. Enabled by default
+:ping_free_ip: <%= scope.lookupvar("foreman_proxy::dhcp_ping_free_ip") %>


### PR DESCRIPTION
Foreman 1.24 introduced this option and it should be exposed so users can change it.