### PR TITLE
Move away from systemd::service_limits

### DIFF
--- a/manifests/plugin/dynflow.pp
+++ b/manifests/plugin/dynflow.pp
@@ -43,13 +43,14 @@ class foreman_proxy::plugin::dynflow (
     version => absent,
   }
 
-  $service = 'foreman-proxy'
+  $service = 'foreman-proxy.service'
 
-  systemd::service_limits { "${service}.service":
-    limits          => {
+  systemd::manage_dropin { "${service}-90-limits.conf":
+    unit           => $service,
+    filename       => '90-limits.conf',
+    service_entry  => {
       'LimitNOFILE' => $open_file_limit,
     },
-    restart_service => false,
-    notify          => Service[$service],
+    notify_service => true,
   }
 }

--- a/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__dynflow_spec.rb
@@ -23,7 +23,12 @@ describe 'foreman_proxy::plugin::dynflow' do
                                 lines)
         end
 
-        it { should contain_systemd__service_limits('foreman-proxy.service') }
+        it do
+          should contain_systemd__manage_dropin('foreman-proxy.service-90-limits.conf')
+            .with_unit('foreman-proxy.service')
+            .with_filename('90-limits.conf')
+            .with_service_entry({'LimitNOFILE' => 1000000})
+        end
       end
 
       describe 'with custom settings' do


### PR DESCRIPTION
This was deprecated in the latest release and will be dropped in the future.

The systemd dependency is a soft dependency. The lower bound is now version 4.0.0