### PR TITLE
manage discovery plugin config file

### DIFF
--- a/examples/discovery.pp
+++ b/examples/discovery.pp
@@ -1,0 +1,2 @@
+include foreman_proxy
+include foreman_proxy::plugin::discovery

--- a/manifests/plugin/discovery.pp
+++ b/manifests/plugin/discovery.pp
@@ -7,6 +7,11 @@
 # $install_images::   Download and extract the discovery image
 #
 # === Advanced parameters:
+# $enabled::      Whether the module is enabled or disabled.
+#
+# $version::      The version to ensure
+#
+# $listen_on::    When enabled, it's configured to listen on HTTPS (default), HTTP or both.
 #
 # $tftp_root::    TFTP root directory where extracted discovery image will be installed
 #
@@ -15,15 +20,20 @@
 # $image_name::   tarball with images
 #
 class foreman_proxy::plugin::discovery (
+  Boolean $enabled = true,
+  Optional[String] $version = undef,
+  Foreman_proxy::ListenOn $listen_on = 'https',
   Boolean $install_images = $foreman_proxy::plugin::discovery::params::install_images,
   Stdlib::Absolutepath $tftp_root = $foreman_proxy::plugin::discovery::params::tftp_root,
   Stdlib::HTTPUrl $source_url = $foreman_proxy::plugin::discovery::params::source_url,
   String $image_name = $foreman_proxy::plugin::discovery::params::image_name,
 ) inherits foreman_proxy::plugin::discovery::params {
-  foreman_proxy::plugin { 'discovery':
+  foreman_proxy::plugin::module { 'discovery':
+    enabled   => $enabled,
+    feature   => 'Discovery',
+    listen_on => $listen_on,
+    version   => $version,
   }
-
-  foreman_proxy::feature { 'Discovery': }
 
   if $install_images {
     $tftp_root_clean = regsubst($tftp_root, '/$', '')

--- a/spec/acceptance/discovery_spec.rb
+++ b/spec/acceptance/discovery_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper_acceptance'
+
+describe 'Scenario: install foreman-proxy with discovery plugin'  do
+  before(:context) { purge_foreman_proxy }
+
+  include_examples 'the example', 'discovery.pp'
+
+  it_behaves_like 'the default foreman proxy application'
+
+  describe command('curl -sk https://127.0.0.1:8443/features | grep -q discovery') do
+    its(:exit_status) { should eq 0 }
+  end
+end

--- a/spec/classes/foreman_proxy__plugin__discovery_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__discovery_spec.rb
@@ -15,6 +15,22 @@ describe 'foreman_proxy::plugin::discovery' do
           '/var/lib/tftpboot'
         end
       end
+      let(:etc_dir) do
+        case facts[:osfamily]
+        when 'FreeBSD', 'DragonFly'
+          '/usr/local/etc'
+        else
+          '/etc'
+        end
+      end
+      let(:group) do
+        case facts[:osfamily]
+        when 'FreeBSD', 'DragonFly'
+          'foreman_proxy'
+        else
+          'foreman-proxy'
+        end
+      end
 
       describe 'without paramaters' do
         it { should compile.with_all_deps }
@@ -22,6 +38,16 @@ describe 'foreman_proxy::plugin::discovery' do
         it { should contain_foreman_proxy__feature('Discovery') }
         it { should_not contain_foreman_proxy__remote_file("#{tftproot}/boot/fdi-image-latest.tar") }
         it { should_not contain_exec('untar fdi-image-latest.tar') }
+
+        it do
+          is_expected.to contain_file("#{etc_dir}/foreman-proxy/settings.d/discovery.yml").with(
+            ensure: 'file',
+            owner: 'root',
+            group: group,
+            mode: '0640',
+            content: %r{:enabled: https},
+          )
+        end
       end
 
       describe 'with install_images => true' do

--- a/templates/plugin/discovery.yml.erb
+++ b/templates/plugin/discovery.yml.erb
@@ -1,0 +1,6 @@
+---
+:enabled: <%= @module_enabled %>
+
+# connection to discovered nodes
+#:node_scheme: https
+#:node_port: 8443


### PR DESCRIPTION
In our production environment, `/etc/foreman-proxy/settings.d` is purged of un-managed files.  This results in `/etc/foreman-proxy/settings.d/discovery.yml` being deleted and the discovery plugin becoming disabled.