### PR TITLE
Fixes #38279 - Respect crypto-policies in mosquitto on EL

### DIFF
--- a/manifests/plugin/remote_execution/mosquitto.pp
+++ b/manifests/plugin/remote_execution/mosquitto.pp
@@ -33,6 +33,12 @@ class foreman_proxy::plugin::remote_execution::mosquitto (
   $mosquitto_ssl_dir = "${mosquitto_config_dir}/ssl"
   $broker = $facts['networking']['fqdn']
 
+  if $facts['os']['family'] == 'RedHat' {
+    $additional_config = ['ciphers PROFILE=SYSTEM']
+  } else {
+    $additional_config = []
+  }
+
   class { 'mosquitto':
     package_name   => 'mosquitto',
     package_ensure => $ensure,
@@ -46,7 +52,7 @@ class foreman_proxy::plugin::remote_execution::mosquitto (
       "keyfile ${mosquitto_ssl_dir}/ssl_key.pem",
       "require_certificate ${require_certificate}",
       "use_identity_as_username ${use_identity_as_username}",
-    ],
+    ] + $additional_config,
   }
 
   file { "${mosquitto_config_dir}/foreman.acl":

--- a/spec/classes/foreman_proxy__plugin__remote_execution__mosquitto_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__remote_execution__mosquitto_spec.rb
@@ -11,6 +11,8 @@ describe 'foreman_proxy::plugin::remote_execution::mosquitto' do
       } end
 
       describe 'with default settings' do
+        let(:ciphers_option) { os_facts.dig(:os, 'family') == 'RedHat' ? ['ciphers PROFILE=SYSTEM'] : [] }
+
         it 'should configure mosquitto' do
           should contain_class('mosquitto').
             with({
@@ -26,7 +28,7 @@ describe 'foreman_proxy::plugin::remote_execution::mosquitto' do
                 'keyfile /etc/mosquitto/ssl/ssl_key.pem',
                 'require_certificate true',
                 'use_identity_as_username true'
-              ]
+              ] + ciphers_option
             })
         end
 


### PR DESCRIPTION
The default built in ciphers can be less secure. On Red Hat there is the special cipher that's PROFILE=SYSTEM where OpenSSL will respect what's configured in crypto-policies. This keeps the configuration out of the installer while still giving the user control. Out of the box this is also more secure.

I don't know how to test this. When I tried `openssl s_client -connect localhost:1883` it disconnects me. Same with `sslscan --show-ciphers localhost:1883`. @adamruzicka any idea?