### PR TITLE
Add acceptance tests for remote_execution::ssh

### DIFF
--- a/examples/remote_execution_ssh.pp
+++ b/examples/remote_execution_ssh.pp
@@ -1,0 +1,2 @@
+include foreman_proxy
+include foreman_proxy::plugin::remote_execution::ssh

--- a/spec/acceptance/remote_execution_ssh_spec.rb
+++ b/spec/acceptance/remote_execution_ssh_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper_acceptance'
+
+describe 'Scenario: install foreman-proxy with remote_execution ssh plugin'  do
+  before(:context) { purge_installed_packages }
+
+  include_examples 'the example', 'remote_execution_ssh.pp'
+
+  it_behaves_like 'the default foreman proxy application'
+end

--- a/spec/acceptance/remote_execution_ssh_spec.rb
+++ b/spec/acceptance/remote_execution_ssh_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'Scenario: install foreman-proxy with remote_execution ssh plugin'  do
+describe 'Scenario: install foreman-proxy with remote_execution ssh plugin' do
   before(:context) { purge_installed_packages }
 
   include_examples 'the example', 'remote_execution_ssh.pp'


### PR DESCRIPTION
Idempotency is currently broke due to a mismatch between Puppet and packaging: see https://github.com/theforeman/foreman-packaging/pull/7799