### PR TITLE
System foreman-proxy group

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -46,8 +46,10 @@ class foreman_proxy::config {
     system  => true,
   }
 
-  group { $foreman_proxy::group:
-    system => true,
+  if $foreman_proxy::manage_foreman_proxy_group {
+    group { $foreman_proxy::group:
+      system => true,
+    }
   }
 
   # Provided by packaging, defined here to allow autorequire for files

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,6 +76,8 @@
 # $manage_puppet_group::        Whether to ensure the $puppet_group exists.  Also ensures group owner of ssl keys and certs is $puppet_group
 #                               Not applicable when ssl is false.
 #
+# $manage_foreman_proxy_group:: Whether to manage foreman-proxy group creation.
+#
 # $puppet::                     Enable Puppet module for environment imports and Puppet runs
 #
 # $puppet_listen_on::           Protocols for the Puppet feature to listen on
@@ -324,6 +326,7 @@ class foreman_proxy (
   Integer[0] $puppetca_token_ttl = 360,
   Optional[Stdlib::Absolutepath] $puppetca_certificate = undef,
   Boolean $manage_puppet_group = true,
+  Boolean $manage_foreman_proxy_group = true,
   Boolean $puppet = true,
   Foreman_proxy::ListenOn $puppet_listen_on = 'https',
   Stdlib::HTTPUrl $puppet_url = $foreman_proxy::params::puppet_url,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,7 +76,7 @@
 # $manage_puppet_group::        Whether to ensure the $puppet_group exists.  Also ensures group owner of ssl keys and certs is $puppet_group
 #                               Not applicable when ssl is false.
 #
-# $manage_foreman_proxy_group:: Whether to manage foreman-proxy group creation.
+# $manage_foreman_proxy_group:: Whether to set foreman-proxy group as a system group with lower GID.
 #
 # $puppet::                     Enable Puppet module for environment imports and Puppet runs
 #


### PR DESCRIPTION
Let people manage whether foreman-proxy group should be a system group or not.
In my case i am getting a dependency cycle error starting from module version 22.0.0:

```
Error: Found 1 dependency cycle:
(Augeas[puppet::server::puppetserver::bootstrap] => Class[Puppet::Server::Puppetserver] => Class[Puppet::Server::Config] => Class[Foreman_proxy::Config] => Group[foreman-proxy] => User[puppet] => File[/opt/puppetlabs/puppet/cache/reports] => Class[Puppet::Server::Config])\nTry the '--graph' option and opening the resulting '.dot' file in OmniGraffle or GraphViz
Error: Failed to apply catalog: One or more resource dependency cycles detected in graph
```

