### PR TITLE
correctly clean up mosquitto inbetween tests

### DIFF
--- a/spec/acceptance/ansible_spec.rb
+++ b/spec/acceptance/ansible_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Scenario: install foreman-proxy with ansible plugin'  do
-  before(:context) { purge_installed_packages }
+  before(:context) { purge_foreman_proxy }
 
   include_examples 'the example', 'ansible.pp'
 

--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Scenario: install foreman-proxy' do
-  before(:context) { purge_installed_packages }
+  before(:context) { purge_foreman_proxy }
 
   include_examples 'the example', 'basic.pp'
 

--- a/spec/acceptance/dns_spec.rb
+++ b/spec/acceptance/dns_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper_acceptance'
 # On EL bind runs using PIDFile in systemd which is broken under docker
 broken_pid_file = ENV['BEAKER_HYPERVISOR'] == 'docker' && host_inventory['facter']['os']['family'] == 'RedHat'
 describe 'Scenario: install foreman-proxy', unless: broken_pid_file do
-  before(:context) { purge_installed_packages }
+  before(:context) { purge_foreman_proxy }
 
   include_examples 'the example', 'dns.pp'
 

--- a/spec/acceptance/dual_spec.rb
+++ b/spec/acceptance/dual_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Scenario: install foreman-proxy with http and https enabled' do
-  before(:context) { purge_installed_packages }
+  before(:context) { purge_foreman_proxy }
 
   include_examples 'the example', 'dual.pp'
 

--- a/spec/acceptance/dynflow_spec.rb
+++ b/spec/acceptance/dynflow_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Scenario: install foreman-proxy', unless: ENV['BEAKER_HYPERVISOR'] == 'docker'  do
-  before(:context) { purge_installed_packages }
+  before(:context) { purge_foreman_proxy }
 
   include_examples 'the example', 'dynflow.pp'
 

--- a/spec/acceptance/http_spec.rb
+++ b/spec/acceptance/http_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Scenario: install foreman-proxy with http enabled' do
-  before(:context) { purge_installed_packages }
+  before(:context) { purge_foreman_proxy }
 
   it_behaves_like 'the example', 'http.pp'
 

--- a/spec/acceptance/journald_spec.rb
+++ b/spec/acceptance/journald_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Scenario: install foreman-proxy with journald' do
-  before(:context) { purge_installed_packages }
+  before(:context) { purge_foreman_proxy }
 
   include_examples 'the example', 'journald.pp'
 

--- a/spec/acceptance/netboot_spec.rb
+++ b/spec/acceptance/netboot_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Scenario: tftp' do
-  before(:context) { purge_installed_packages }
+  before(:context) { purge_foreman_proxy }
 
   include_examples 'the example', 'tftp.pp'
 

--- a/spec/acceptance/remote_execution_script_pull_mqtt_spec.rb
+++ b/spec/acceptance/remote_execution_script_pull_mqtt_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Scenario: install foreman-proxy with remote_execution script plugin with pull-mqtt'  do
-  before(:context) { purge_installed_packages }
+  before(:context) { purge_foreman_proxy }
 
   context 'with default params' do
     include_examples 'the example', 'remote_execution_script_pull_mqtt.pp'

--- a/spec/acceptance/remote_execution_script_spec.rb
+++ b/spec/acceptance/remote_execution_script_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'Scenario: install foreman-proxy with remote_execution script plugin'  do
-  before(:context) { purge_installed_packages }
+  before(:context) { purge_foreman_proxy }
 
   include_examples 'the example', 'remote_execution_script.pp'
 
@@ -13,7 +13,7 @@ describe 'Scenario: install foreman-proxy with remote_execution script plugin'  
 end
 
 describe 'Scenario: install foreman-proxy with remote_execution script plugin and ssh_log_level param' do
-  before(:context) { purge_installed_packages }
+  before(:context) { purge_foreman_proxy }
 
   include_examples 'the example', 'remote_execution_script-ssh_log_level.pp'
 

--- a/spec/support/acceptance/cleanup.rb
+++ b/spec/support/acceptance/cleanup.rb
@@ -1,8 +1,9 @@
-def purge_installed_packages
+def purge_foreman_proxy
   case os[:family]
   when /redhat|fedora/
-    on default, 'yum -y remove foreman* tfm-*'
+    on default, 'yum -y remove foreman* tfm-* mosquitto'
   when /debian|ubuntu/
-    on default, 'apt-get purge -y foreman*', { :acceptable_exit_codes => [0, 100] }
+    on default, 'apt-get purge -y foreman* mosquitto', { :acceptable_exit_codes => [0, 100] }
   end
+  on default, 'rm -rf /etc/mosquitto/'
 end


### PR DESCRIPTION
otherwise `remote_execution_script_pull_mqtt_spec.rb` leaves `mosquitto`
installed and `remote_execution_script_spec.rb` will encounter a system
where `/etc/mosquitto` exists