### PR TITLE
Fixes #36940 - Add SecureBoot support for arbitrary operating systems to "Grub2 UEFI" PXE loaders

### DIFF
--- a/manifests/tftp.pp
+++ b/manifests/tftp.pp
@@ -13,7 +13,17 @@ class foreman_proxy::tftp (
     root => $root,
   }
 
-  $dirs = pick($directories, prefix(['pxelinux.cfg','grub','grub2','boot','ztp.cfg','poap.cfg'], "${tftp::root}/"))
+  $dirs = pick($directories, prefix([
+        'pxelinux.cfg',
+        'grub',
+        'grub2',
+        'boot',
+        'ztp.cfg',
+        'poap.cfg',
+        'host-config',
+        'bootloader-universe',
+        'bootloader-universe/pxegrub2',
+  ], "${tftp::root}/"))
 
   file { $dirs:
     ensure    => directory,


### PR DESCRIPTION
A new parameter 'bootloader_universe' has been added for tftp on the Smart Proxy side for the new "Grub2 UEFI SecureBoot (target OS)" PXE loader. This PR aims to add the new parameter to foreman-installer.

Refer to https://github.com/theforeman/smart-proxy/pull/877 and https://github.com/theforeman/foreman/pull/9864 for more information.