### PR TITLE
Add acceptance tests for salt plugin

### DIFF
--- a/examples/salt.pp
+++ b/examples/salt.pp
@@ -1,0 +1,11 @@
+$baseurl = "https://repo.saltproject.io/salt/py3/redhat/${facts['os']['release']['major']}/\$basearch/latest"
+
+yumrepo { 'salt-repo':
+  descr   => "Salt repo for RHEL/CentOS ${facts['os']['release']['major']} PY3",
+  baseurl => $baseurl,
+  gpgkey  => "${baseurl}/SALT-PROJECT-GPG-PUBKEY-2023.pub",
+  before  => Class['foreman_proxy::plugin::salt'],
+}
+
+include foreman_proxy
+include foreman_proxy::plugin::salt

--- a/spec/acceptance/salt_spec.rb
+++ b/spec/acceptance/salt_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper_acceptance'
+
+describe 'Scenario: install foreman-proxy with openscap plugin', if: ['redhat', 'centos'].include?(os[:family]) do
+  before(:context) { purge_foreman_proxy }
+
+  include_examples 'the example', 'salt.pp'
+
+  it_behaves_like 'the default foreman proxy application'
+
+  specify { expect(file('/etc/salt/master.d')).to be_directory }
+  specify { expect(file('/etc/salt/master.d/foreman.conf')).to be_file.and(have_attributes(owner: 'root', group: 'foreman-proxy')) }
+end


### PR DESCRIPTION
I wrote this to test out https://github.com/theforeman/puppet-foreman_proxy/pull/826 and this makes the future easier.

While testing I noticed there's a file placed by the plugin:
```console
# rpm -qf /etc/salt/foreman.yaml 
rubygem-smart_proxy_salt-5.0.1-1.fm3_9.el8.noarch
```

I do not know who uses this file, but the installer doesn't manage the content so I question its use.