### PR TITLE
Ensure the config directory, user and deal with a missing domain

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,10 +40,14 @@ class foreman_proxy::config {
     ensure  => 'present',
     shell   => $foreman_proxy::shell,
     comment => 'Foreman Proxy daemon user',
+    gid     => $foreman_proxy::group,
     groups  => $foreman_proxy::groups + $dns_groups + $puppet_groups,
     home    => $foreman_proxy::dir,
-    require => Class['foreman_proxy::install'],
-    notify  => Class['foreman_proxy::service'],
+    system  => true,
+  }
+
+  group { $foreman_proxy::group:
+    system => true,
   }
 
   # Provided by packaging, defined here to allow autorequire for files

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -46,6 +46,13 @@ class foreman_proxy::config {
     notify  => Class['foreman_proxy::service'],
   }
 
+  # Provided by packaging, defined here to allow autorequire for files
+  file { $foreman_proxy::config_dir:
+    ensure => directory,
+    owner  => 'root',
+    group  => 0,
+  }
+
   foreman_proxy::settings_file { 'settings':
     path => "${foreman_proxy::config_dir}/settings.yml",
   }

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -3,6 +3,9 @@
 # @param user
 #   The user under which Foreman Proxy runs
 #
+# @param group
+#   The group under which Foreman Proxy runs
+#
 # @param dir
 #   The directory where Foreman Proxy is deployed
 #
@@ -11,6 +14,7 @@
 #
 class foreman_proxy::globals (
   Optional[String] $user = undef,
+  Optional[String] $group = undef,
   Optional[Stdlib::Absolutepath] $dir = undef,
   Enum['latest', 'present', 'installed', 'absent'] $plugin_version = 'installed',
 ) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -159,7 +159,11 @@ class foreman_proxy::params inherits foreman_proxy::globals {
 
   # DHCP settings - requires optional DHCP puppet module
   $dhcp_interface        = pick(fact('networking.primary'), 'eth0')
-  $dhcp_option_domain    = [$facts['networking']['domain']]
+  if fact('networking.domain') {
+    $dhcp_option_domain  = [$facts['networking']['domain']]
+  } else {
+    $dhcp_option_domain  = []
+  }
   $dhcp_failover_address = fact('ipaddress')
 
   # DNS settings - requires optional DNS puppet module

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class foreman_proxy::params inherits foreman_proxy::globals {
       $etc   = '/etc'
       $shell = '/bin/false'
       $user  = pick($foreman_proxy::globals::user, 'foreman-proxy')
+      $group = pick($foreman_proxy::globals::group, 'foreman-proxy')
 
       $dhcp_config = '/etc/dhcp/dhcpd.conf'
       $dhcp_leases = '/var/lib/dhcpd/dhcpd.leases'
@@ -53,6 +54,7 @@ class foreman_proxy::params inherits foreman_proxy::globals {
       $etc   = '/etc'
       $shell = '/bin/false'
       $user  = pick($foreman_proxy::globals::user, 'foreman-proxy')
+      $group = pick($foreman_proxy::globals::group, 'foreman-proxy')
 
       $dhcp_config = '/etc/dhcp/dhcpd.conf'
       $dhcp_leases = '/var/lib/dhcp/dhcpd.leases'
@@ -80,6 +82,7 @@ class foreman_proxy::params inherits foreman_proxy::globals {
       $etc   = '/usr/local/etc'
       $shell = '/usr/bin/false'
       $user  = pick($foreman_proxy::globals::user, 'foreman_proxy')
+      $group = pick($foreman_proxy::globals::group, 'foreman_proxy')
 
       $puppet_bindir = '/usr/local/bin'
       $puppetdir     = '/usr/local/etc/puppet'

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -347,6 +347,12 @@ describe 'foreman_proxy' do
         end
       end
 
+      context 'without a domain' do
+        let(:facts) { override_facts(super(), networking: {domain: nil}, domain: nil) }
+
+        it { is_expected.to compile.with_all_deps }
+      end
+
       context 'with custom foreman_ssl params' do
         let :params do
           super().merge(

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -70,15 +70,15 @@ describe 'foreman_proxy' do
         end
 
         it "should create the #{proxy_user_name} user" do
-          should contain_user("#{proxy_user_name}").with({
-            :ensure  => 'present',
-            :shell   => "#{shell}",
-            :comment => 'Foreman Proxy daemon user',
-            :groups  => ['puppet'],
-            :home    => "#{home_dir}",
-            :require => 'Class[Foreman_proxy::Install]',
-            :notify  => 'Class[Foreman_proxy::Service]',
-          })
+          should contain_user("#{proxy_user_name}")
+            .with_ensure('present')
+            .with_shell(shell)
+            .with_comment('Foreman Proxy daemon user')
+            .with_gid(proxy_user_name)
+            .with_groups(['puppet'])
+            .with_home(home_dir)
+            .that_requires('Class[Foreman_proxy::Install]')
+            .that_notifies('Class[Foreman_proxy::Service]')
         end
 
         it 'should create configuration files' do


### PR DESCRIPTION
This provides auto requires, for example when you want to manage certificates in the config directory.