### PR TITLE
Fixes #39093 - add container db connection options

### DIFF
--- a/manifests/plugin/container_gateway.pp
+++ b/manifests/plugin/container_gateway.pp
@@ -18,6 +18,10 @@
 #
 # $postgresql_password::      User password for the postgres database
 #
+# $database_max_connections:: Maximum number of DB connections
+#
+# $database_pool_timeout::    Time in seconds to wait for DB connection
+#
 # $sqlite_db_path::           Absolute path for the SQLite DB file to exist at
 #
 # $sqlite_timeout::           Database busy timeout in milliseconds
@@ -48,6 +52,8 @@ class foreman_proxy::plugin::container_gateway (
   String $postgresql_database = 'container_gateway',
   Optional[String[1]] $postgresql_user = undef,
   Optional[String] $postgresql_password = undef,
+  Optional[Integer] $database_max_connections = undef,
+  Optional[Integer] $database_pool_timeout = undef,
   Optional[Stdlib::HTTPUrl] $client_endpoint = undef,
 ) {
   foreman_proxy::plugin::module { 'container_gateway':

--- a/spec/classes/foreman_proxy__plugin__container_gateway_spec.rb
+++ b/spec/classes/foreman_proxy__plugin__container_gateway_spec.rb
@@ -107,6 +107,25 @@ describe 'foreman_proxy::plugin::container_gateway' do
           ])
         end
       end
+
+      describe 'with database connection pool parameters' do
+        let :params do {
+          :database_max_connections => 20,
+          :database_pool_timeout => 30,
+        } end
+
+        it 'container_gateway.yml should contain configuration with database pool settings' do
+          verify_exact_contents(catalogue, '/etc/foreman-proxy/settings.d/container_gateway.yml', [
+            '---',
+            ':enabled: https',
+            ":pulp_endpoint: https://#{facts[:networking]['fqdn']}",
+            ':sqlite_db_path: /var/lib/foreman-proxy/smart_proxy_container_gateway.db',
+            ':db_connection_string: postgres:///container_gateway',
+            ':db_max_connections: 20',
+            ':db_pool_timeout: 30'
+          ])
+        end
+      end
     end
   end
 end

--- a/templates/plugin/container_gateway.yml.erb
+++ b/templates/plugin/container_gateway.yml.erb
@@ -23,3 +23,9 @@ when 'sqlite'
 end
 -%>
 :db_connection_string: <%= uri %>
+<% if scope.lookupvar("foreman_proxy::plugin::container_gateway::database_max_connections") -%>
+:db_max_connections: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::database_max_connections") %>
+<% end -%>
+<% if scope.lookupvar("foreman_proxy::plugin::container_gateway::database_pool_timeout") -%>
+:db_pool_timeout: <%= scope.lookupvar("foreman_proxy::plugin::container_gateway::database_pool_timeout") %>
+<% end -%>


### PR DESCRIPTION
Adds support for https://github.com/Katello/smart_proxy_container_gateway/pull/63

Allows users to modify DB max connections and  the pool timeout for the container gateway.

The default in the gateway is proposed to be set at 30 connections / 30s timeout.

The reason for the entire effort is that the default 4 connections does not allow enough concurrency for concurrent container pulls.

One big question: should this be configurable via the Installer? Or just via Hiera? My hope is that most users will be able to operate with the defaults.