### PR TITLE
Simplify grub_efi_path on redhat family

### DIFF
--- a/manifests/tftp/netboot.pp
+++ b/manifests/tftp/netboot.pp
@@ -28,10 +28,7 @@ class foreman_proxy::tftp::netboot (
 
   case $grub_installation_type {
     'redhat': {
-      $grub_efi_path = $facts['os']['name'] ? {
-        /Fedora|CentOS|AlmaLinux|Rocky/ => downcase($facts['os']['name']),
-        default         => 'redhat',
-      }
+      $grub_efi_path = downcase($facts['os']['name'])
 
       file { "${root}/grub2/grubx64.efi":
         ensure  => file,


### PR DESCRIPTION
Remains backwards-compatible with supported distros, and we don't have to look for openeuler or oraclelinux or any other EL variant.