### PR TITLE
Support changing the base URL for Yum repositories

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -259,6 +259,8 @@
 #
 # $gpgcheck::                   Turn on/off gpg check in repo files (effective only on RedHat family systems)
 #
+# $yum_repo_baseurl::           Base URL for the Yum repositories
+#
 # $dhcp_failover_address::      Address for DHCP to listen for connections from its peer
 #
 # $dhcp_failover_port::         Port for DHCP to listen & communicate with it DHCP peer
@@ -289,6 +291,7 @@ class foreman_proxy (
   Optional[String] $repo = $foreman_proxy::params::repo,
   Boolean $gpgcheck = $foreman_proxy::params::gpgcheck,
   String $version = $foreman_proxy::params::version,
+  Stdlib::HTTPUrl $yum_repo_baseurl = $foreman_proxy::params::yum_repo_baseurl,
   Enum['latest', 'present', 'installed', 'absent'] $ensure_packages_version = $foreman_proxy::params::ensure_packages_version,
   Variant[Array[String], String] $bind_host = $foreman_proxy::params::bind_host,
   Integer[0, 65535] $http_port = $foreman_proxy::params::http_port,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,9 +3,10 @@
 class foreman_proxy::install {
   if $foreman_proxy::repo {
     foreman::repos { 'foreman_proxy':
-      repo     => $foreman_proxy::repo,
-      gpgcheck => $foreman_proxy::gpgcheck,
-      before   => Package['foreman-proxy'],
+      repo             => $foreman_proxy::repo,
+      gpgcheck         => $foreman_proxy::gpgcheck,
+      yum_repo_baseurl => $foreman_proxy::yum_repo_baseurl,
+      before           => Package['foreman-proxy'],
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -137,6 +137,7 @@ class foreman_proxy::params inherits foreman_proxy::globals {
   $repo                    = undef
   $gpgcheck                = true
   $version                 = 'present'
+  $yum_repo_baseurl        = 'https://yum.theforeman.org'
   $ensure_packages_version = 'present'
 
   # Enable listening on http

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -937,6 +937,24 @@ describe 'foreman_proxy' do
         end
       end
 
+      context 'with nightly repo' do
+        let(:params) { super().merge(repo: 'nightly') }
+
+        it 'should include repos via foreman::repos with default base URL' do
+          should contain_foreman__repos('foreman_proxy')
+            .with_yum_repo_baseurl('https://yum.theforeman.org')
+        end
+      end
+
+      context 'with yum_repo_baseurl and nightly repo' do
+        let(:params) { super().merge(yum_repo_baseurl: 'http://example.org', repo: 'nightly') }
+
+        it 'should include repos via foreman::repos with custom base URL' do
+          should contain_foreman__repos('foreman_proxy')
+            .with_yum_repo_baseurl('http://example.org')
+        end
+      end
+
       describe 'manage_puppet_group' do
         context 'when puppet and puppetca are false and manage_puppet_group = true' do
           let(:params) do


### PR DESCRIPTION
This patchset adapts puppet-foreman_proxy to the new interface of `foreman::repos` which now requires a base URL for Yum repositories to be set.

See https://github.com/theforeman/puppet-foreman/pull/943

Fixes #671 

Unblocks https://github.com/theforeman/puppet-foreman/pull/948