### PR TITLE
Fixes #37121 - Automatically secure the DHCP OMAPI interface

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -163,7 +163,7 @@
 #
 # $dhcp_key_name::              DHCP key name
 #
-# $dhcp_key_secret::            DHCP password
+# $dhcp_key_secret::            DHCP key secret
 #
 # $dhcp_omapi_port::            DHCP server OMAPI port
 #
@@ -363,7 +363,7 @@ class foreman_proxy (
   String $dhcp_server = '127.0.0.1',
   Stdlib::Absolutepath $dhcp_config = $foreman_proxy::params::dhcp_config,
   Stdlib::Absolutepath $dhcp_leases = $foreman_proxy::params::dhcp_leases,
-  Optional[String] $dhcp_key_name = undef,
+  String[1] $dhcp_key_name = 'omapi_key',
   Optional[String] $dhcp_key_secret = undef,
   Stdlib::Port $dhcp_omapi_port = 7911,
   Optional[String] $dhcp_peer_address = undef,

--- a/manifests/proxydhcp.pp
+++ b/manifests/proxydhcp.pp
@@ -62,16 +62,32 @@ class foreman_proxy::proxydhcp {
     $_dhcp_ipxefilename = undef
   }
 
+  # TODO parametrize
+  # TODO: EL8 only supports HMAC-MD5 but Fedora doesn't
+  $dhcp_key_algorithm = 'HMAC-MD5'
+  if $foreman_proxy::dhcp_key_name {
+    if $foreman_proxy::dhcp_key_secret {
+      $dhcp_key_secret = $foreman_proxy::dhcp_key_secret
+    } else {
+      # TODO: replace wtih dns::tsig_keygen
+      $dhcp_key = cache_data('theforeman' 'dhcp_omapi', dns::dnssec_keygen($foreman_proxy::dhcp_key_name, $dhcp_key_algorithm, 512, 'HOST'))
+      $dhcp_key_secret = $dhcp_key['PrivateKey']
+    }
+  } else {
+    $dhcp_key_secret = $foreman_proxy::dhcp_key_secret
+  }
+
   class { 'dhcp':
-    dnsdomain     => $foreman_proxy::dhcp_option_domain,
-    nameservers   => $nameservers,
-    interfaces    => [$foreman_proxy::dhcp_interface] + $foreman_proxy::dhcp_additional_interfaces,
-    pxeserver     => $ip,
-    pxefilename   => $foreman_proxy::dhcp_pxefilename,
-    ipxe_filename => $_dhcp_ipxefilename,
-    omapi_name    => $foreman_proxy::dhcp_key_name,
-    omapi_key     => $foreman_proxy::dhcp_key_secret,
-    conf_dir_mode => $conf_dir_mode,
+    dnsdomain       => $foreman_proxy::dhcp_option_domain,
+    nameservers     => $nameservers,
+    interfaces      => [$foreman_proxy::dhcp_interface] + $foreman_proxy::dhcp_additional_interfaces,
+    pxeserver       => $ip,
+    pxefilename     => $foreman_proxy::dhcp_pxefilename,
+    ipxe_filename   => $_dhcp_ipxefilename,
+    omapi_name      => $foreman_proxy::dhcp_key_name,
+    omapi_key       => $dhcp_key_secret,
+    omapi_algorithm => $dhcp_key_algorithm,
+    conf_dir_mode   => $conf_dir_mode,
   }
 
   dhcp::pool { $facts['networking']['domain']:


### PR DESCRIPTION
The tsig-keygen command can be used to generate a TSIG key to secure the OMAPI communication.

This is a draft since I realized I need to rewrite some things. Initially it was based on https://github.com/theforeman/foreman-documentation/pull/2709 but then reading the manual I realized dnssec-keygen in Fedora can no longer create TSIG keys. Luckily, tsig-keygen also exists on EL8. Probably also on Debian/Ubuntu.

Another thing I realized was the very complex permission model. It would be way easier if puppet-dhcp creates a separate file for the OMAPI key with strict permissions and the regular DHCP file only includes that. This would allow us to drop the posix ACLs.