### PR TITLE
Stop installing centos-release-ansible-29 in CI

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -12,13 +12,6 @@ package { $dig_package:
   ensure => installed,
 }
 
-# Needed for the Ansible plugin
-if $facts['os']['name'] == 'CentOS' {
-  package { 'centos-release-ansible-29':
-    ensure => present,
-  }
-}
-
 # Create certificates
 $certificate_group = 'foreman-proxy'
 $directory = '/etc/foreman-proxy'


### PR DESCRIPTION
This hasn't been needed since we can depend on ansible-core.