### PR TITLE
Support BMC redfish integration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -214,6 +214,8 @@
 #
 # $bmc_default_provider::       BMC default provider.
 #
+# $bmc_redfish_verify_ssl::     BMC Redfish verify ssl.
+#
 # $bmc_ssh_user::               BMC SSH user.
 #
 # $bmc_ssh_key::                BMC SSH key location.
@@ -397,7 +399,8 @@ class foreman_proxy (
   String $libvirt_connection = 'qemu:///system',
   Boolean $bmc = false,
   Foreman_proxy::ListenOn $bmc_listen_on = 'https',
-  Enum['ipmitool', 'freeipmi', 'shell', 'ssh'] $bmc_default_provider = 'ipmitool',
+  Enum['ipmitool', 'freeipmi', 'redfish', 'shell', 'ssh'] $bmc_default_provider = 'ipmitool',
+  Boolean $bmc_redfish_verify_ssl = true,
   String $bmc_ssh_user = 'root',
   Stdlib::Absolutepath $bmc_ssh_key = '/usr/share/foreman/.ssh/id_rsa',
   # lint:ignore:quoted_booleans

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,7 +15,7 @@ class foreman_proxy::install {
     contain foreman::providers
   }
 
-  if $foreman_proxy::bmc and $foreman_proxy::bmc_default_provider != 'shell' {
+  if $foreman_proxy::bmc and !($foreman_proxy::bmc_default_provider in ['shell', 'redfish']) {
     ensure_packages([$foreman_proxy::bmc_default_provider], { ensure => $foreman_proxy::ensure_packages_version, })
   }
 

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -545,6 +545,19 @@ describe 'foreman_proxy' do
             ])
           end
         end
+
+        context 'redfish provider' do
+          let(:params) { super().merge(bmc_default_provider: 'redfish') }
+
+          it 'should enable bmc with ssh' do
+            verify_exact_contents(catalogue, "#{etc_dir}/foreman-proxy/settings.d/bmc.yml", [
+              '---',
+              ':enabled: https',
+              ':bmc_default_provider: redfish',
+              ':redfish_verify_ssl: true',
+            ])
+          end
+        end
       end
 
       context 'only http enabled' do

--- a/templates/bmc.yml.erb
+++ b/templates/bmc.yml.erb
@@ -4,6 +4,7 @@
 
 # Available providers:
 # - freeipmi / ipmitool - requires the appropriate package installed, and the rubyipmi gem
+# - redfish - RESTful API over HTTPS
 # - shell - for local reboot control (requires sudo access to /sbin/shutdown for the proxy user)
 # - ssh - limited remote control (status, reboot, turn off)
 :bmc_default_provider: <%= scope.lookupvar("foreman_proxy::bmc_default_provider") %>
@@ -18,4 +19,6 @@
 :bmc_ssh_powercycle: "<%= scope.lookupvar("foreman_proxy::bmc_ssh_powercycle") %>"
 :bmc_ssh_poweroff: "<%= scope.lookupvar("foreman_proxy::bmc_ssh_poweroff") %>"
 :bmc_ssh_poweron: "<%= scope.lookupvar("foreman_proxy::bmc_ssh_poweron") %>"
+<% elsif scope.lookupvar("foreman_proxy::bmc_default_provider") == 'redfish' -%>
+:redfish_verify_ssl: <%= scope.lookupvar("foreman_proxy::bmc_redfish_verify_ssl") %>
 <% end -%>


### PR DESCRIPTION
This adds Redfish BMC support

The feature is not (yet) documented anywhere, but the smart proxy supports Redfish and it seems to work fine: https://github.com/theforeman/smart-proxy/blob/develop/modules/bmc/bmc_api.rb#L421