### PR TITLE
Fixes #35925 - Enable ssh server keepalive for ansible

### DIFF
--- a/manifests/plugin/ansible/params.pp
+++ b/manifests/plugin/ansible/params.pp
@@ -9,7 +9,7 @@ class foreman_proxy::plugin::ansible::params {
   $working_dir = '/tmp'
   $host_key_checking = false
   $roles_path = ['/etc/ansible/roles', '/usr/share/ansible/roles']
-  $ssh_args = '-o ProxyCommand=none -C -o ControlMaster=auto -o ControlPersist=60s'
+  $ssh_args = '-o ProxyCommand=none -C -o ControlMaster=auto -o ControlPersist=60s -o ServerAliveInterval=15 -o ServerAliveCountMax=3'
   $install_runner = true
   $collections_paths = ['/etc/ansible/collections', '/usr/share/ansible/collections']
   case $facts['os']['family'] {

--- a/spec/classes/foreman_proxy__plugin__ansible_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__ansible_spec.rb
@@ -43,7 +43,7 @@ describe 'foreman_proxy::plugin::ansible' do
             'export FOREMAN_SSL_KEY="/etc/puppetlabs/puppet/ssl/private_keys/foo.example.com.pem"',
             'export FOREMAN_SSL_CERT="/etc/puppetlabs/puppet/ssl/certs/foo.example.com.pem"',
             'export FOREMAN_SSL_VERIFY="/etc/puppetlabs/puppet/ssl/certs/ca.pem"',
-            'export ANSIBLE_SSH_ARGS="-o ProxyCommand=none -C -o ControlMaster=auto -o ControlPersist=60s"',
+            'export ANSIBLE_SSH_ARGS="-o ProxyCommand=none -C -o ControlMaster=auto -o ControlPersist=60s -o ServerAliveInterval=15 -o ServerAliveCountMax=3"',
           ])
         end
       end
@@ -90,7 +90,7 @@ describe 'foreman_proxy::plugin::ansible' do
             'export FOREMAN_SSL_KEY="/etc/puppetlabs/puppet/ssl/private_keys/foo.example.com.pem"',
             'export FOREMAN_SSL_CERT="/etc/puppetlabs/puppet/ssl/certs/foo.example.com.pem"',
             'export FOREMAN_SSL_VERIFY="/etc/puppetlabs/puppet/ssl/certs/ca.pem"',
-            'export ANSIBLE_SSH_ARGS="-o ProxyCommand=none -C -o ControlMaster=auto -o ControlPersist=60s"',
+            'export ANSIBLE_SSH_ARGS="-o ProxyCommand=none -C -o ControlMaster=auto -o ControlPersist=60s -o ServerAliveInterval=15 -o ServerAliveCountMax=3"',
           ])
         end
       end


### PR DESCRIPTION
To properly detect if the remote end just disappears

Ansible counterpart of https://github.com/theforeman/smart_proxy_remote_execution_ssh/pull/100