### PR TITLE
Fix space_before_arrow lint check

### DIFF
--- a/manifests/plugin/omaha.pp
+++ b/manifests/plugin/omaha.pp
@@ -43,6 +43,6 @@ class foreman_proxy::plugin::omaha (
     path    => '/bin:/usr/bin',
   }
   -> file { $contentpath:
-    ensure  => directory,
+    ensure => directory,
   }
 }

--- a/manifests/plugin/pulp.pp
+++ b/manifests/plugin/pulp.pp
@@ -45,7 +45,7 @@ class foreman_proxy::plugin::pulp (
     # pulp3: removed in rubygem-smart_proxy_pulp 2.0
     # pulp/pulpnode: removed in rubygem-smart_proxy_pulp 3.0
     foreman_proxy::settings_file { ['pulp3', 'pulp', 'pulpnode']:
-      ensure        => absent,
+      ensure => absent,
     },
   ]
 }


### PR DESCRIPTION
Since puppet-lint 4.3.0 this is checked.