### PR TITLE
add foreman::shell param

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -15,11 +15,15 @@
 # @param tftp_syslinux_filenames
 #   Syslinux files to install on TFTP (full paths)
 #
+# @param shell
+#   Shell of foreman-proxy user
+#
 class foreman_proxy::globals (
   Optional[String] $user = undef,
   Optional[String] $group = undef,
   Optional[Stdlib::Absolutepath] $dir = undef,
   Enum['latest', 'present', 'installed', 'absent'] $plugin_version = 'installed',
   Optional[Array[Stdlib::Absolutepath]] $tftp_syslinux_filenames = undef,
+  Optional[Stdlib::Absolutepath] $shell = undef,
 ) {
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,7 @@ class foreman_proxy::params inherits foreman_proxy::globals {
 
       $dir   = pick($foreman_proxy::globals::dir, '/usr/share/foreman-proxy')
       $etc   = '/etc'
-      $shell = '/bin/false'
+      $shell = pick($foreman_proxy::globals::shell, '/bin/false')
       $user  = pick($foreman_proxy::globals::user, 'foreman-proxy')
       $group = pick($foreman_proxy::globals::group, 'foreman-proxy')
 
@@ -52,7 +52,7 @@ class foreman_proxy::params inherits foreman_proxy::globals {
 
       $dir   = pick($foreman_proxy::globals::dir, '/usr/share/foreman-proxy')
       $etc   = '/etc'
-      $shell = '/bin/false'
+      $shell = pick($foreman_proxy::globals::shell, '/bin/false')
       $user  = pick($foreman_proxy::globals::user, 'foreman-proxy')
       $group = pick($foreman_proxy::globals::group, 'foreman-proxy')
 
@@ -80,7 +80,7 @@ class foreman_proxy::params inherits foreman_proxy::globals {
 
       $dir   = pick($foreman_proxy::globals::dir, '/usr/local/share/foreman-proxy')
       $etc   = '/usr/local/etc'
-      $shell = '/usr/bin/false'
+      $shell = pick($foreman_proxy::globals::shell, '/usr/bin/false')
       $user  = pick($foreman_proxy::globals::user, 'foreman_proxy')
       $group = pick($foreman_proxy::globals::group, 'foreman_proxy')
 

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -1042,6 +1042,18 @@ describe 'foreman_proxy' do
         it { should compile.with_all_deps }
         it { should contain_package('foreman-proxy').that_requires('Anchor[foreman::repo]') }
       end
+
+      context 'with shell' do
+        let(:pre_condition) do
+          <<~PP
+          class { 'foreman_proxy::globals':
+            shell => "/dne/foo",
+          }
+          PP
+        end
+
+        it { should contain_user("#{proxy_user_name}").with_shell('/dne/foo') }
+      end
     end
   end
 end


### PR DESCRIPTION
To allow the login shell of the foreman-proxy user to be overridden.

On EL7, after the `smart_proxy_remote_execution_ssh` gem switched from `Net::SSH` to shelling out to run `ssh`, REX is completely broken for me with the `foreman-proxy` user's shell set to `/bin/false`.  Changing the shell to `/bin/bash` allows ssh to function.