### PR TITLE
Fixes #37325 - make postgres the container gateway default DB

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -17,6 +17,7 @@ fixtures:
     systemd:  'https://github.com/camptocamp/puppet-systemd'
     tftp:     'https://github.com/theforeman/puppet-tftp'
     translate: 'https://github.com/puppetlabs/puppetlabs-translate'
+    postgresql: 'https://github.com/puppetlabs/puppetlabs-postgresql'
     xinetd:   'https://github.com/puppetlabs/puppetlabs-xinetd'
     yumrepo_core: "https://github.com/puppetlabs/puppetlabs-yumrepo_core"
     sshkeys_core: "https://github.com/puppetlabs/puppetlabs-sshkeys_core"

--- a/README.md
+++ b/README.md
@@ -100,11 +100,6 @@ class { 'foreman_proxy::plugin::ansible':
 }
 ```
 
-### Katello Container Gateway Support
-
-If installing a Foreman Proxy with the Container Gateway, ensure that the
-postgresql module is available for use on the system.
-
 ## Contributing
 
 * Fork the project

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ class { 'foreman_proxy::plugin::ansible':
 }
 ```
 
+### Katello Container Gateway Support
+
+If installing a Foreman Proxy with the Container Gateway, ensure that the
+postgresql module is available for use on the system.
+
 ## Contributing
 
 * Fork the project

