### PR TITLE
Fixes #33590 - Support multiple DNS domains

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -382,7 +382,7 @@ class foreman_proxy (
   Boolean $dns_managed = true,
   String $dns_provider = 'nsupdate',
   String $dns_interface = $foreman_proxy::params::dns_interface,
-  Optional[Stdlib::Fqdn] $dns_zone = $foreman_proxy::params::dns_zone,
+  Variant[Array[Stdlib::Fqdn], Stdlib::Fqdn, Undef] $dns_zone = $foreman_proxy::params::dns_zone,
   Optional[Variant[String, Array[String]]] $dns_reverse = undef,
   String $dns_server = '127.0.0.1',
   Integer[0] $dns_ttl = 86400,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -156,16 +156,20 @@ class foreman_proxy::params inherits foreman_proxy::globals {
 
   # DHCP settings - requires optional DHCP puppet module
   $dhcp_interface        = pick(fact('networking.primary'), 'eth0')
-  $dhcp_option_domain    = [$facts['networking']['domain']]
+  if fact('networking.domain') {
+    $dhcp_option_domain = [$facts['networking']['domain']]
+  } else {
+    $dhcp_option_domain = []
+  }
   $dhcp_failover_address = fact('ipaddress')
 
   # DNS settings - requires optional DNS puppet module
   $dns_interface      = pick(fact('networking.primary'), 'eth0')
-  $dns_zone           = $facts['networking']['domain']
-  if $dns_zone {
-    $dns_realm        = upcase($dns_zone)
+  $dns_zone           = $dhcp_option_domain
+  if fact('networking.domain') {
+    $dns_realm = upcase($facts['networking']['domain'])
   } else {
-    $dns_realm        = undef
+    $dns_realm = undef
   }
   $dns_tsig_keytab    = "${config_dir}/dns.keytab"
   $dns_tsig_principal = "foremanproxy/${facts['networking']['fqdn']}@${dns_realm}"

--- a/manifests/proxydns.pp
+++ b/manifests/proxydns.pp
@@ -9,7 +9,7 @@
 #   zone(s).
 #
 # @param forward_zone
-#   The forward DNS zone name
+#   The forward DNS zone name or names
 #
 # @param reverse_zone
 #   The reverse DNS zone name
@@ -21,7 +21,7 @@
 class foreman_proxy::proxydns(
   $forwarders = $foreman_proxy::dns_forwarders,
   $interface = $foreman_proxy::dns_interface,
-  Stdlib::Fqdn $forward_zone = $foreman_proxy::dns_zone,
+  Variant[Array[Stdlib::Fqdn], Stdlib::Fqdn] $forward_zone = $foreman_proxy::dns_zone,
   $reverse_zone = $foreman_proxy::dns_reverse,
   String $soa = $facts['networking']['fqdn'],
 ) {

--- a/spec/classes/foreman_proxy__proxydns__spec.rb
+++ b/spec/classes/foreman_proxy__proxydns__spec.rb
@@ -56,13 +56,33 @@ describe 'foreman_proxy::proxydns' do
           end
 
           context 'with dns_zone overridden' do
-            let(:params) { super().merge(forward_zone: 'something.example.com') }
+            context 'as single string' do
+              let(:params) { super().merge(forward_zone: 'something.example.com') }
 
-            it 'should include the forward zone' do
-              should contain_dns__zone('something.example.com')
-                .with_soa('foo.example.com')
-                .with_reverse(false)
-                .with_soaip('192.168.100.1')
+              it 'should include the forward zone' do
+                should contain_dns__zone('something.example.com')
+                  .with_soa('foo.example.com')
+                  .with_reverse(false)
+                  .with_soaip('192.168.100.1')
+              end
+            end
+
+            context 'as array' do
+              let(:params) { super().merge(forward_zone: ['first.example.com', 'second.example.com']) }
+
+              it 'should include the first forward zone' do
+                should contain_dns__zone('first.example.com')
+                  .with_soa('foo.example.com')
+                  .with_reverse(false)
+                  .with_soaip('192.168.100.1')
+              end
+
+              it 'should include the second forward zone' do
+                should contain_dns__zone('second.example.com')
+                  .with_soa('foo.example.com')
+                  .with_reverse(false)
+                  .with_soaip('192.168.100.1')
+              end
             end
           end
 

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -626,7 +626,7 @@ describe 'foreman_proxy' do
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_package(nsupdate_pkg).with_ensure('installed') }
-          it { is_expected.to contain_class('foreman_proxy::proxydns') }
+          it { is_expected.to contain_class('foreman_proxy::proxydns').with_forward_zone(['example.com']) }
 
           context 'dns_managed => false' do
             let(:params) { super().merge(dns_managed: false) }
@@ -634,6 +634,18 @@ describe 'foreman_proxy' do
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_package(nsupdate_pkg).with_ensure('installed') }
             it { is_expected.not_to contain_class('foreman_proxy::proxydns') }
+          end
+
+          context 'single domain as string' do
+            let(:params) { super().merge(dns_zone: 'example.com') }
+
+            it { is_expected.to contain_class('foreman_proxy::proxydns').with_forward_zone('example.com') }
+          end
+
+          context 'multiple domains' do
+            let(:params) { super().merge(dns_zone: ['first.example.com', 'second.example.com']) }
+
+            it { is_expected.to contain_class('foreman_proxy::proxydns').with_forward_zone(['first.example.com', 'second.example.com']) }
           end
         end
 


### PR DESCRIPTION
This changes the dns_zone option from an optional string to an array which allows creating multiple zones. For compatibility it still supports the single string and undef options. In a major release this should be changed to only accept an array.