### PR TITLE
Fix Error: Function lookup() did not find a value for the name 'tftp:…

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,7 @@
 # @summary The default parameters for the foreman proxy
 # @api private
 class foreman_proxy::params inherits foreman_proxy::globals {
-  $tftp_root = lookup('tftp::root', undef, undef, '/not/used')
+  $tftp_root = lookup('tftp::root', Stdlib::Unixpath, undef, '/not/used')
   $lower_fqdn = downcase($facts['networking']['fqdn'])
 
   case $facts['os']['family'] {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,7 @@
 # @summary The default parameters for the foreman proxy
 # @api private
 class foreman_proxy::params inherits foreman_proxy::globals {
-  $tftp_root = lookup('tftp::root')
+  $tftp_root = lookup('tftp::root', undef, undef, '/not/used')
   $lower_fqdn = downcase($facts['networking']['fqdn'])
 
   case $facts['os']['family'] {


### PR DESCRIPTION
…:root'

https://github.com/theforeman/puppet-foreman_proxy/commit/f849d1284d3ee0a41eae4becc8b1a561b668c93c
This change is 'problematic' for us as we don't use tftp (or dns, dhcp) so we don't have the tftp module installed.
It does cause the following error in our catalog compilation

Error: Function lookup() did not find a value for the name 'tftp::root' 

This 'naive' change seems to fix that issue.