### PR TITLE
Use localhost in acceptance tests

### DIFF
--- a/spec/acceptance/netboot_spec.rb
+++ b/spec/acceptance/netboot_spec.rb
@@ -12,11 +12,16 @@ describe 'Scenario: tftp' do
     it { should be_linked_to '../boot' }
   end
 
+  describe file("#{root}/grub2/grub.cfg") do
+    it { should be_file }
+    its(:content) { should match(/This system was not recognized by Foreman/) }
+  end
+
   describe 'ensure tftp client is installed' do
     on hosts, puppet('resource', 'package', 'tftp', 'ensure=installed')
   end
 
-  describe command("echo get /grub2/grub.cfg /tmp/downloaded_file | tftp #{fact('fqdn')}") do
+  describe command('echo get /grub2/grub.cfg /tmp/downloaded_file | tftp localhost') do
     its(:exit_status) { should eq 0 }
   end
 


### PR DESCRIPTION
This is to see if the tests are fixed this way. Locally they already passed for me in a Vagrant VM so this is to reproduce it in a real env.