### PR TITLE
set puppet version under puppet.yml to enable puppet module

### DIFF
--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -211,6 +211,7 @@ describe 'foreman_proxy' do
           verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/puppet.yml", [
             '---',
             ':enabled: https',
+            ":puppet_version: #{Puppet.version}",
           ])
         end
 

--- a/templates/puppet.yml.erb
+++ b/templates/puppet.yml.erb
@@ -1,3 +1,5 @@
 ---
 # Puppet management
 :enabled: <%= @module_enabled %>
+
+:puppet_version: <%= @puppetversion %>


### PR DESCRIPTION
Foreman 1.22 requires :puppet_version variable to be set to enable puppet module. This var was set before, but looks like was removed.