--- a/manifests/plugin/container_gateway.pp
+++ b/manifests/plugin/container_gateway.pp
@@ -44,7 +44,7 @@ class foreman_proxy::plugin::container_gateway (
   Optional[Stdlib::Port] $postgresql_port = undef,
   String $postgresql_database = 'container_gateway',
   String $postgresql_user = pick($foreman_proxy::globals::user, 'foreman-proxy'),
-  String $postgresql_password = extlib::cache_data('container_gateway_cache_data', 'db_password', extlib::random_password(32))
+  Optional[String] $postgresql_password = undef
 ) {
   foreman_proxy::plugin::module { 'container_gateway':
     version   => $version,
@@ -60,7 +60,9 @@ class foreman_proxy::plugin::container_gateway (
       user     => $foreman_proxy::plugin::container_gateway::postgresql_user,
       password => postgresql::postgresql_password(
         $foreman_proxy::plugin::container_gateway::postgresql_user,
-        $foreman_proxy::plugin::container_gateway::postgresql_password
+        $foreman_proxy::plugin::container_gateway::postgresql_password.lest || {
+          extlib::cache_data('container_gateway_cache_data', 'db_password', extlib::random_password(32))
+        }
       ),
       encoding => 'utf8',
       locale   => 'C.utf8',

--- a/manifests/plugin/container_gateway.pp
+++ b/manifests/plugin/container_gateway.pp
@@ -4,6 +4,18 @@
 #
 # $pulp_endpoint::            Pulp 3 server endpoint
 #
+# $database_backend::         'sqlite' or 'postgres'
+#
+# $postgresql_host::          Host of the postgres database.
+#
+# $postgresql_port::          Port of the postgres database.
+#
+# $postgresql_database::      Name of the postgres database
+#
+# $postgresql_user::          User for the postgres database
+#
+# $postgresql_password::      User password for the postgres database
+#
 # $sqlite_db_path::           Absolute path for the SQLite DB file to exist at
 #
 # $sqlite_timeout::           Database busy timeout in milliseconds
@@ -22,13 +34,30 @@ class foreman_proxy::plugin::container_gateway (
   Boolean $enabled = true,
   Foreman_proxy::ListenOn $listen_on = 'https',
   Stdlib::HTTPUrl $pulp_endpoint = "https://${facts['networking']['fqdn']}",
+  String $database_backend = 'postgres',
   Stdlib::Absolutepath $sqlite_db_path = '/var/lib/foreman-proxy/smart_proxy_container_gateway.db',
   Optional[Integer] $sqlite_timeout = undef,
+  Stdlib::Host $postgresql_host = 'localhost',
+  Stdlib::Port $postgresql_port = 5432,
+  String $postgresql_database = 'container_gateway',
+  String $postgresql_user = 'foreman-proxy',
+  String $postgresql_password = extlib::cache_data('container_gateway_cache_data', 'db_password', extlib::random_password(32))
 ) {
   foreman_proxy::plugin::module { 'container_gateway':
     version   => $version,
     enabled   => $enabled,
     feature   => 'Container_Gateway',
     listen_on => $listen_on,
+  }
+  include postgresql::server
+  postgresql::server::db { $foreman_proxy::plugin::container_gateway::postgresql_database:
+    user     => $foreman_proxy::plugin::container_gateway::postgresql_user,
+    password => postgresql::postgresql_password(
+      $foreman_proxy::plugin::container_gateway::postgresql_user,
+      $foreman_proxy::plugin::container_gateway::postgresql_password
+    ),
+    encoding => 'utf8',
+    locale   => 'en_US.utf8',
+    require  => Package['glibc-langpack-en'],
   }
 }

--- a/manifests/plugin/container_gateway.pp
+++ b/manifests/plugin/container_gateway.pp
@@ -6,6 +6,8 @@
 #
 # $database_backend::         'sqlite' or 'postgres'
 #
+# $manage_postgresql::        If the PostgreSQL database should be managed
+#
 # $postgresql_host::          Host of the postgres database.
 #
 # $postgresql_port::          Port of the postgres database.
@@ -37,6 +39,7 @@ class foreman_proxy::plugin::container_gateway (
   String $database_backend = 'postgres',
   Stdlib::Absolutepath $sqlite_db_path = '/var/lib/foreman-proxy/smart_proxy_container_gateway.db',
   Optional[Integer] $sqlite_timeout = undef,
+  Boolean $manage_postgresql = true,
   Stdlib::Host $postgresql_host = 'localhost',
   Stdlib::Port $postgresql_port = 5432,
   String $postgresql_database = 'container_gateway',
@@ -49,15 +52,18 @@ class foreman_proxy::plugin::container_gateway (
     feature   => 'Container_Gateway',
     listen_on => $listen_on,
   }
-  include postgresql::server
-  postgresql::server::db { $foreman_proxy::plugin::container_gateway::postgresql_database:
-    user     => $foreman_proxy::plugin::container_gateway::postgresql_user,
-    password => postgresql::postgresql_password(
-      $foreman_proxy::plugin::container_gateway::postgresql_user,
-      $foreman_proxy::plugin::container_gateway::postgresql_password
-    ),
-    encoding => 'utf8',
-    locale   => 'en_US.utf8',
-    require  => Package['glibc-langpack-en'],
+
+  if $foreman_proxy::plugin::container_gateway::manage_postgresql {
+    include postgresql::server
+    postgresql::server::db { $foreman_proxy::plugin::container_gateway::postgresql_database:
+      user     => $foreman_proxy::plugin::container_gateway::postgresql_user,
+      password => postgresql::postgresql_password(
+        $foreman_proxy::plugin::container_gateway::postgresql_user,
+        $foreman_proxy::plugin::container_gateway::postgresql_password
+      ),
+      encoding => 'utf8',
+      locale   => 'en_US.utf8',
+      require  => Package['glibc-langpack-en'],
+    }
   }
 }

--- a/manifests/plugin/container_gateway.pp
+++ b/manifests/plugin/container_gateway.pp
@@ -56,16 +56,22 @@ class foreman_proxy::plugin::container_gateway (
   if $manage_postgresql and $database_backend == 'postgres' {
     include postgresql::server
     $_postgresql_user = pick($postgresql_user, $foreman_proxy::user)
-    postgresql::server::db { $postgresql_database:
-      user     => $_postgresql_user,
-      password => postgresql::postgresql_password(
-        $_postgresql_user,
-        $postgresql_password.lest || {
-          extlib::cache_data('container_gateway_cache_data', 'db_password', extlib::random_password(32))
-        }
-      ),
-      encoding => 'utf8',
-      locale   => 'C.utf8',
+    if $postgresql_password {
+      postgresql::server::db { $postgresql_database:
+        user     => $_postgresql_user,
+        password => postgresql::postgresql_password(
+          $_postgresql_user,
+          $postgresql_password
+        ),
+        encoding => 'utf8',
+        locale   => 'C.utf8',
+      }
+    } else {
+      postgresql::server::db { $postgresql_database:
+        user     => $_postgresql_user,
+        encoding => 'utf8',
+        locale   => 'C.utf8',
+      }
     }
   }
 }

--- a/spec/acceptance/container_gateway_spec.rb
+++ b/spec/acceptance/container_gateway_spec.rb
@@ -6,4 +6,9 @@ describe 'Scenario: install foreman-proxy with container_gateway plugin', if: ['
   include_examples 'the example', 'container_gateway.pp'
 
   it_behaves_like 'the default foreman proxy application'
+
+  describe service("postgresql") do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
 end

--- a/spec/classes/foreman_proxy__plugin__container_gateway_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__container_gateway_spec.rb
@@ -14,7 +14,7 @@ describe 'foreman_proxy::plugin::container_gateway' do
             ':enabled: https',
             ":pulp_endpoint: https://#{facts[:fqdn]}",
             ':sqlite_db_path: /var/lib/foreman-proxy/smart_proxy_container_gateway.db',
-            ':db_connection_string: postgres://:@:/container_gateway'
+            ':db_connection_string: postgres:///container_gateway'
           ])
         end
       end

--- a/spec/classes/foreman_proxy__plugin__container_gateway_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__container_gateway_spec.rb
@@ -14,7 +14,7 @@ describe 'foreman_proxy::plugin::container_gateway' do
             ':enabled: https',
             ":pulp_endpoint: https://#{facts[:fqdn]}",
             ':sqlite_db_path: /var/lib/foreman-proxy/smart_proxy_container_gateway.db',
-            ':db_connection_string: postgres://foreman-proxy:@:/container_gateway'
+            ':db_connection_string: postgres://:@:/container_gateway'
           ])
         end
       end
@@ -37,7 +37,6 @@ describe 'foreman_proxy::plugin::container_gateway' do
             ':enabled: https',
             ':pulp_endpoint: https://test.example.com',
             ':sqlite_db_path: /dev/null.db',
-            ':sqlite_timeout: 12345',
             ':db_connection_string: postgres://foreman-proxy:changeme@test.example.com:5432/container_gateway'
           ])
         end

