### PR TITLE
Fixes #31642 - Add container gateway support

### DIFF
--- a/manifests/plugin/container_gateway.pp
+++ b/manifests/plugin/container_gateway.pp
@@ -1,0 +1,31 @@
+# = Foreman Proxy Container Gateway plugin
+#
+# This class installs the Container Gateway plugin
+#
+# $pulp_endpoint::            Pulp 3 server endpoint
+#
+# $sqlite_db_path::           Absolute path for the SQLite DB file to exist at
+#
+# === Advanced parameters:
+#
+# $enabled::                  enables/disables the pulp plugin
+#
+# $listen_on::                proxy feature listens on http, https, or both
+#
+# $version::                  plugin package version, it's passed to ensure parameter of package resource
+#                             can be set to specific version number, 'latest', 'present' etc.
+#
+class foreman_proxy::plugin::container_gateway (
+  Optional[String] $version = undef,
+  Boolean $enabled = true,
+  Foreman_proxy::ListenOn $listen_on = 'https',
+  Stdlib::HTTPUrl $pulp_endpoint = "https://${facts['networking']['fqdn']}",
+  Stdlib::Absolutepath $sqlite_db_path = '/var/lib/foreman-proxy/smart_proxy_container_gateway.db',
+) {
+  foreman_proxy::plugin::module { 'container_gateway':
+    version   => $version,
+    enabled   => $enabled,
+    feature   => 'Container_Gateway',
+    listen_on => $listen_on,
+  }
+}

--- a/spec/classes/foreman_proxy__plugin__container_gateway_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__container_gateway_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe 'foreman_proxy::plugin::container_gateway' do
+  on_plugin_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:pre_condition) { 'include foreman_proxy' }
+
+      describe 'with default settings' do
+        it { should contain_foreman_proxy__plugin__module('container_gateway') }
+        it 'container_gateway.yml should contain the correct configuration' do
+          verify_exact_contents(catalogue, '/etc/foreman-proxy/settings.d/container_gateway.yml', [
+            '---',
+            ':enabled: https',
+            ":pulp_endpoint: https://#{facts[:fqdn]}",
+            ':sqlite_db_path: /var/lib/foreman-proxy/smart_proxy_container_gateway.db'
+          ])
+        end
+      end
+
+      describe 'with overwritten parameters' do
+        let :params do {
+          :pulp_endpoint => 'https://test.example.com',
+          :sqlite_db_path => '/dev/null.db',
+        } end
+
+        it 'container_gateway.yml should contain the correct configuration' do
+          verify_exact_contents(catalogue, '/etc/foreman-proxy/settings.d/container_gateway.yml', [
+            '---',
+            ':enabled: https',
+            ':pulp_endpoint: https://test.example.com',
+            ':sqlite_db_path: /dev/null.db'
+          ])
+        end
+      end
+    end
+  end
+end

--- a/templates/plugin/container_gateway.yml.erb
+++ b/templates/plugin/container_gateway.yml.erb
@@ -1,0 +1,5 @@
+---
+# Container Gateway for Katello
+:enabled: <%= @module_enabled %>
+:pulp_endpoint: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::pulp_endpoint") %>
+:sqlite_db_path: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::sqlite_db_path") %>


### PR DESCRIPTION
Adds support for the Container Gateway smart proxy plugin.

I'm pretty new to the foreman-installer so let me know any places where I'm breaking standards.

TODO:
- [x] Add tests
- [x] ~~Add `foreman-proxy-content` answers file migration (https://github.com/theforeman/foreman-installer/pull/643)~~