### PR TITLE
Update Pulp plugin to drop Pulp 2

### DIFF
--- a/manifests/plugin/pulp.pp
+++ b/manifests/plugin/pulp.pp
@@ -4,20 +4,10 @@
 #
 # === Advanced parameters:
 #
-# $enabled::            enables/disables the pulp plugin
-#
 # $listen_on::          proxy feature listens on http, https, or both
 #
 # $version::            plugin package version, it's passed to ensure parameter of package resource
 #                       can be set to specific version number, 'latest', 'present' etc.
-#
-# $pulp_url::           pulp url to use
-#
-# $pulp_dir::           directory for pulp
-#
-# $pulp_content_dir::   directory for pulp content
-#
-# $pulpnode_enabled::   enables/disables the pulpnode plugin
 #
 # $pulpcore_enabled::      enables/disables the pulpcore plugin
 #
@@ -27,50 +17,28 @@
 #
 # $pulpcore_content_url::  The URL to the Pulp 3 content
 #
-# $puppet_content_dir:: Directory for puppet content. Automatically determined if empty.
-#
-# $mongodb_dir::        directory for Mongo DB
-#
 class foreman_proxy::plugin::pulp (
-  Boolean $enabled = $foreman_proxy::plugin::pulp::params::enabled,
-  Foreman_proxy::ListenOn $listen_on = $foreman_proxy::plugin::pulp::params::listen_on,
-  Boolean $pulpnode_enabled = $foreman_proxy::plugin::pulp::params::pulpnode_enabled,
-  Boolean $pulpcore_enabled = $foreman_proxy::plugin::pulp::params::pulpcore_enabled,
+  Foreman_proxy::ListenOn $listen_on = 'https',
+  Boolean $pulpcore_enabled = true,
+  Boolean $pulpcore_mirror = false,
   Stdlib::HTTPUrl $pulpcore_api_url = $foreman_proxy::plugin::pulp::params::pulpcore_api_url,
   Stdlib::HTTPUrl $pulpcore_content_url = $foreman_proxy::plugin::pulp::params::pulpcore_content_url,
-  Boolean $pulpcore_mirror = $foreman_proxy::plugin::pulp::params::pulpcore_mirror,
-  Optional[String] $version = $foreman_proxy::plugin::pulp::params::version,
-  Stdlib::HTTPUrl $pulp_url = $foreman_proxy::plugin::pulp::params::pulp_url,
-  Stdlib::Absolutepath $pulp_dir = $foreman_proxy::plugin::pulp::params::pulp_dir,
-  Stdlib::Absolutepath $pulp_content_dir = $foreman_proxy::plugin::pulp::params::pulp_content_dir,
-  Optional[Stdlib::Absolutepath] $puppet_content_dir = $foreman_proxy::plugin::pulp::params::puppet_content_dir,
-  Stdlib::Absolutepath $mongodb_dir = $foreman_proxy::plugin::pulp::params::mongodb_dir,
+  Optional[String] $version = undef,
 ) inherits foreman_proxy::plugin::pulp::params {
-  $real_puppet_content_dir = pick($puppet_content_dir, lookup('puppet::server_envs_dir') |$key| { undef }, $facts['puppet_environmentpath'], "${foreman_proxy::puppetcodedir}/environments")
 
   foreman_proxy::plugin {'pulp':
     version => $version,
   }
   -> [
-    foreman_proxy::module { 'pulp':
-      template_path => 'foreman_proxy/plugin/pulp.yml.erb',
-      enabled       => $enabled,
-      feature       => 'Pulp',
-      listen_on     => $listen_on,
-    },
-    foreman_proxy::module { 'pulpnode':
-      template_path => 'foreman_proxy/plugin/pulpnode.yml.erb',
-      enabled       => $pulpnode_enabled,
-      feature       => 'Pulp Node',
-      listen_on     => $listen_on,
-    },
     foreman_proxy::module { 'pulpcore':
       template_path => 'foreman_proxy/plugin/pulpcore.yml.erb',
       enabled       => $pulpcore_enabled,
       feature       => 'Pulpcore',
       listen_on     => $listen_on,
     },
-    foreman_proxy::settings_file { 'pulp3': # file removed in rubygem-smart_proxy_pulp 2.0
+    # pulp3: removed in rubygem-smart_proxy_pulp 2.0
+    # pulp/pulpnode: removed in rubygem-smart_proxy_pulp 3.0
+    foreman_proxy::settings_file { ['pulp3', 'pulp', 'pulpnode']:
       ensure        => absent,
     },
   ]

--- a/manifests/plugin/pulp/params.pp
+++ b/manifests/plugin/pulp/params.pp
@@ -1,17 +1,6 @@
 # Default parameters for the Pulp smart proxy plugin
 # @api private
 class foreman_proxy::plugin::pulp::params {
-  $enabled              = true
-  $listen_on            = 'https'
-  $version              = undef
-  $pulpnode_enabled     = false
-  $pulpcore_enabled     = false
-  $pulpcore_mirror      = false
-  $pulp_url             = "https://${facts['networking']['fqdn']}/pulp"
   $pulpcore_api_url     = "https://${facts['networking']['fqdn']}"
-  $pulpcore_content_url = "${pulp_url}/content"
-  $pulp_dir             = '/var/lib/pulp'
-  $pulp_content_dir     = '/var/lib/pulp/content'
-  $puppet_content_dir   = undef
-  $mongodb_dir          = '/var/lib/mongodb'
+  $pulpcore_content_url = "${pulpcore_api_url}/pulp/content"
 }

--- a/spec/classes/foreman_proxy__plugin__pulp_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__pulp_spec.rb
@@ -11,40 +11,6 @@ describe 'foreman_proxy::plugin::pulp' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_foreman_proxy__plugin('pulp') }
 
-        it 'should configure pulp.yml' do
-          is_expected.to contain_file("#{etc_dir}/foreman-proxy/settings.d/pulp.yml")
-            .with_ensure('file')
-            .with_owner('root')
-            .with_group('foreman-proxy')
-
-          verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/pulp.yml", [
-                                  '---',
-                                  ':enabled: https',
-                                  ":pulp_url: https://#{facts[:fqdn]}/pulp",
-                                  ':pulp_dir: /var/lib/pulp',
-                                  ':pulp_content_dir: /var/lib/pulp/content',
-                                  ':puppet_content_dir: /etc/puppetlabs/code/environments',
-                                  ':mongodb_dir: /var/lib/mongodb'
-                                ])
-        end
-
-        it 'should configure pulpnode.yml' do
-          is_expected.to contain_file("#{etc_dir}/foreman-proxy/settings.d/pulpnode.yml")
-            .with_ensure('file')
-            .with_owner('root')
-            .with_group('foreman-proxy')
-
-          verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/pulpnode.yml", [
-                                  '---',
-                                  ':enabled: false',
-                                  ":pulp_url: https://#{facts[:fqdn]}/pulp",
-                                  ':pulp_dir: /var/lib/pulp',
-                                  ':pulp_content_dir: /var/lib/pulp/content',
-                                  ':puppet_content_dir: /etc/puppetlabs/code/environments',
-                                  ':mongodb_dir: /var/lib/mongodb'
-                                ])
-        end
-
         it 'should configure pulpcore.yml' do
           is_expected.to contain_file("#{etc_dir}/foreman-proxy/settings.d/pulpcore.yml")
             .with_ensure('file')
