### PR TITLE
Support Ubuntu 20.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,7 @@
 # @summary The default parameters for the foreman proxy
 # @api private
 class foreman_proxy::params inherits foreman_proxy::globals {
-
+  $tftp_root = lookup('tftp::root')
   $lower_fqdn = downcase($facts['networking']['fqdn'])
 
   case $facts['os']['family'] {
@@ -25,7 +25,6 @@ class foreman_proxy::params inherits foreman_proxy::globals {
       $keyfile  = '/etc/rndc.key'
       $nsupdate = 'bind-utils'
 
-      $tftp_root  = '/var/lib/tftpboot'
       if versioncmp($facts['os']['release']['major'], '7') <= 0 {
         $tftp_syslinux_filenames = [
           '/usr/share/syslinux/chain.c32',
@@ -63,11 +62,6 @@ class foreman_proxy::params inherits foreman_proxy::globals {
       $keyfile  = '/etc/bind/rndc.key'
       $nsupdate = 'dnsutils'
 
-      if $facts['os']['name'] == 'Ubuntu' {
-        $tftp_root = '/var/lib/tftpboot'
-      } else {
-        $tftp_root = '/srv/tftp'
-      }
       $tftp_syslinux_filenames = [
         '/usr/lib/PXELINUX/pxelinux.0',
         '/usr/lib/syslinux/memdisk',
@@ -99,7 +93,6 @@ class foreman_proxy::params inherits foreman_proxy::globals {
       $keyfile  = '/usr/local/etc/namedb/rndc.key'
       $nsupdate = 'bind-tools'
 
-      $tftp_root = '/tftpboot'
       $tftp_syslinux_filenames = [
         '/usr/local/share/syslinux/bios/core/pxelinux.0',
         '/usr/local/share/syslinux/bios/memdisk/memdisk',

--- a/manifests/plugin/ansible/params.pp
+++ b/manifests/plugin/ansible/params.pp
@@ -19,7 +19,11 @@ class foreman_proxy::plugin::ansible::params {
       $runner_package_name = 'ansible-runner'
     }
     'Debian': {
-      $callback = 'foreman'
+      if ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'], '20.04') >= 0) {
+        $callback = 'theforeman.foreman.foreman'
+      } else {
+        $callback = 'foreman'
+      }
       $manage_runner_repo = true
       $runner_package_name = 'python3-ansible-runner'
     }

--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,7 @@
     },
     {
       "name": "theforeman/tftp",
-      "version_requirement": ">= 1.3.0 < 7.0.0"
+      "version_requirement": ">= 3.0.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/metadata.json
+++ b/metadata.json
@@ -87,7 +87,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     },
     {

--- a/spec/classes/foreman_proxy__plugin__discovery_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__discovery_spec.rb
@@ -5,14 +5,17 @@ describe 'foreman_proxy::plugin::discovery' do
     context "on #{os}" do
       let(:facts) { facts }
       let(:pre_condition) { 'include foreman_proxy' }
-
-      case facts[:operatingsystem]
+      let(:tftproot) do
+        case facts[:operatingsystem]
         when 'Debian'
-          tftproot = '/srv/tftp'
-        when 'FreeBSD'
-          tftproot = '/tftpboot'
+          '/srv/tftp'
+        when 'FreeBSD', 'DragonFly'
+          '/tftpboot'
+        when 'Ubuntu'
+          facts[:operatingsystemmajrelease] == '18.04' ? '/var/lib/tftpboot' : '/srv/tftp'
         else
-          tftproot = '/var/lib/tftpboot'
+          '/var/lib/tftpboot'
+        end
       end
 
       describe 'without paramaters' do

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -28,16 +28,13 @@ describe 'foreman_proxy' do
       end
 
       let(:tftp_root) do
-        case facts[:osfamily]
+        case facts[:operatingsystem]
         when 'Debian'
-          case facts[:operatingsystem]
-          when 'Ubuntu'
-            '/var/lib/tftpboot'
-          else
-            '/srv/tftp'
-          end
+          '/srv/tftp'
         when 'FreeBSD', 'DragonFly'
           '/tftpboot'
+        when 'Ubuntu'
+          facts[:operatingsystemmajrelease] == '18.04' ? '/var/lib/tftpboot' : '/srv/tftp'
         else
           '/var/lib/tftpboot'
         end

--- a/spec/classes/foreman_proxy__tftp_spec.rb
+++ b/spec/classes/foreman_proxy__tftp_spec.rb
@@ -17,7 +17,11 @@ describe 'foreman_proxy::tftp' do
 
       case facts[:osfamily]
       when 'Debian'
-        tftp_root = facts[:operatingsystem] == 'Ubuntu' ?  '/var/lib/tftpboot' : '/srv/tftp'
+        tftp_root = if facts[:operatingsystem] == 'Ubuntu'
+                      facts[:operatingsystemmajrelease] == '18.04' ? '/var/lib/tftpboot' : '/srv/tftp'
+                    else
+                      '/srv/tftp'
+                    end
         names = {
           '/usr/lib/PXELINUX/pxelinux.0'                => "#{tftp_root}/pxelinux.0",
           '/usr/lib/syslinux/memdisk'                   => "#{tftp_root}/memdisk",


### PR DESCRIPTION
The most notable change is that Ubuntu 20.04 changes the tftp root from /var/lib/tftpboot to /srv/tftp. This matches Debian again.

The other change is that it ships a new enough Ansible to use the callback from collections.

Replaces https://github.com/theforeman/puppet-foreman_proxy/pull/666 & https://github.com/theforeman/puppet-foreman_proxy/pull/667.