### PR TITLE
Fixes #33549 - Add parameter dhcp_ipxefilename to set a value for DHCP's iPXE filename

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -157,6 +157,11 @@
 #
 # $dhcp_pxefilename::           DHCP "filename" value, defaults otherwise to pxelinux.0
 #
+# $dhcp_ipxefilename::          iPXE DHCP "filename" value, If not specified, it's determined dynamically.
+#                               When the templates feature is enabled, the template_url is used.
+#
+# $dhcp_ipxe_bootstrap::        Enable or disable iPXE bootstrap(discovery) feature
+#
 # $dhcp_network::               DHCP server network value, defaults otherwise to value based on IP of dhcp_interface
 #
 # $dhcp_netmask::               DHCP server netmask value, defaults otherwise to value based on IP of dhcp_interface
@@ -358,6 +363,8 @@ class foreman_proxy (
   Variant[Undef, Boolean, String] $dhcp_range = undef,
   Optional[String] $dhcp_pxeserver = undef,
   String $dhcp_pxefilename = 'pxelinux.0',
+  Optional[String[1]] $dhcp_ipxefilename = undef,
+  Boolean $dhcp_ipxe_bootstrap = false,
   Optional[String] $dhcp_network = undef,
   Optional[String] $dhcp_netmask = undef,
   String $dhcp_nameservers = 'default',

--- a/manifests/proxydhcp.pp
+++ b/manifests/proxydhcp.pp
@@ -47,12 +47,24 @@ class foreman_proxy::proxydhcp {
     $conf_dir_mode = undef
   }
 
+  if $foreman_proxy::dhcp_ipxefilename {
+    $_dhcp_ipxefilename = $foreman_proxy::dhcp_ipxefilename
+  } elsif $foreman_proxy::templates and $foreman_proxy::dhcp_ipxe_bootstrap {
+    $_dhcp_ipxefilename = "${foreman_proxy::template_url}/unattended/iPXE?bootstrap=1"
+  } elsif $foreman_proxy::templates {
+    $_dhcp_ipxefilename = "${foreman_proxy::template_url}/unattended/iPXE"
+  } else {
+    $_dhcp_ipxefilename = undef
+  }
+
+
   class { 'dhcp':
     dnsdomain     => $foreman_proxy::dhcp_option_domain,
     nameservers   => $nameservers,
     interfaces    => [$foreman_proxy::dhcp_interface] + $foreman_proxy::dhcp_additional_interfaces,
     pxeserver     => $ip,
     pxefilename   => $foreman_proxy::dhcp_pxefilename,
+    ipxe_filename => $_dhcp_ipxefilename,
     omapi_name    => $foreman_proxy::dhcp_key_name,
     omapi_key     => $foreman_proxy::dhcp_key_secret,
     conf_dir_mode => $conf_dir_mode,

--- a/spec/classes/foreman_proxy__proxydhcp__spec.rb
+++ b/spec/classes/foreman_proxy__proxydhcp__spec.rb
@@ -37,6 +37,7 @@ describe 'foreman_proxy' do
             .with_interfaces(['eth0'])
             .with_pxeserver('192.0.2.10')
             .with_pxefilename('pxelinux.0')
+            .with_ipxe_filename(nil)
         end
 
         it do
@@ -210,6 +211,29 @@ describe 'foreman_proxy' do
 
         it { should compile.and_raise_error(/Could not get the ip address from fact ipaddress_doesnotexist/) }
       end
+
+      context 'with templates' do
+        let(:facts) { facts }
+        let(:params) { super().merge(templates: true) }
+
+        it { should compile.with_all_deps }
+        it { should contain_class('dhcp').with_ipxe_filename('http://foo.example.com:8000/unattended/iPXE') }
+
+        context 'with bootstrap' do
+          let(:params) { super().merge(dhcp_ipxe_bootstrap: true) }
+
+          it { should compile.with_all_deps }
+          it { should contain_class('dhcp').with_ipxe_filename('http://foo.example.com:8000/unattended/iPXE?bootstrap=1') }
+        end
+
+        context 'with explicit parameter' do
+          let(:params) { super().merge(dhcp_ipxefilename: 'http://customapi.example.com/boot') }
+
+          it { should compile.with_all_deps }
+          it { should contain_class('dhcp').with_ipxe_filename('http://customapi.example.com/boot') }
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
Hey folks,

I have added a parameter `dhcp_ipxefilename` to set a iPXE boot file in the isc dhcp server. [fixes #703]

Thanks in advance
Harm