@@ -53,61 +19,41 @@ describe 'foreman_proxy::plugin::pulp' do
 
           verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/pulpcore.yml", [
                                   '---',
-                                  ':enabled: false',
+                                  ':enabled: https',
                                   ":pulp_url: https://#{facts[:fqdn]}",
                                   ":content_app_url: https://#{facts[:fqdn]}/pulp/content",
                                   ':mirror: false'
                                 ])
         end
 
+        it 'should remove pulp.yml' do
+          is_expected.to contain_file("#{etc_dir}/foreman-proxy/settings.d/pulp.yml")
+            .with_ensure('absent')
+        end
+
+        it 'should remove pulpnode.yml' do
+          is_expected.to contain_file("#{etc_dir}/foreman-proxy/settings.d/pulpnode.yml")
+            .with_ensure('absent')
+        end
+
         it 'should remove pulp3.yml' do
           is_expected.to contain_file("#{etc_dir}/foreman-proxy/settings.d/pulp3.yml")
             .with_ensure('absent')
-	end
+        end
       end
 
       describe 'with overrides' do
         let :params do
           {
-            pulpnode_enabled: true,
             pulpcore_enabled: true,
             pulpcore_mirror: true,
             pulpcore_api_url: 'https://pulpcore.example.com',
             pulpcore_content_url: 'https://pulpcore.example.com/pulp/content',
-            pulp_url: 'https://pulp.example.com',
-            pulp_dir: '/tmp/pulp',
-            pulp_content_dir: '/tmp/content',
-            puppet_content_dir: '/tmp/puppet',
-            mongodb_dir: '/tmp/mongodb',
           }
         end
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_foreman_proxy__plugin('pulp') }
-
-        it 'should configure pulp.yml' do
-          verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/pulp.yml", [
-                                  '---',
-                                  ':enabled: https',
-                                  ':pulp_url: https://pulp.example.com',
-                                  ':pulp_dir: /tmp/pulp',
-                                  ':pulp_content_dir: /tmp/content',
-                                  ':puppet_content_dir: /tmp/puppet',
-                                  ':mongodb_dir: /tmp/mongodb'
-                                ])
-        end
-
-        it 'should configure pulpnode.yml' do
-          verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/pulpnode.yml", [
-                                  '---',
-                                  ':enabled: https',
-                                  ':pulp_url: https://pulp.example.com',
-                                  ':pulp_dir: /tmp/pulp',
-                                  ':pulp_content_dir: /tmp/content',
-                                  ':puppet_content_dir: /tmp/puppet',
-                                  ':mongodb_dir: /tmp/mongodb'
-                                ])
-        end
 
         it 'should configure pulpcore.yml' do
           verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/pulpcore.yml", [

