### PR TITLE
Fixes #37803 - Remove hardcoded ProxyCommand

### DIFF
--- a/manifests/plugin/ansible/params.pp
+++ b/manifests/plugin/ansible/params.pp
@@ -9,7 +9,7 @@ class foreman_proxy::plugin::ansible::params {
   $working_dir = '/tmp'
   $host_key_checking = false
   $roles_path = ['/etc/ansible/roles', '/usr/share/ansible/roles']
-  $ssh_args = '-o ProxyCommand=none -C -o ControlMaster=auto -o ControlPersist=60s -o ServerAliveInterval=15 -o ServerAliveCountMax=3'
+  $ssh_args = '-C -o ControlMaster=auto -o ControlPersist=60s -o ServerAliveInterval=15 -o ServerAliveCountMax=3'
   $install_runner = true
   $collections_paths = ['/etc/ansible/collections', '/usr/share/ansible/collections']
   case $facts['os']['family'] {

--- a/spec/classes/foreman_proxy__plugin__ansible_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__ansible_spec.rb
@@ -45,7 +45,7 @@ describe 'foreman_proxy::plugin::ansible' do
             'export FOREMAN_SSL_KEY="/etc/puppetlabs/puppet/ssl/private_keys/foo.example.com.pem"',
             'export FOREMAN_SSL_CERT="/etc/puppetlabs/puppet/ssl/certs/foo.example.com.pem"',
             'export FOREMAN_SSL_VERIFY="/etc/puppetlabs/puppet/ssl/certs/ca.pem"',
-            'export ANSIBLE_SSH_ARGS="-o ProxyCommand=none -C -o ControlMaster=auto -o ControlPersist=60s -o ServerAliveInterval=15 -o ServerAliveCountMax=3"',
+            'export ANSIBLE_SSH_ARGS="-C -o ControlMaster=auto -o ControlPersist=60s -o ServerAliveInterval=15 -o ServerAliveCountMax=3"',
           ])
         end
       end
@@ -92,7 +92,7 @@ describe 'foreman_proxy::plugin::ansible' do
             'export FOREMAN_SSL_KEY="/etc/puppetlabs/puppet/ssl/private_keys/foo.example.com.pem"',
             'export FOREMAN_SSL_CERT="/etc/puppetlabs/puppet/ssl/certs/foo.example.com.pem"',
             'export FOREMAN_SSL_VERIFY="/etc/puppetlabs/puppet/ssl/certs/ca.pem"',
-            'export ANSIBLE_SSH_ARGS="-o ProxyCommand=none -C -o ControlMaster=auto -o ControlPersist=60s -o ServerAliveInterval=15 -o ServerAliveCountMax=3"',
+            'export ANSIBLE_SSH_ARGS="-C -o ControlMaster=auto -o ControlPersist=60s -o ServerAliveInterval=15 -o ServerAliveCountMax=3"',
           ])
         end
       end


### PR DESCRIPTION
Previously, we added a hardcoded `ProxyCommand=none` because ipa-client-install added
`ProxyCommand /usr/bin/sss_ssh_knownhostsproxy -p %p %h` into `/etc/ssh/ssh_config`, which caused failure to execute ansible commands on systems without the `/sbin/nologin` shell. [^1] However; this also prevents users from using their own jump host in the ssh configuration since the hardcoded command line arguments always take precedence.

Since this issue was fixed in the ipa tooling 3 years ago (they now use the `Match exec true` rule)[^2], I propose we remove the hardcoded ProxyCommand to allow users to specify their own jump hosts. The same is being done for remote execution. [^3]

Some users who have configured the ipa client before the fix landed in ipa might still report that they are getting errors when trying to run ansible commands because the ProxyCommand specified in `etc/ssh/ssh_config` is failing to execute. We should suggest these users to remove the ProxyCommand from ssh config, which should fix all of their issues originating from this. This is more of a problem of the old ipa tooling rather than a problem of foreman.

[^1]: https://projects.theforeman.org/issues/25481
[^2]: https://pagure.io/freeipa/issue/7676
[^3]: https://github.com/theforeman/smart_proxy_remote_execution_ssh/pull/117