--- a/spec/classes/foreman_proxy__plugin__container_gateway_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__container_gateway_spec.rb
@@ -15,12 +15,8 @@ describe 'foreman_proxy::plugin::container_gateway' do
             ':enabled: https',
             ":pulp_endpoint: https://#{facts[:fqdn]}",
             ':database_backend: postgresql',
-            ':postgresql_host: localhost',
-            ':postgresql_port: 5432',
-            ':postgresql_database: container_gateway',
-            ':postgresql_user: foreman-proxy',
-            ':postgresql_password: changeme',
-            ':sqlite_db_path: /var/lib/foreman-proxy/smart_proxy_container_gateway.db'
+            ':sqlite_db_path: /var/lib/foreman-proxy/smart_proxy_container_gateway.db',
+            ':postgresql_connection_string: postgres://foreman-proxy:changeme@localhost:5432/container_gateway'
           ])
         end
       end
@@ -46,11 +42,7 @@ describe 'foreman_proxy::plugin::container_gateway' do
             ':database_backend: postgresql',
             ':sqlite_db_path: /dev/null.db',
             ':sqlite_timeout: 12345',
-            ':postgresql_host: test.example.com',
-            ':postgresql_port: 5432',
-            ':postgresql_database: container_gateway',
-            ':postgresql_user: foreman-proxy',
-            ':postgresql_password: changeme'
+            ':postgresql_connection_string: postgres://foreman-proxy:changeme@test.example.com:5432/container_gateway'
           ])
         end
       end

--- a/spec/classes/foreman_proxy__plugin__container_gateway_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__container_gateway_spec.rb
@@ -9,16 +9,41 @@ describe 'foreman_proxy::plugin::container_gateway' do
       describe 'with default settings' do
         it { should contain_foreman_proxy__plugin__module('container_gateway') }
         it 'container_gateway.yml should contain the correct configuration' do