--- a/templates/plugin/pulp.yml.erb
+++ b/templates/plugin/pulp.yml.erb
@@ -1,9 +1,0 @@
----
-# Pulp integration
-:enabled: <%= @module_enabled %>
-:pulp_url: <%= scope.lookupvar("foreman_proxy::plugin::pulp::pulp_url") %>
-# Path to pulp, pulp content and mongodb directories
-:pulp_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::pulp_dir") %>
-:pulp_content_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::pulp_content_dir") %>
-:puppet_content_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::real_puppet_content_dir") %>
-:mongodb_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::mongodb_dir") %>

--- a/templates/plugin/pulpnode.yml.erb
+++ b/templates/plugin/pulpnode.yml.erb
@@ -1,9 +1,0 @@
----
-# Pulp integration
-:enabled: <%= @module_enabled %>
-:pulp_url: <%= scope.lookupvar("foreman_proxy::plugin::pulp::pulp_url") %>
-# Path to pulp, pulp content and mongodb directories
-:pulp_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::pulp_dir") %>
-:pulp_content_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::pulp_content_dir") %>
-:puppet_content_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::real_puppet_content_dir") %>
-:mongodb_dir: <%= scope.lookupvar("foreman_proxy::plugin::pulp::mongodb_dir") %>


### PR DESCRIPTION
Katello 4.0 drops Pulp 2 in favor of Pulp 3 completely. If this
plugin is used, then Pulpcore will be used and the user can decide
if it should be deployed as a mirror configuration or not. This drops
most of the parameters as they are not relevant with Pulp 3.

I was not sure if disabling the Pulp 2 plugins was all that needed doing. At some point we will want to clean them up but figured I'd start by just disabling them. This is obviously backwards incompatible. I prefer to have latest reflect the state of Katello 4.0 given its so different. We could resort to erroring out when a user attempts to use parameters that dont work with 4.0, but that also means we have to keep around a lot this parameter cruft for a lot longer period of time. Further, in the installers use case, this would present misleading parameters.