### PR TITLE
Pin puppet-apt since it dropped Puppet 7

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,9 @@
 ---
 fixtures:
   repositories:
-    apt:      'https://github.com/puppetlabs/puppetlabs-apt'
+    apt:
+      repo: 'https://github.com/puppetlabs/puppetlabs-apt'
+      ref: 'v10.0.1'
     augeas_core: 'https://github.com/puppetlabs/puppetlabs-augeas_core'
     concat:   'https://github.com/puppetlabs/puppetlabs-concat'
     cron_core: "https://github.com/puppetlabs/puppetlabs-cron_core"


### PR DESCRIPTION
Since we pull the main branch for testing, and it was updated to drop Puppet 7 support Debian and Ubuntu testing fails:

https://github.com/puppetlabs/puppetlabs-apt/commit/3f9afe6a4840a5804a740d924f6fde0b277db8e0