### PR TITLE
Fixes #34774 - don't expose tftp syslinux files directly

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -12,10 +12,14 @@
 # @param plugin_version
 #   The default plugin package state to ensure
 #
+# @param tftp_syslinux_filenames
+#   Syslinux files to install on TFTP (full paths)
+#
 class foreman_proxy::globals (
   Optional[String] $user = undef,
   Optional[String] $group = undef,
   Optional[Stdlib::Absolutepath] $dir = undef,
   Enum['latest', 'present', 'installed', 'absent'] $plugin_version = 'installed',
+  Optional[Array[Stdlib::Absolutepath]] $tftp_syslinux_filenames = undef,
 ) {
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -112,8 +112,6 @@
 #
 # $tftp_manage_wget::           If enabled will install the wget package
 #
-# $tftp_syslinux_filenames::    Syslinux files to install on TFTP (full paths)
-#
 # $tftp_root::                  TFTP root directory
 #
 # $tftp_dirs::                  Directories to be create in $tftp_root
@@ -344,7 +342,6 @@ class foreman_proxy (
   Foreman_proxy::ListenOn $tftp_listen_on = 'https',
   Boolean $tftp_managed = true,
   Boolean $tftp_manage_wget = true,
-  Array[Stdlib::Absolutepath] $tftp_syslinux_filenames = $foreman_proxy::params::tftp_syslinux_filenames,
   Optional[Stdlib::Absolutepath] $tftp_root = $foreman_proxy::params::tftp_root,
   Optional[Array[Stdlib::Absolutepath]] $tftp_dirs = undef,
   Optional[String] $tftp_servername = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,7 +26,7 @@ class foreman_proxy::params inherits foreman_proxy::globals {
       $nsupdate = 'bind-utils'
 
       if versioncmp($facts['os']['release']['major'], '7') <= 0 {
-        $tftp_syslinux_filenames = [
+        $_tftp_syslinux_filenames = [
           '/usr/share/syslinux/chain.c32',
           '/usr/share/syslinux/mboot.c32',
           '/usr/share/syslinux/menu.c32',
@@ -34,7 +34,7 @@ class foreman_proxy::params inherits foreman_proxy::globals {
           '/usr/share/syslinux/pxelinux.0',
         ]
       } else {
-        $tftp_syslinux_filenames = [
+        $_tftp_syslinux_filenames = [
           '/usr/share/syslinux/chain.c32',
           '/usr/share/syslinux/ldlinux.c32',
           '/usr/share/syslinux/libcom32.c32',
@@ -63,7 +63,7 @@ class foreman_proxy::params inherits foreman_proxy::globals {
       $keyfile  = '/etc/bind/rndc.key'
       $nsupdate = 'dnsutils'
 
-      $tftp_syslinux_filenames = [
+      $_tftp_syslinux_filenames = [
         '/usr/lib/PXELINUX/pxelinux.0',
         '/usr/lib/syslinux/memdisk',
         '/usr/lib/syslinux/modules/bios/chain.c32',
@@ -95,7 +95,7 @@ class foreman_proxy::params inherits foreman_proxy::globals {
       $keyfile  = '/usr/local/etc/namedb/rndc.key'
       $nsupdate = 'bind-tools'
 
-      $tftp_syslinux_filenames = [
+      $_tftp_syslinux_filenames = [
         '/usr/local/share/syslinux/bios/core/pxelinux.0',
         '/usr/local/share/syslinux/bios/memdisk/memdisk',
         '/usr/local/share/syslinux/bios/com32/chain/chain.c32',
@@ -110,6 +110,8 @@ class foreman_proxy::params inherits foreman_proxy::globals {
       fail("${facts['networking']['hostname']}: This module does not support osfamily ${facts['os']['family']}")
     }
   }
+
+  $tftp_syslinux_filenames = pick($foreman_proxy::globals::tftp_syslinux_filenames, $_tftp_syslinux_filenames)
 
   if $facts['os']['family'] !~ /^(FreeBSD|DragonFly)$/ {
     if fact('aio_agent_version') =~ String[1] {

--- a/manifests/tftp.pp
+++ b/manifests/tftp.pp
@@ -4,7 +4,7 @@ class foreman_proxy::tftp (
   String[1] $user = $foreman_proxy::user,
   Optional[Stdlib::Absolutepath] $root = $foreman_proxy::tftp_root,
   Optional[Array[Stdlib::Absolutepath]] $directories = $foreman_proxy::tftp_dirs,
-  Array[Stdlib::Absolutepath] $syslinux_filenames = $foreman_proxy::tftp_syslinux_filenames,
+  Array[Stdlib::Absolutepath] $syslinux_filenames = $foreman_proxy::params::tftp_syslinux_filenames,
   Boolean $manage_wget = $foreman_proxy::tftp_manage_wget,
   String[1] $wget_version = $foreman_proxy::ensure_packages_version,
   Boolean $tftp_replace_grub2_cfg = $foreman_proxy::tftp_replace_grub2_cfg,

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -506,20 +506,6 @@ describe 'foreman_proxy' do
         context 'with tftp_managed => true' do
           let(:params) { super().merge(tftp_managed: true) }
 
-          context 'tftp_syslinux_filenames set' do
-            let(:params) do
-              super().merge(
-                tftp_root: '/tftpboot',
-                tftp_syslinux_filenames: ['/my/file', '/my/anotherfile'],
-              )
-            end
-
-            it 'should copy the given files' do
-              should contain_file('/tftpboot/file').with_source('/my/file')
-              should contain_file('/tftpboot/anotherfile').with_source('/my/anotherfile')
-            end
-          end
-
           context 'with tftp_manage_wget disabled' do
             let(:params) { super().merge(tftp_manage_wget: false) }
             it { should_not contain_package('wget') }


### PR DESCRIPTION
advanced users who might want to change this, can override this by
setting `foreman_proxy::globals::tftp_syslinux_filenames` in hiera