-          expect(get_content(catalogue, '/etc/foreman-proxy/settings.d/container_gateway.yml')).to include("---")
-          expect(get_content(catalogue, '/etc/foreman-proxy/settings.d/container_gateway.yml')).to include(":enabled: https")
-          expect(get_content(catalogue, '/etc/foreman-proxy/settings.d/container_gateway.yml')).to include(":pulp_endpoint: https://#{facts[:fqdn]}")
-          expect(get_content(catalogue, '/etc/foreman-proxy/settings.d/container_gateway.yml')).to include(":sqlite_db_path: /var/lib/foreman-proxy/smart_proxy_container_gateway.db")
-          connection_string = get_content(catalogue, '/etc/foreman-proxy/settings.d/container_gateway.yml').find { |str| str.include?("db_connection_string") }
-          expect(connection_string.split(/[:@\/]/)[6]).to be_a(String).and have_attributes(length: 32)
+          verify_exact_contents(catalogue, '/etc/foreman-proxy/settings.d/container_gateway.yml', [
+            '---',
+            ':enabled: https',
+            ":pulp_endpoint: https://#{facts[:fqdn]}",
+            ':sqlite_db_path: /var/lib/foreman-proxy/smart_proxy_container_gateway.db',
+            ':db_connection_string: postgres://foreman-proxy:@:/container_gateway'
+          ])
         end
       end
 
-      describe 'with overwritten parameters' do
+      describe 'with overwritten postgres parameters' do
+        let :params do {
+          :pulp_endpoint => 'https://test.example.com',
+          :sqlite_db_path => '/dev/null.db',
+          :database_backend => 'postgres',
+          :postgresql_host => 'test.example.com',
+          :postgresql_port => 5432,
+          :postgresql_database => 'container_gateway',
+          :postgresql_user => 'foreman-proxy',
+          :postgresql_password => 'changeme'
+        } end
+
+        it 'container_gateway.yml should contain the correct configuration' do
+          verify_exact_contents(catalogue, '/etc/foreman-proxy/settings.d/container_gateway.yml', [
+            '---',
+            ':enabled: https',
+            ':pulp_endpoint: https://test.example.com',
+            ':sqlite_db_path: /dev/null.db',
+            ':sqlite_timeout: 12345',
+            ':db_connection_string: postgres://foreman-proxy:changeme@test.example.com:5432/container_gateway'
+          ])
+        end
+      end
+
+      describe 'with overwritten sqlite parameters' do
         let :params do {
           :pulp_endpoint => 'https://test.example.com',
           :sqlite_db_path => '/dev/null.db',

--- a/spec/classes/foreman_proxy__plugin__container_gateway_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__container_gateway_spec.rb
@@ -7,12 +7,19 @@ describe 'foreman_proxy::plugin::container_gateway' do
       let(:pre_condition) { 'include foreman_proxy' }
 
       describe 'with default settings' do
+        let :postgresql_password do 'changeme' end
         it { should contain_foreman_proxy__plugin__module('container_gateway') }
         it 'container_gateway.yml should contain the correct configuration' do
           verify_exact_contents(catalogue, '/etc/foreman-proxy/settings.d/container_gateway.yml', [
             '---',
             ':enabled: https',
             ":pulp_endpoint: https://#{facts[:fqdn]}",
+            ':database_backend: postgresql',
+            ':postgresql_host: localhost',
+            ':postgresql_port: 5432',
+            ':postgresql_database: container_gateway',
+            ':postgresql_user: foreman-proxy',
+            ':postgresql_password: changeme',
             ':sqlite_db_path: /var/lib/foreman-proxy/smart_proxy_container_gateway.db'
           ])
         end
@@ -21,8 +28,14 @@ describe 'foreman_proxy::plugin::container_gateway' do
       describe 'with overwritten parameters' do
         let :params do {
           :pulp_endpoint => 'https://test.example.com',
+          :database_backend => 'postgresql',
           :sqlite_db_path => '/dev/null.db',
           :sqlite_timeout => 12345,
+          :postgresql_host => 'test.example.com',
+          :postgresql_port => 5432,
+          :postgresql_database => 'container_gateway',
+          :postgresql_user => 'foreman-proxy',
+          :postgresql_password => 'changeme'
         } end
 
         it 'container_gateway.yml should contain the correct configuration' do
@@ -30,8 +43,14 @@ describe 'foreman_proxy::plugin::container_gateway' do
             '---',
             ':enabled: https',
             ':pulp_endpoint: https://test.example.com',
+            ':database_backend: postgresql',
             ':sqlite_db_path: /dev/null.db',
-            ':sqlite_timeout: 12345'
+            ':sqlite_timeout: 12345',
+            ':postgresql_host: test.example.com',
+            ':postgresql_port: 5432',
+            ':postgresql_database: container_gateway',
+            ':postgresql_user: foreman-proxy',
+            ':postgresql_password: changeme'
           ])
         end
       end

