### PR TITLE
Skip journal check on EL7 when using Docker

### DIFF
--- a/spec/acceptance/journald_spec.rb
+++ b/spec/acceptance/journald_spec.rb
@@ -11,9 +11,8 @@ describe 'Scenario: install foreman-proxy with journald' do
     it { is_expected.to be_installed }
   end
 
-  # Logging to the journal is broken on Travis and EL7 but works in Vagrant VMs
-  # and regular docker containers
-  describe command('journalctl -u foreman-proxy'), unless: ENV['TRAVIS'] == 'true' && os[:family] == 'redhat' && os[:release] =~ /^7\./ do
+  # Logging to the journal is broken on Docker with EL7
+  describe command('journalctl -u foreman-proxy'), unless: default[:hypervisor] == 'docker' && os[:family] == 'redhat' && os[:release] =~ /^7\./ do
     its(:stdout) { is_expected.to match(%r{WEBrick::HTTPServer#start}) }
   end
 end


### PR DESCRIPTION
This is broken on Docker CE. It worked in the past (and still does when using Docker in EL7). This should have been updated when it was migrated to Github Actions.