### PR TITLE
Add support for running on Puppet Enterprise Primary

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -309,7 +309,7 @@ class foreman_proxy (
   Foreman_proxy::ListenOn $puppetca_listen_on = 'https',
   Stdlib::Absolutepath $ssldir = $foreman_proxy::params::ssldir,
   Stdlib::Absolutepath $puppetdir = $foreman_proxy::params::puppetdir,
-  String $puppet_group = 'puppet',
+  String $puppet_group = $foreman_proxy::params::puppet_group,
   String $puppetca_provider = 'puppetca_hostname_whitelisting',
   Stdlib::Absolutepath $autosignfile = $foreman_proxy::params::autosignfile,
   Boolean $puppetca_sign_all = false,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -174,4 +174,11 @@ class foreman_proxy::params inherits foreman_proxy::globals {
   # shares cached_data with the foreman module so they're the same
   $oauth_consumer_key    = extlib::cache_data('foreman_cache_data', 'oauth_consumer_key', extlib::random_password(32))
   $oauth_consumer_secret = extlib::cache_data('foreman_cache_data', 'oauth_consumer_secret', extlib::random_password(32))
+
+  # PE uses a different user/group compared to open source puppet
+  # the is_pe fact exists in PE and in stdlib. It can be true/false/undef (undef means open source)
+  $puppet_group = $facts['is_pe'] ? {
+    true => 'pe-puppet',
+    default => 'puppet'
+  }
 }


### PR DESCRIPTION
This enables user to run foreman-proxy on a Puppet Enterprise primary.