### PR TITLE
Automatically include plugin dns provider classes

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,6 +24,9 @@ class foreman_proxy::config {
   if $foreman_proxy::dns and $foreman_proxy::dns_provider in ['nsupdate', 'nsupdate_gss'] and $foreman_proxy::dns_managed {
     include foreman_proxy::proxydns
     $dns_groups = [$foreman_proxy::proxydns::user_group]
+  } elsif $foreman_proxy::dns and $foreman_proxy::dns_provider in ['infoblox', 'powerdns', 'route53'] {
+    include "foreman_proxy::plugin::dns::${foreman_proxy::dns_provider}"
+    $dns_groups = []
   } else {
     $dns_groups = []
   }

--- a/manifests/plugin/dns/infoblox.pp
+++ b/manifests/plugin/dns/infoblox.pp
@@ -13,9 +13,9 @@
 # $dns_view::   The Infoblox DNS View
 #
 class foreman_proxy::plugin::dns::infoblox (
-  Stdlib::Host $dns_server = undef,
-  String $username = undef,
-  String $password = undef,
+  Stdlib::Host $dns_server,
+  String $username,
+  String $password,
   String $dns_view = 'default',
 ) {
   foreman_proxy::plugin::provider { 'dns_infoblox':

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -675,6 +675,24 @@ describe 'foreman_proxy' do
             ])
           end
         end
+
+        context 'when dns_provider => infoblox' do
+          let(:params) { super().merge(dns_provider: 'infoblox') }
+
+          it { is_expected.to compile.and_raise_error(/expects a value for parameter 'dns_server'/) }
+        end
+
+        context 'when dns_provider => powerdns' do
+          let(:params) { super().merge(dns_provider: 'powerdns') }
+
+          it { is_expected.to compile.and_raise_error(/expects a value for parameter 'rest_api_key'/) }
+        end
+
+        context 'when dns_provider => route53' do
+          let(:params) { super().merge(dns_provider: 'route53') }
+
+          it { is_expected.to compile.and_raise_error(/expects a value for parameter 'aws_access_key'/) }
+        end
       end
 
       context 'empty keyfile' do


### PR DESCRIPTION
When the user specifies a known DNS provider, the plugin class should be included to manage it. This also means it becomes possible to simply `include foreman_proxy` and fully configure it via Hiera without additional includes.