### PR TITLE
Fixes #35809 - always enable rex when enabling ansible

### DIFF
--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -59,6 +59,7 @@ class foreman_proxy::plugin::ansible (
   }
 
   include foreman_proxy::plugin::dynflow
+  include foreman_proxy::plugin::remote_execution::script
   if $install_runner {
     include foreman_proxy::plugin::ansible::runner
   }

--- a/spec/classes/foreman_proxy__plugin__ansible_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__ansible_spec.rb
@@ -8,6 +8,7 @@ describe 'foreman_proxy::plugin::ansible' do
 
       describe 'with default settings' do
         it { should contain_class('foreman_proxy::plugin::dynflow') }
+        it { should contain_class('foreman_proxy::plugin::remote_execution::script') }
         it { should contain_foreman_proxy__plugin__module('ansible') }
 
         case os
@@ -58,6 +59,7 @@ describe 'foreman_proxy::plugin::ansible' do
         end
 
         it { should contain_class('foreman_proxy::plugin::dynflow') }
+        it { should contain_class('foreman_proxy::plugin::remote_execution::script') }
 
         case os
         when 'debian-10-x86_64'


### PR DESCRIPTION
sp_ansible depends on sp_rex to work, but we never properly setup the later unless the user *explicitly* also asks for it