### PR TITLE
Make exception to grub_efi_path for OracleLinux

### DIFF
--- a/manifests/tftp/netboot.pp
+++ b/manifests/tftp/netboot.pp
@@ -28,7 +28,10 @@ class foreman_proxy::tftp::netboot (
 
   case $grub_installation_type {
     'redhat': {
-      $grub_efi_path = downcase($facts['os']['name'])
+      $grub_efi_path = $facts['os']['name'] ? {
+        'OracleLinux' => 'redhat',
+        default => downcase($facts['os']['name']),
+      }
 
       file { "${root}/grub2/grubx64.efi":
         ensure  => file,


### PR DESCRIPTION
Apparently they didn't get the memo when rebranding their distro.