### PR TITLE
Add `$manage_user` and `$manage_group` options

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,18 +38,22 @@ class foreman_proxy::config {
     $puppet_groups = []
   }
 
-  user { $foreman_proxy::user:
-    ensure  => 'present',
-    shell   => $foreman_proxy::shell,
-    comment => 'Foreman Proxy daemon user',
-    gid     => $foreman_proxy::group,
-    groups  => $foreman_proxy::groups + $dns_groups + $puppet_groups,
-    home    => $foreman_proxy::dir,
-    system  => true,
+  if $foreman_proxy::manage_user {
+    user { $foreman_proxy::user:
+      ensure  => 'present',
+      shell   => $foreman_proxy::shell,
+      comment => 'Foreman Proxy daemon user',
+      gid     => $foreman_proxy::group,
+      groups  => $foreman_proxy::groups + $dns_groups + $puppet_groups,
+      home    => $foreman_proxy::dir,
+      system  => true,
+    }
   }
 
-  group { $foreman_proxy::group:
-    system => true,
+  if $foreman_proxy::manage_group {
+    group { $foreman_proxy::group:
+      system => true,
+    }
   }
 
   # Provided by packaging, defined here to allow autorequire for files

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,10 @@
 #
 # $ssl_port::                   HTTPS port to listen on (if ssl is enabled)
 #
+# $manage_user::                Manage to foreman-proxy user
+#
+# $manage_group::               Manage to foreman-proxy group
+#
 # $groups::                     Array of additional groups for the foreman proxy user
 #
 # $log::                        Foreman proxy log file, 'STDOUT', 'SYSLOG' or 'JOURNAL'
@@ -289,6 +293,8 @@ class foreman_proxy (
   Variant[Array[String], String] $bind_host = ['*'],
   Stdlib::Port $http_port = 8000,
   Stdlib::Port $ssl_port = 8443,
+  Boolean $manage_user = true,
+  Boolean $manage_group = true,
   Array[String] $groups = [],
   Variant[Enum['STDOUT', 'SYSLOG', 'JOURNAL'], Stdlib::Absolutepath] $log = '/var/log/foreman-proxy/proxy.log',
   Enum['WARN', 'DEBUG', 'ERROR', 'FATAL', 'INFO', 'UNKNOWN'] $log_level = 'INFO',

--- a/spec/classes/foreman_proxy__spec.rb
+++ b/spec/classes/foreman_proxy__spec.rb
@@ -1047,6 +1047,18 @@ describe 'foreman_proxy' do
 
         it { should contain_user("#{proxy_user_name}").with_shell('/dne/foo') }
       end
+
+      context 'with manage_user and manage_group disabled' do
+        let(:params) do
+          super().merge(
+            manage_user: false,
+            manage_group: false
+          )
+        end
+
+        it { should_not contain_user("#{proxy_user_name}") }
+        it { should_not contain_group("#{proxy_user_name}") }
+      end
     end
   end
 end


### PR DESCRIPTION
Add options to not manage foreman-proxy user and group.

We have some very specific user and group requirements, and would like to do user/group management in our profile.