### PR TITLE
adding smart_proxy_dns_route53 plugin support

### DIFF
--- a/manifests/plugin/dns/route53.pp
+++ b/manifests/plugin/dns/route53.pp
@@ -7,8 +7,8 @@
 #   The Secret Access Key of the IAM account
 #
 class foreman_proxy::plugin::dns::route53 (
-  String $aws_access_key = '', # lint:ignore:empty_string_assignment,
-  String $aws_secret_key = '', # lint:ignore:empty_string_assignment,
+  String $aws_access_key,
+  String $aws_secret_key,
 ) {
   foreman_proxy::plugin::provider { 'dns_route53':
   }

--- a/manifests/plugin/dns/route53.pp
+++ b/manifests/plugin/dns/route53.pp
@@ -1,0 +1,15 @@
+# @summary Install the Amazon Route53 DNS plugin for Foreman proxy
+#
+# @param aws_access_key
+#   The Access Key ID of the IAM account
+#
+# @param aws_secret_key
+#   The Secret Access Key of the IAM account
+#
+class foreman_proxy::plugin::dns::route53 (
+  String $aws_access_key = '', # lint:ignore:empty_string_assignment,
+  String $aws_secret_key = '', # lint:ignore:empty_string_assignment,
+) {
+  foreman_proxy::plugin::provider { 'dns_route53':
+  }
+}

--- a/spec/classes/foreman_proxy__plugin__dns__route53_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__dns__route53_spec.rb
@@ -6,22 +6,6 @@ describe 'foreman_proxy::plugin::dns::route53' do
       let(:facts) { os_facts }
       let(:pre_condition) { 'include foreman_proxy' }
 
-      context 'default parameters' do
-        it { should compile.with_all_deps }
-
-        it 'should install the correct plugin' do
-          should contain_foreman_proxy__plugin('dns_route53')
-        end
-
-        it 'should contain the correct configuration' do
-          verify_exact_contents(catalogue, '/etc/foreman-proxy/settings.d/dns_route53.yml', [
-            '---',
-            ':aws_access_key: ""',
-            ':aws_secret_key: ""',
-          ])
-        end
-      end
-
       context 'explicit parameters' do
         let :params do
           {

--- a/spec/classes/foreman_proxy__plugin__dns__route53_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__dns__route53_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe 'foreman_proxy::plugin::dns::route53' do
+  on_plugin_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:pre_condition) { 'include foreman_proxy' }
+
+      context 'default parameters' do
+        it { should compile.with_all_deps }
+
+        it 'should install the correct plugin' do
+          should contain_foreman_proxy__plugin('dns_route53')
+        end
+
+        it 'should contain the correct configuration' do
+          verify_exact_contents(catalogue, '/etc/foreman-proxy/settings.d/dns_route53.yml', [
+            '---',
+            ':aws_access_key: ""',
+            ':aws_secret_key: ""',
+          ])
+        end
+      end
+
+      context 'explicit parameters' do
+        let :params do
+          {
+            :aws_access_key => 'ABCDEF123456',
+            :aws_secret_key => 'changeme',
+          }
+        end
+
+        it { should compile.with_all_deps }
+
+        it 'should install the correct plugin' do
+          should contain_foreman_proxy__plugin('dns_route53')
+        end
+
+        it 'should contain the correct configuration' do
+          verify_exact_contents(catalogue, '/etc/foreman-proxy/settings.d/dns_route53.yml', [
+            '---',
+            ':aws_access_key: "ABCDEF123456"',
+            ':aws_secret_key: "changeme"',
+          ])
+        end
+      end
+    end
+  end
+end

--- a/templates/dns.yml.erb
+++ b/templates/dns.yml.erb
@@ -3,12 +3,12 @@
 :enabled: <%= @module_enabled %>
 # valid providers:
 #   dns_dnscmd (Microsoft Windows native implementation)
-#   dns_infoblox
+#   dns_infoblox (separate plugin)
 #   dns_libvirt (dnsmasq via libvirt)
 #   dns_nsupdate
 #   dns_nsupdate_gss (for GSS-TSIG support)
-#   dns_powerdns
-#   dns_route53
+#   dns_powerdns (separate plugin)
+#   dns_route53 (separate plugin)
 :use_provider: dns_<%= scope.lookupvar("foreman_proxy::dns_provider") %>
 # use this setting if you want to override default TTL setting (86400)
 :dns_ttl: <%= scope.lookupvar("foreman_proxy::dns_ttl") %>

--- a/templates/dns.yml.erb
+++ b/templates/dns.yml.erb
@@ -3,9 +3,12 @@
 :enabled: <%= @module_enabled %>
 # valid providers:
 #   dns_dnscmd (Microsoft Windows native implementation)
+#   dns_infoblox
+#   dns_libvirt (dnsmasq via libvirt)
 #   dns_nsupdate
 #   dns_nsupdate_gss (for GSS-TSIG support)
-#   dns_libvirt (dnsmasq via libvirt)
+#   dns_powerdns
+#   dns_route53
 :use_provider: dns_<%= scope.lookupvar("foreman_proxy::dns_provider") %>
 # use this setting if you want to override default TTL setting (86400)
 :dns_ttl: <%= scope.lookupvar("foreman_proxy::dns_ttl") %>

--- a/templates/plugin/dns_route53.yml.erb
+++ b/templates/plugin/dns_route53.yml.erb
@@ -1,0 +1,3 @@
+---
+:aws_access_key: "<%= scope.lookupvar('foreman_proxy::plugin::dns::route53::aws_access_key') %>"
+:aws_secret_key: "<%= scope.lookupvar('foreman_proxy::plugin::dns::route53::aws_secret_key') %>"


### PR DESCRIPTION
Based heavily on the code for the powerdns plugin, I added support for the smart_proxy_dns_route53 plugin. Tested in our own dev and prod foreman deployments. I also added "dns_route53" to the list of valid providers in templates/dns.yml.erb and alphabetized the list.