### PR TITLE
Remove Foreman repository parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -255,10 +255,6 @@
 #
 # === Advanced parameters:
 #
-# $repo::                       Which repository to use. Can be a specific version or nightly. Will not configure anything when undefined.
-#
-# $gpgcheck::                   Turn on/off gpg check in repo files (effective only on RedHat family systems)
-#
 # $dhcp_failover_address::      Address for DHCP to listen for connections from its peer
 #
 # $dhcp_failover_port::         Port for DHCP to listen & communicate with it DHCP peer
@@ -286,8 +282,6 @@
 # $puppetca_certificate::       Token-whitelisting only: Certificate to use when encrypting tokens (undef to use SSL certificate)
 #
 class foreman_proxy (
-  Optional[String] $repo = $foreman_proxy::params::repo,
-  Boolean $gpgcheck = $foreman_proxy::params::gpgcheck,
   String $version = $foreman_proxy::params::version,
   Enum['latest', 'present', 'installed', 'absent'] $ensure_packages_version = $foreman_proxy::params::ensure_packages_version,
   Variant[Array[String], String] $bind_host = $foreman_proxy::params::bind_host,
@@ -431,6 +425,8 @@ class foreman_proxy (
   contain foreman_proxy::config
   contain foreman_proxy::service
   contain foreman_proxy::register
+
+  Anchor <| title == 'foreman::repo' |> ~> Class['foreman_proxy::install']
 
   # lint:ignore:spaceship_operator_without_tag
   Class['foreman_proxy::install']

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,14 +1,6 @@
 # @summary Install the foreman proxy
 # @api private
 class foreman_proxy::install {
-  if $foreman_proxy::repo {
-    foreman::repos { 'foreman_proxy':
-      repo     => $foreman_proxy::repo,
-      gpgcheck => $foreman_proxy::gpgcheck,
-      before   => Package['foreman-proxy'],
-    }
-  }
-
   package {'foreman-proxy':
     ensure => $foreman_proxy::version,
   }
@@ -17,16 +9,10 @@ class foreman_proxy::install {
     package { 'foreman-proxy-journald':
       ensure => installed,
     }
-    if $foreman_proxy::repo {
-      Foreman::Repos['foreman_proxy'] -> Package['foreman-proxy-journald']
-    }
   }
 
   if $foreman_proxy::register_in_foreman {
     contain foreman::providers
-    if $foreman_proxy::repo {
-      Foreman::Repos['foreman_proxy'] -> Class['foreman::providers']
-    }
   }
 
   if $foreman_proxy::bmc and $foreman_proxy::bmc_default_provider != 'shell' {

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -985,6 +985,19 @@ describe 'foreman_proxy' do
           end
         end
       end
+
+      context 'with foreman::repo included', unless: ['FreeBSD', 'DragonFly'].include?(facts[:operatingsystem]) do
+        let(:pre_condition) do
+          <<-PUPPET
+          class { 'foreman::repo':
+            repo => 'nightly',
+          }
+          PUPPET
+        end
+
+        it { should compile.with_all_deps }
+        it { should contain_package('foreman-proxy').that_requires('Anchor[foreman::repo]') }
+      end
     end
   end
 end


### PR DESCRIPTION
This prefers that the Foreman class repo is used. The benefit is that a user doesn't end up with effectively the same repository twice. Once named foreman and once foreman_proxy, but pointing to the same URL.

To keep the order consistent, it does collect the anchor that foreman::repo has which guarantees that the repo is set up before packages are installed.