### PR TITLE
Refs #37707 - Support purging container_gateway

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -3,6 +3,9 @@
 # Foreman Proxy internally has the concept of modules. Some modules have
 # providers or even multiple ones. That's not part of this definition.
 #
+# @param ensure
+#  Whether the module is expected to be present or absent
+#
 # @param enabled
 #  Whether the module is enabled or disabled.
 #
@@ -20,12 +23,13 @@
 #   An optional template path
 #
 define foreman_proxy::module (
+  Enum['present', 'absent'] $ensure = 'present',
   Boolean $enabled = false,
   Foreman_proxy::ListenOn $listen_on = 'https',
   Optional[String] $template_path = undef,
   String $feature = $title.capitalize(),
 ) {
-  if $enabled {
+  if $ensure != 'absent' and $enabled {
     $module_enabled = $listen_on ? {
       'both'  => 'true',
       'https' => 'https',
@@ -39,6 +43,7 @@ define foreman_proxy::module (
   }
 
   foreman_proxy::settings_file { $name:
+    ensure         => bool2str($ensure == 'present', 'file', 'absent'),
     module_enabled => $module_enabled,
     template_path  => $template_path,
   }

--- a/manifests/plugin/container_gateway.pp
+++ b/manifests/plugin/container_gateway.pp
@@ -53,7 +53,7 @@ class foreman_proxy::plugin::container_gateway (
     listen_on => $listen_on,
   }
 
-  if $manage_postgresql and $database_backend == 'postgres' {
+  if $version != 'absent' and $enabled and $manage_postgresql and $database_backend == 'postgres' {
     include postgresql::server
     $_postgresql_user = pick($postgresql_user, $foreman_proxy::user)
     if $postgresql_password {

--- a/manifests/plugin/module.pp
+++ b/manifests/plugin/module.pp
@@ -35,6 +35,7 @@ define foreman_proxy::plugin::module (
     package => $package,
   }
   -> foreman_proxy::module { $name:
+    ensure        => bool2str($version != 'absent', 'present', 'absent'),
     enabled       => $enabled,
     feature       => $feature,
     listen_on     => $listen_on,

--- a/spec/acceptance/container_gateway_spec.rb
+++ b/spec/acceptance/container_gateway_spec.rb
@@ -7,8 +7,31 @@ describe 'Scenario: install foreman-proxy with container_gateway plugin', if: ['
 
   it_behaves_like 'the default foreman proxy application'
 
+  describe 'is created' do
+    it { expect(package('rubygem-smart_proxy_container_gateway')).to be_installed }
+    it { expect(file('/etc/foreman-proxy/settings.d/container_gateway.yml')).to be_file }
+  end
+
   describe service("postgresql") do
     it { is_expected.to be_enabled }
     it { is_expected.to be_running }
+  end
+
+  describe 'and purge it' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<~PUPPET
+          include foreman_proxy
+          class { 'foreman_proxy::plugin::container_gateway':
+            version => 'absent',
+          }
+        PUPPET
+      end
+
+      describe 'it is purged' do
+        it { expect(package('rubygem-smart_proxy_container_gateway')).not_to be_installed }
+        it { expect(file('/etc/foreman-proxy/settings.d/container_gateway.yml')).not_to be_file }
+      end
+    end
   end
 end

--- a/spec/classes/foreman_proxy__plugin__container_gateway_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__container_gateway_spec.rb
@@ -66,6 +66,30 @@ describe 'foreman_proxy::plugin::container_gateway' do
           ])
         end
       end
+
+      describe 'with enabled => false' do
+        let(:params) do
+          {
+            enabled: false,
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_foreman_proxy__plugin__module('container_gateway').with_enabled(false) }
+        it { is_expected.not_to contain_class('postgresql::server') }
+      end
+
+      describe 'with version => absent' do
+        let(:params) do
+          {
+            version: 'absent',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_foreman_proxy__plugin__module('container_gateway').with_version('absent') }
+        it { is_expected.not_to contain_class('postgresql::server') }
+      end
     end
   end
 end

--- a/spec/defines/foreman_proxy_module_spec.rb
+++ b/spec/defines/foreman_proxy_module_spec.rb
@@ -9,7 +9,7 @@ describe 'foreman_proxy::module' do
 
       context 'with defaults' do
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_foreman_proxy__settings_file('test').with_module_enabled('false') }
+        it { is_expected.to contain_foreman_proxy__settings_file('test').with_ensure('file').with_module_enabled('false') }
         it { is_expected.not_to contain_foreman_proxy__feature('Test') }
       end
 
@@ -47,6 +47,24 @@ describe 'foreman_proxy::module' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_foreman_proxy__feature('TEST') }
         end
+      end
+
+      context 'with enabled => false' do
+        let(:params) { { enabled: false } }
+
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.not_to contain_foreman_proxy__feature('Test') }
+        it { is_expected.to contain_foreman_proxy__settings_file('test').with_ensure('file') }
+      end
+
+      context 'with ensure => absent' do
+        let(:params) { { ensure: 'absent' } }
+
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.not_to contain_foreman_proxy__feature('Test') }
+        it { is_expected.to contain_foreman_proxy__settings_file('test').with_ensure('absent') }
       end
     end
   end

--- a/spec/defines/foreman_proxy_plugin_module_spec.rb
+++ b/spec/defines/foreman_proxy_plugin_module_spec.rb
@@ -11,10 +11,23 @@ describe 'foreman_proxy::plugin::module' do
       it { is_expected.to contain_foreman_proxy__plugin('test').with_version('installed').with_package(/[-_]test$/) }
       it do
         is_expected.to contain_foreman_proxy__module('test')
+          .with_ensure('present')
           .with_enabled(false)
           .with_feature('Test')
           .with_listen_on('https')
           .with_template_path('foreman_proxy/plugin/test.yml.erb')
+      end
+
+      context 'with version absent' do
+        let(:params) do
+          {
+            version: 'absent',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_foreman_proxy__plugin('test').with_version('absent') }
+        it { is_expected.to contain_foreman_proxy__module('test').with_ensure('absent') }
       end
     end
   end

--- a/spec/defines/foreman_proxy_settings_file_spec.rb
+++ b/spec/defines/foreman_proxy_settings_file_spec.rb
@@ -25,6 +25,17 @@ describe 'foreman_proxy::settings_file' do
             .with_mode('0640')
             .with_content("---\n# Test file only\n# Can be true, false, or http/https to enable just one of the protocols\n:enabled: false\n")
         end
+
+        context 'with ensure => absent' do
+          let(:params) do
+            {
+              ensure: 'absent',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_file(config_path).with_ensure('absent') }
+        end
       end
 
       context 'with foreman_proxy included' do


### PR DESCRIPTION
This implements support to ensure container_gateway is disabled or absent. It does not remove the database, so it's easy to install again and pick up where you left.