### PR TITLE
Drop ansible-runner repository management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Part of the Foreman installer: <https://github.com/theforeman/foreman-installer>
 
 | Module version | Proxy versions | Notes                                               |
 |----------------|----------------|-----------------------------------------------------|
+| 24.x           | 3.5 and newer  | See compatibility notes in its README for 3.1-3.4   |
 | 23.x           | 3.4 and newer  | See compatibility notes in its README for 3.1-3.3   |
 | 22.x           | 3.3 and newer  | See compatibility notes in its README for 3.1-3.3   |
 | 21.x           | 3.1 and 3.2    |                                                     |
@@ -27,6 +28,7 @@ Part of the Foreman installer: <https://github.com/theforeman/foreman-installer>
 | 2.x            | 1.5 - 1.10     |                                                     |
 | 1.x            | 1.4 and older  |                                                     |
 
+ * 24.x dropped management of ansible-runner repository, ansible-runner is now in the Foreman plugin repository. This requires Foreman 3.5.
  * 23.x dropped EL7 support. 3.1 and newer work on EL8.
  * 22.x renamed foreman_proxy::plugin::remote_execution::ssh to foreman_proxy::plugin::remote_execution::script as the feature within the plugin has changed from SSH to Script.
  * 20.x started to register as a Smart Proxy host. This requires Foreman 3.1. When using an older Foreman, set `$register_in_foreman` to false. This does require manual registration then.

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -28,8 +28,6 @@
 #
 # $install_runner:: If true, installs ansible-runner package to support running ansible by ansible-runner
 #
-# $manage_runner_repo:: If true, adds upstream repositories to install ansible-runner package from
-#
 # $callback:: The callback plugin to configure in ansible.cfg
 #
 # $runner_package_name:: The name of the ansible-runner package to install
@@ -46,7 +44,6 @@ class foreman_proxy::plugin::ansible (
   Array[Stdlib::Absolutepath] $roles_path = $foreman_proxy::plugin::ansible::params::roles_path,
   String $ssh_args = $foreman_proxy::plugin::ansible::params::ssh_args,
   Boolean $install_runner = $foreman_proxy::plugin::ansible::params::install_runner,
-  Boolean $manage_runner_repo = $foreman_proxy::plugin::ansible::params::manage_runner_repo,
   String $callback = $foreman_proxy::plugin::ansible::params::callback,
   String $runner_package_name = $foreman_proxy::plugin::ansible::params::runner_package_name,
   Array[Stdlib::Absolutepath] $collections_paths = $foreman_proxy::plugin::ansible::params::collections_paths,

--- a/manifests/plugin/ansible/runner.pp
+++ b/manifests/plugin/ansible/runner.pp
@@ -1,28 +1,14 @@
 # = Ansible runner package installation
 #
-# $manage_runner_repo:: If true, adds upstream repositories to install ansible-runner package from
-#
 # $package_name:: Name of the package to install to provide 'ansible-runner' command
 #
 class foreman_proxy::plugin::ansible::runner (
-  Boolean $manage_runner_repo = $foreman_proxy::plugin::ansible::manage_runner_repo,
   String  $package_name = $foreman_proxy::plugin::ansible::runner_package_name,
 ) {
-  if $manage_runner_repo {
-    case $facts['os']['family'] {
-      'RedHat': {
-        yumrepo { 'ansible-runner':
-          descr    => 'Ansible runner',
-          baseurl  => "https://releases.ansible.com/ansible-runner/rpm/epel-${facts['os']['release']['major']}-\$basearch/",
-          gpgcheck => true,
-          gpgkey   => 'https://releases.ansible.com/keys/RPM-GPG-KEY-ansible-release.pub',
-          enabled  => '1',
-          before   => Package[$package_name],
-        }
-      }
-      default: {
-        fail("Repository containing 'ansible-runner' not known for '${facts['os']['family']}'")
-      }
+  if $facts['os']['family'] == 'RedHat' {
+    yumrepo { 'ansible-runner':
+      ensure => absent,
+      before => Package[$package_name],
     }
   }
 

--- a/spec/classes/foreman_proxy__plugin__ansible_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__ansible_spec.rb
@@ -16,10 +16,7 @@ describe 'foreman_proxy::plugin::ansible' do
         when 'redhat-7-x86_64'
           it 'should include ansible-runner upstream repo' do
             should contain_yumrepo('ansible-runner')
-                   .with_baseurl("https://releases.ansible.com/ansible-runner/rpm/epel-7-$basearch/")
-                   .with_gpgcheck(true)
-                   .with_gpgkey('https://releases.ansible.com/keys/RPM-GPG-KEY-ansible-release.pub')
-                   .with_enabled('1')
+                   .with_ensure('absent')
                    .that_comes_before('Package[ansible-runner]')
           end
           it { should contain_package('ansible-runner').with_ensure('installed') }
@@ -61,7 +58,6 @@ describe 'foreman_proxy::plugin::ansible' do
             working_dir: '/tmp/ansible',
             host_key_checking: true,
             stdout_callback: 'debug',
-            manage_runner_repo: false,
           }
         end
 


### PR DESCRIPTION
The ansible-runner package is now delivered via the Foreman plugins repository.

Requires that ansible-runner be in the plugins repository (https://github.com/theforeman/foreman-packaging/pull/8434)