### PR TITLE
Update Salt Master configuration template

### DIFF
--- a/templates/plugin/salt_master.conf.erb
+++ b/templates/plugin/salt_master.conf.erb
@@ -16,6 +16,11 @@ autosign_file: <%= scope.lookupvar('foreman_proxy::plugin::salt::autosign_file')
 
 
 ##
+# Salt Master service user
+user: <%= scope.lookupvar('::foreman_proxy::plugin::salt::user') %>
+
+
+##
 # Node classifier
 master_tops:
   ext_nodes: /usr/bin/foreman-node
@@ -38,6 +43,10 @@ rest_cherrypy:
   port: 9191
   ssl_key: <%= @foreman_ssl_key %>
   ssl_crt: <%= @foreman_ssl_cert %>
+
+netapi_enable_clients:
+  - local
+  - local_async
 
 
 ##


### PR DESCRIPTION
* Add netapi_enable_clients explicitly due to 3006 changes https://docs.saltproject.io/en/master/topics/netapi/netapi-enable-clients.html#select-client-interfaces-to-enable

&rarr; This is more of an pro-active change. I don't quite know where exactly we run into an issue with cherrypy-API permissions. So, I need a second opinion on this.

* Set user for running Salt Master service due to 3006 changes https://docs.saltproject.io/en/3006/topics/releases/3006.0.html#linux-packaging-salt-master-salt-user-and-group

&rarr; This is motivated by the following change:

Since 3006, Salt installs with an explicit user that runs the Salt Master daemon in order to limit the daemon permissions. If that users differs from the user that we execute the `salt ...` commands with (when triggering Salt from Smart Proxy), we get some permission issues. More specifically, `sudo -u foreman-proxy salt '*' test.ping` runs into the following error:

```
[ERROR   ] Unable to connect to the salt master publisher at /var/run/salt/master
The salt master could not be contacted. Is master running?
```

When executing `salt '*' test.ping`, that comand wants to connect to the Salt Master whose PID is stored in `/var/run/salt/master/*`. But, with the 3006-explicit-user update, they limit access to the `/var/run/salt` folder to the same user which runs the Salt Master daemon.

Therefore, I see two options:

A) Make the Salt Master daemon run with the same user that we execute the `salt ...` commands with (currently implemented in this PR)
B) Take care that the foreman-proxy user has the necessary permissions/adapt the folder permissions that the foreman-proxy user can execute `salt ...` even if the daemon is started by a different user.