### PR TITLE
Default package versions to installed instead of present

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -283,7 +283,7 @@
 #
 class foreman_proxy (
   String $version = 'present',
-  Enum['latest', 'present', 'installed', 'absent'] $ensure_packages_version = 'present',
+  Enum['latest', 'present', 'installed', 'absent'] $ensure_packages_version = 'installed',
   Variant[Array[String], String] $bind_host = ['*'],
   Stdlib::Port $http_port = 8000,
   Stdlib::Port $ssl_port = 8443,

--- a/manifests/tftp/netboot.pp
+++ b/manifests/tftp/netboot.pp
@@ -18,7 +18,7 @@ class foreman_proxy::tftp::netboot (
   Enum['redhat', 'debian', 'none'] $grub_installation_type = $foreman_proxy::tftp::netboot::params::grub_installation_type,
   String $grub_modules = $foreman_proxy::tftp::netboot::params::grub_modules,
 ) inherits foreman_proxy::tftp::netboot::params {
-  ensure_packages($packages, { ensure => 'present', })
+  ensure_packages($packages, { ensure => 'installed', })
 
   # The symlink from grub2/boot to boot is needed for UEFI HTTP boot
   file {"${root}/grub2/boot":

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -68,7 +68,7 @@ describe 'foreman_proxy' do
         end
 
         it 'should not install wget' do
-          should_not contain_package('wget').with_ensure('present')
+          should_not contain_package('wget').with_ensure('installed')
         end
 
         it "should create the #{proxy_user_name} user" do
@@ -455,11 +455,11 @@ describe 'foreman_proxy' do
             .with_user(proxy_user_name)
             .with_root(tftp_root)
             .with_manage_wget(true)
-            .with_wget_version('present')
+            .with_wget_version('installed')
         end
 
         it 'should install wget' do
-          should contain_package('wget').with_ensure('present')
+          should contain_package('wget').with_ensure('installed')
         end
 
         context 'with custom tftp parameters' do
@@ -625,14 +625,14 @@ describe 'foreman_proxy' do
           let(:params) { super().merge(dns_provider: 'nsupdate') }
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_package(nsupdate_pkg).with_ensure('present') }
+          it { is_expected.to contain_package(nsupdate_pkg).with_ensure('installed') }
           it { is_expected.to contain_class('foreman_proxy::proxydns') }
 
           context 'dns_managed => false' do
             let(:params) { super().merge(dns_managed: false) }
 
             it { is_expected.to compile.with_all_deps }
-            it { is_expected.to contain_package(nsupdate_pkg).with_ensure('present') }
+            it { is_expected.to contain_package(nsupdate_pkg).with_ensure('installed') }
             it { is_expected.not_to contain_class('foreman_proxy::proxydns') }
           end
         end
@@ -641,7 +641,7 @@ describe 'foreman_proxy' do
           let(:params) { super().merge(dns_provider: 'nsupdate_gss') }
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_package(nsupdate_pkg).with_ensure('present') }
+          it { is_expected.to contain_package(nsupdate_pkg).with_ensure('installed') }
           it { is_expected.to contain_class('foreman_proxy::proxydns') }
 
           it 'should contain dns_tsig_* settings' do

--- a/spec/classes/foreman_proxy__tftp__netboot_spec.rb
+++ b/spec/classes/foreman_proxy__tftp__netboot_spec.rb
@@ -20,8 +20,8 @@ describe 'foreman_proxy::tftp::netboot' do
 
       if facts[:osfamily] == 'Debian'
         it { is_expected.to contain_class('foreman_proxy::tftp::netboot').with_grub_installation_type('debian') }
-        it { should contain_package('grub-common').with_ensure('present') }
-        it { should contain_package('grub-efi-amd64-bin').with_ensure('present') }
+        it { should contain_package('grub-common').with_ensure('installed') }
+        it { should contain_package('grub-efi-amd64-bin').with_ensure('installed') }
 
         it 'should generate efi image from grub2 modules for Debian' do
           should contain_exec('build-grub2-efi-image').with_unless("/bin/grep -q regexp '/tftproot/grub2/grubx64.efi'")
@@ -34,10 +34,10 @@ describe 'foreman_proxy::tftp::netboot' do
         it { should contain_file("/tftproot/grub2/shim.efi").with_ensure('link') }
       elsif facts[:osfamily] == 'RedHat'
         it { is_expected.to contain_class('foreman_proxy::tftp::netboot').with_grub_installation_type('redhat') }
-        it { should contain_package('grub2-efi-x64').with_ensure('present') }
-        it { should contain_package('grub2-efi-x64-modules').with_ensure('present') }
-        it { should contain_package('grub2-tools').with_ensure('present') }
-        it { should contain_package('shim-x64').with_ensure('present') }
+        it { should contain_package('grub2-efi-x64').with_ensure('installed') }
+        it { should contain_package('grub2-efi-x64-modules').with_ensure('installed') }
+        it { should contain_package('grub2-tools').with_ensure('installed') }
+        it { should contain_package('shim-x64').with_ensure('installed') }
 
         case facts[:operatingsystem]
         when /^(RedHat|Scientific|OracleLinux)$/


### PR DESCRIPTION
The release of puppetlabs-stdlib included a change to ensure_packages
that defaults to installed rather than present. Additionally, if
ensure_packages provides an override set to present, this is internally
converted to installed. Thus any previous test that checked for present
fails.

This updates the tests to check for installed and updates the defaults
within the module from present to installed to match the default behavior
of ensure_packages.

Ref: https://github.com/puppetlabs/puppetlabs-stdlib/commit/842992eb834d72163f5d2dcf8fab8deef15225f9