### PR TITLE
[REX SSH Plugin] Don't manage net-ssh-krb package

### DIFF
--- a/manifests/plugin/remote_execution/ssh.pp
+++ b/manifests/plugin/remote_execution/ssh.pp
@@ -53,13 +53,6 @@ class foreman_proxy::plugin::remote_execution::ssh (
     listen_on => $listen_on,
   }
 
-  if $ssh_kerberos_auth {
-    $kerberos_pkg = "${foreman_proxy::params::ruby_package_prefix}net-ssh-krb"
-    package { $kerberos_pkg:
-      ensure => present,
-    }
-  }
-
   if $generate_keys {
     class { 'foreman_proxy::plugin::remote_execution::ssh::keys':
       install_key       => $install_key,

--- a/spec/classes/foreman_proxy__plugin__remote_execution__ssh_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__remote_execution__ssh_spec.rb
@@ -5,7 +5,6 @@ describe 'foreman_proxy::plugin::remote_execution::ssh' do
     context "on #{os}" do
       let(:facts) { os_facts }
       let(:pre_condition) { 'include foreman_proxy' }
-      let(:package_name) { os.start_with?('debian') ? 'ruby-net-ssh-krb' : 'tfm-rubygem-net-ssh-krb' }
 
       describe 'with default settings' do
         it { should contain_class('foreman_proxy::plugin::dynflow') }
@@ -29,7 +28,6 @@ describe 'foreman_proxy::plugin::remote_execution::ssh' do
         end
 
         it { should_not contain_file('/root/.ssh') }
-        it { should_not contain_package(package_name) }
       end
 
       describe 'with override parameters' do
@@ -66,7 +64,6 @@ describe 'foreman_proxy::plugin::remote_execution::ssh' do
 
         it { should_not contain_exec('generate_ssh_key') }
         it { should_not contain_file('/root/.ssh') }
-        it { should contain_package(package_name) }
       end
 
       describe 'with ssh key generating and installation' do


### PR DESCRIPTION
The package is not required since smart_proxy_remote_execution_ssh-0.5.0
and is no longer packaged in foreman repositories