### PR TITLE
Fixes #33808 - Make templates listen on both again

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -15,7 +15,9 @@ fixtures:
     foreman:  'https://github.com/theforeman/puppet-foreman'
     puppet:   'https://github.com/theforeman/puppet-puppet'
     redis:    'https://github.com/voxpupuli/puppet-redis'
-    stdlib:   'https://github.com/puppetlabs/puppetlabs-stdlib'
+    stdlib:
+      repo: 'https://github.com/puppetlabs/puppetlabs-stdlib'
+      ref: 'v7.1.0'
     sudo:     'https://github.com/saz/puppet-sudo'
     systemd:  'https://github.com/camptocamp/puppet-systemd'
     tftp:     'https://github.com/theforeman/puppet-tftp'

--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,7 @@ gem 'puppet_metadata', '~> 0.3'
 gem 'puppet-blacksmith', '>= 6.0.0', {"groups"=>["development"]}
 gem 'voxpupuli-acceptance', '~> 1.0', {"groups"=>["system_tests"]}
 
+# Pin rdoc to prevent updating bundled psych (https://github.com/ruby/rdoc/commit/ebe185c8775b2afe844eb3da6fa78adaa79e29a4)
+gem 'rdoc', '< 6.4'
+
 # vim:ft=ruby

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -327,7 +327,7 @@ class foreman_proxy (
   Stdlib::Absolutepath $puppet_ssl_key = $foreman_proxy::params::ssl_key,
   Integer[0] $puppet_api_timeout = 30,
   Boolean $templates = false,
-  Foreman_proxy::ListenOn $templates_listen_on = 'https',
+  Foreman_proxy::ListenOn $templates_listen_on = 'both',
   Stdlib::HTTPUrl $template_url = $foreman_proxy::params::template_url,
   Boolean $registration = true,
   Foreman_proxy::ListenOn $registration_listen_on = 'https',


### PR DESCRIPTION
In cf0da38cc900f3d927e4de9eed8f4fabc7c5bedc the parameters were changed
and this unintentionally introduced a regression by changing the default
from both to https.

Fixes: cf0da38cc900f3d927e4de9eed8f4fabc7c5bedc
(cherry picked from commit 0d5afc55976bbdcde8a8941a337a6364778ec133)