### PR TITLE
require the grub packages before copying files on RedHat too

### DIFF
--- a/manifests/tftp/netboot.pp
+++ b/manifests/tftp/netboot.pp
@@ -34,15 +34,17 @@ class foreman_proxy::tftp::netboot (
       }
 
       file { "${root}/grub2/grubx64.efi":
-        ensure => file,
-        source => "/boot/efi/EFI/${grub_efi_path}/grubx64.efi",
+        ensure  => file,
+        source  => "/boot/efi/EFI/${grub_efi_path}/grubx64.efi",
+        require => Package[$packages],
       }
 
       file { "${root}/grub2/shimx64.efi":
-        ensure => file,
-        source => "/boot/efi/EFI/${grub_efi_path}/shimx64.efi",
-        mode   => '0644',
-        owner  => 'root',
+        ensure  => file,
+        source  => "/boot/efi/EFI/${grub_efi_path}/shimx64.efi",
+        mode    => '0644',
+        owner   => 'root',
+        require => Package[$packages],
       }
 
       file { "${root}/grub2/shim.efi":


### PR DESCRIPTION
this was done on Debian-family systems already, but not on RedHat, resulting in "double" errors if the package could not be installed:

    /Stage[main]/Foreman_proxy::Tftp::Netboot/Package[grub2-efi-x64]/ensure: change from 'purged' to 'present' failed: Execution of '/bin/dnf -d 0 -e 1 -y install grub2-efi-x64' returned 1: Error: Unable to find a match: grub2-efi-x64
    /Stage[main]/Foreman_proxy::Tftp::Netboot/File[/var/lib/tftpboot/grub2/grubx64.efi]: Could not evaluate: Could not retrieve information from environment production source(s) file:///boot/efi/EFI/redhat/grubx64.efi