### PR TITLE
Fixes #32235,#19494 - Run Dynflow within smart-proxy on EL*

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Part of the Foreman installer: <https://github.com/theforeman/foreman-installer>
 
 | Module version | Proxy versions | Notes                                               |
 |----------------|----------------|-----------------------------------------------------|
-| 16.x - 17.x    | 2.3 and newer  | See compatibility notes in its README for 2.0-2.2   |
+| 16.x - 18.x    | 2.3 and newer  | See compatibility notes in its README for 2.0-2.2   |
 | 13.x - 15.x    | 2.0 - 2.2      |                                                     |
 | 12.x           | 1.19 - 1.24    | See compatibility notes in its README for 1.19-1.22 |
 | 11.x           | 1.19 - 1.23    | See compatibility notes in its README for 1.19-1.21 |
@@ -23,6 +23,7 @@ Part of the Foreman installer: <https://github.com/theforeman/foreman-installer>
 | 2.x            | 1.5 - 1.10     |                                                     |
 | 1.x            | 1.4 and older  |                                                     |
 
+18.x switched to running `smart_proxy_dynflow` as part of `foreman-proxy` service by default. On EL* distributions and Foreman < 2.5, `foreman_proxy::plugin::dynflow::external_core` needs to be explicitly set to `true`.
 16.x added support for Smart Proxy Registration feature, available in Smart Proxy 2.3 and newer.
 12.x has dropped support for Puppet 3 which was officially unsupported for a while and Foreman Proxy 1.23 dropped altogether.
 

--- a/manifests/plugin/dynflow.pp
+++ b/manifests/plugin/dynflow.pp
@@ -72,6 +72,15 @@ class foreman_proxy::plugin::dynflow (
     notify  => Service[$service],
   }
 
+  systemd::service_limits { "${service}.service":
+    limits          => {
+      'LimitNOFILE' => $open_file_limit,
+    },
+    restart_service => false,
+    require         => Foreman_proxy::Plugin['dynflow_core'],
+    notify          => Service[$service],
+  }
+
   service { 'smart_proxy_dynflow_core':
     ensure => $external_core,
     enable => $external_core,

--- a/manifests/plugin/dynflow/params.pp
+++ b/manifests/plugin/dynflow/params.pp
@@ -11,8 +11,5 @@ class foreman_proxy::plugin::dynflow::params {
   $ssl_disabled_ciphers  = undef
   $tls_disabled_versions = undef
   $open_file_limit       = 1000000
-  $external_core         = $facts['os']['family'] ? {
-    'RedHat' => true,
-    default  => undef
-  }
+  $external_core         = false
 }

--- a/spec/acceptance/dynflow_spec.rb
+++ b/spec/acceptance/dynflow_spec.rb
@@ -7,23 +7,12 @@ describe 'Scenario: install foreman-proxy', unless: ENV['BEAKER_HYPERVISOR'] == 
 
   it_behaves_like 'the default foreman proxy application'
 
-  if os[:family] =~ /redhat|fedora/
-    describe service('smart_proxy_dynflow_core') do
-      it { is_expected.to be_enabled }
-      it { is_expected.to be_running }
-    end
+  describe service('smart_proxy_dynflow_core') do
+    it { is_expected.not_to be_enabled }
+    it { is_expected.not_to be_running }
+  end
 
-    describe port(8008) do
-      it { is_expected.to be_listening }
-    end
-  else
-    describe service('smart_proxy_dynflow_core') do
-      it { is_expected.not_to be_enabled }
-      it { is_expected.not_to be_running }
-    end
-
-    describe port(8008) do
-      it { is_expected.not_to be_listening }
-    end
+  describe port(8008) do
+    it { is_expected.not_to be_listening }
   end
 end

--- a/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
@@ -27,6 +27,7 @@ describe 'foreman_proxy::plugin::dynflow' do
         it { should contain_foreman_proxy__plugin('dynflow_core') }
         it { should contain_service('smart_proxy_dynflow_core').
                with(ensure: false, enable: false) }
+        it { should contain_systemd__service_limits('foreman-proxy.service') }
 
         it { should_not contain_file("#{etc_dir}/smart_proxy_dynflow_core/settings.d") }
         it { should_not contain_file("#{etc_dir}/smart_proxy_dynflow_core/settings.yml") }
@@ -89,6 +90,7 @@ describe 'foreman_proxy::plugin::dynflow' do
         it { should contain_foreman_proxy__plugin('dynflow_core') }
         it { should contain_service('smart_proxy_dynflow_core').
             with(ensure: false, enable: false) }
+        it { should contain_systemd__service_limits('foreman-proxy.service') }
 
         it { should_not contain_file("#{etc_dir}/smart_proxy_dynflow_core/settings.d") }
         it { should_not contain_file("#{etc_dir}/smart_proxy_dynflow_core/settings.yml") }


### PR DESCRIPTION
Implements step 2 of [Phasing out smart_proxy_dynflow_core](https://community.theforeman.org/t/phasing-out-smart-proxy-dynflow-core/22841)