--- a/templates/plugin/container_gateway.yml.erb
+++ b/templates/plugin/container_gateway.yml.erb
@@ -2,7 +2,19 @@
 # Container Gateway for Katello
 :enabled: <%= @module_enabled %>
 :pulp_endpoint: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::pulp_endpoint") %>
+:database_backend: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::database_backend") %>
 :sqlite_db_path: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::sqlite_db_path") %>
 <% if scope.lookupvar("foreman_proxy::plugin::container_gateway::sqlite_timeout") -%>
 :sqlite_timeout: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::sqlite_timeout") %>
 <% end -%>
+:postgresql_connection_string: postgres://<%=
+  "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_user")}:" \
+  "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_password")}@" \
+  "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_host")}:" \
+  "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_port")}/" \
+  "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_database")}"
+  %>
+:postgresql_host: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_host") %>
+:postgresql_port: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_port") %>
+:postgresql_user: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_user") %>
+:postgresql_password: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_password") %>

--- a/templates/plugin/container_gateway.yml.erb
+++ b/templates/plugin/container_gateway.yml.erb
@@ -14,7 +14,3 @@
   "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_port")}/" \
   "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_database")}"
   %>
-:postgresql_host: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_host") %>
-:postgresql_port: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_port") %>
-:postgresql_user: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_user") %>
-:postgresql_password: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_password") %>

--- a/templates/plugin/container_gateway.yml.erb
+++ b/templates/plugin/container_gateway.yml.erb
@@ -6,24 +6,17 @@
 <% if scope.lookupvar("foreman_proxy::plugin::container_gateway::sqlite_timeout") -%>
 :sqlite_timeout: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::sqlite_timeout") %>
 <% end -%>
-<% if scope.lookupvar('foreman_proxy::plugin::container_gateway::database_backend') == 'postgres' -%>
-:db_connection_string: <%= [
-  scope.lookupvar('foreman_proxy::plugin::container_gateway::database_backend'),
-  '://',
-  scope.lookupvar('foreman_proxy::plugin::container_gateway::postgresql_user'),
-  ':',
-  scope.lookupvar('foreman_proxy::plugin::container_gateway::postgresql_password'),
-  '@',
-  scope.lookupvar('foreman_proxy::plugin::container_gateway::postgresql_host'),
-  ':',
-  scope.lookupvar('foreman_proxy::plugin::container_gateway::postgresql_port'),
-  '/',
-  scope.lookupvar('foreman_proxy::plugin::container_gateway::postgresql_database')
-].join %>
-<% end -%>
-<% if scope.lookupvar("foreman_proxy::plugin::container_gateway::database_backend") == 'sqlite' -%>
-:db_connection_string: <%=
-  "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::database_backend")}://" \
-  "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::sqlite_db_path")}"
-  %>
-<% end -%>
+<%-
+case scope.lookupvar('foreman_proxy::plugin::container_gateway::database_backend')
+when 'postgres'
+  uri = URI("postgres://")
+  uri.user = scope.lookupvar('foreman_proxy::plugin::container_gateway::postgresql_user')
+  uri.password = scope.lookupvar('foreman_proxy::plugin::container_gateway::postgresql_password')
+  uri.host = scope.lookupvar('foreman_proxy::plugin::container_gateway::postgresql_host')
+  uri.port = scope.lookupvar('foreman_proxy::plugin::container_gateway::postgresql_port')
+  uri.path = "/#{scope.lookupvar('foreman_proxy::plugin::container_gateway::postgresql_database')}"
+when 'sqlite'
+  uri = "sqlite://#{scope.lookupvar('foreman_proxy::plugin::container_gateway::sqlite_db_path')}"
+end
+-%>
+:db_connection_string: <%= uri %>

