### PR TITLE
Fixes #33808: Make templates listen on both again

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -327,7 +327,7 @@ class foreman_proxy (
   Stdlib::Absolutepath $puppet_ssl_key = $foreman_proxy::params::ssl_key,
   Integer[0] $puppet_api_timeout = 30,
   Boolean $templates = false,
-  Foreman_proxy::ListenOn $templates_listen_on = 'https',
+  Foreman_proxy::ListenOn $templates_listen_on = 'both',
   Stdlib::HTTPUrl $template_url = $foreman_proxy::params::template_url,
   Boolean $registration = true,
   Foreman_proxy::ListenOn $registration_listen_on = 'https',


### PR DESCRIPTION
In cf0da38cc900f3d927e4de9eed8f4fabc7c5bedc the parameters were changed and this unintentionally introduced a regression by changing the default from both to https.

Fixes: cf0da38cc900f3d927e4de9eed8f4fabc7c5bedc