### PR TITLE
Allow puppet-puppet < 16.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -32,7 +32,7 @@
     },
     {
       "name": "theforeman/puppet",
-      "version_requirement": ">= 10.0.0 < 15.0.0"
+      "version_requirement": ">= 10.0.0 < 16.0.0"
     },
     {
       "name": "theforeman/tftp",


### PR DESCRIPTION
This should have been included in the 18.0.0 release
of this module.