--- a/templates/plugin/container_gateway.yml.erb
+++ b/templates/plugin/container_gateway.yml.erb
@@ -6,15 +6,20 @@
 <% if scope.lookupvar("foreman_proxy::plugin::container_gateway::sqlite_timeout") -%>
 :sqlite_timeout: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::sqlite_timeout") %>
 <% end -%>
-<% if scope.lookupvar("foreman_proxy::plugin::container_gateway::database_backend") == 'postgres' -%>
-:db_connection_string: <%=
-  "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::database_backend")}://" \
-  "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_user")}:" \
-  "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_password")}@" \
-  "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_host")}:" \
-  "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_port")}/" \
-  "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_database")}"
-  %>
+<% if scope.lookupvar('foreman_proxy::plugin::container_gateway::database_backend') == 'postgres' -%>
+:db_connection_string: <%= [
+  scope.lookupvar('foreman_proxy::plugin::container_gateway::database_backend'),
+  '://',
+  scope.lookupvar('foreman_proxy::plugin::container_gateway::postgresql_user'),
+  ':',
+  scope.lookupvar('foreman_proxy::plugin::container_gateway::postgresql_password'),
+  '@',
+  scope.lookupvar('foreman_proxy::plugin::container_gateway::postgresql_host'),
+  ':',
+  scope.lookupvar('foreman_proxy::plugin::container_gateway::postgresql_port'),
+  '/',
+  scope.lookupvar('foreman_proxy::plugin::container_gateway::postgresql_database')
+].join %>
 <% end -%>
 <% if scope.lookupvar("foreman_proxy::plugin::container_gateway::database_backend") == 'sqlite' -%>
 :db_connection_string: <%=

--- a/templates/plugin/container_gateway.yml.erb
+++ b/templates/plugin/container_gateway.yml.erb
@@ -2,15 +2,23 @@
 # Container Gateway for Katello
 :enabled: <%= @module_enabled %>
 :pulp_endpoint: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::pulp_endpoint") %>
-:database_backend: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::database_backend") %>
 :sqlite_db_path: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::sqlite_db_path") %>
 <% if scope.lookupvar("foreman_proxy::plugin::container_gateway::sqlite_timeout") -%>
 :sqlite_timeout: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::sqlite_timeout") %>
 <% end -%>
-:postgresql_connection_string: postgres://<%=
+<% if scope.lookupvar("foreman_proxy::plugin::container_gateway::database_backend") == 'postgres' -%>
+:db_connection_string: <%=
+  "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::database_backend")}://" \
   "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_user")}:" \
   "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_password")}@" \
   "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_host")}:" \
   "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_port")}/" \
   "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::postgresql_database")}"
   %>
+<% end -%>
+<% if scope.lookupvar("foreman_proxy::plugin::container_gateway::database_backend") == 'sqlite' -%>
+:db_connection_string: <%=
+  "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::database_backend")}://" \
+  "#{scope.lookupvar("foreman_proxy::plugin::container_gateway::sqlite_db_path")}"
+  %>
+<% end -%>


### PR DESCRIPTION
Draft PR for adding postgres support to the container gateway class. Settings should match the in-progress new settings here: https://github.com/Katello/smart_proxy_container_gateway/pull/33/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R42-R47

I'm not certain that this is the right direction for adding postgres support -- so far I'm thinking that the actual database should be create in puppet-foreman_proxy_content so I don't add a hard postgres library requirement to puppet-foreman_proxy.

foreman_proxy_content PR: https://github.com/theforeman/puppet-foreman_proxy_content/pull/479

Another question was about testing the random database password -- is there a way to stub the `extlib::random_password(32)` call?