### PR TITLE
Change module feature default to capitalize

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -23,7 +23,7 @@ define foreman_proxy::module (
   Boolean $enabled = false,
   Foreman_proxy::ListenOn $listen_on = 'https',
   Optional[String] $template_path = undef,
-  String $feature = upcase($title),
+  String $feature = $title.capitalize(),
 ) {
   if $enabled {
     $module_enabled = $listen_on ? {

--- a/manifests/module/bmc.pp
+++ b/manifests/module/bmc.pp
@@ -11,6 +11,7 @@ class foreman_proxy::module::bmc (
 ) {
   foreman_proxy::module { 'bmc':
     enabled   => $enabled,
+    feature   => 'BMC',
     listen_on => $listen_on,
   }
 }

--- a/manifests/module/dhcp.pp
+++ b/manifests/module/dhcp.pp
@@ -11,6 +11,7 @@ class foreman_proxy::module::dhcp (
 ) {
   foreman_proxy::module { 'dhcp':
     enabled   => $enabled,
+    feature   => 'DHCP',
     listen_on => $listen_on,
   }
 }

--- a/manifests/module/dns.pp
+++ b/manifests/module/dns.pp
@@ -11,6 +11,7 @@ class foreman_proxy::module::dns (
 ) {
   foreman_proxy::module { 'dns':
     enabled   => $enabled,
+    feature   => 'DNS',
     listen_on => $listen_on,
   }
 }

--- a/manifests/module/tftp.pp
+++ b/manifests/module/tftp.pp
@@ -19,6 +19,7 @@ class foreman_proxy::module::tftp (
 
   foreman_proxy::module { 'tftp':
     enabled   => $enabled,
+    feature   => 'TFTP',
     listen_on => $listen_on,
   }
 }

--- a/spec/defines/foreman_proxy_module_spec.rb
+++ b/spec/defines/foreman_proxy_module_spec.rb
@@ -10,7 +10,7 @@ describe 'foreman_proxy::module' do
       context 'with defaults' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_foreman_proxy__settings_file('test').with_module_enabled('false') }
-        it { is_expected.not_to contain_foreman_proxy__feature('TEST') }
+        it { is_expected.not_to contain_foreman_proxy__feature('Test') }
       end
 
       context 'with enabled => true' do
@@ -18,7 +18,7 @@ describe 'foreman_proxy::module' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_foreman_proxy__settings_file('test').with_module_enabled('https') }
-        it { is_expected.to contain_foreman_proxy__feature('TEST') }
+        it { is_expected.to contain_foreman_proxy__feature('Test') }
 
         context 'with listen_on => both' do
           let(:params) { super().merge(listen_on: 'both') }
@@ -36,16 +36,16 @@ describe 'foreman_proxy::module' do
       end
 
       context 'with feature' do
-        let(:params) { { feature: 'Test' } }
+        let(:params) { { feature: 'TEST' } }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.not_to contain_foreman_proxy__feature('Test') }
+        it { is_expected.not_to contain_foreman_proxy__feature('TEST') }
 
         context 'with enabled => true' do
           let(:params) { super().merge(enabled: true) }
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_foreman_proxy__feature('Test') }
+          it { is_expected.to contain_foreman_proxy__feature('TEST') }
         end
       end
     end


### PR DESCRIPTION
foreman_proxy::plugin::module uses $title.capitalize() and now foreman::module does too. This makes it more consistent. It also explicitly sets the feature where needed. This was explained in an issue[1].

[1]: https://github.com/theforeman/puppet-foreman_proxy/pull/773#issuecomment-1206289813